### PR TITLE
fix: pin numba>=0.59 so [analysis]/[all] installs on Python 3.10+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 analysis = [
     "statsmodels>=0.14",
     "scikit-learn>=1.3",
+    "numba>=0.59",
     "umap-learn>=0.5",
     "python-igraph>=0.11",
     "leidenalg>=0.10",


### PR DESCRIPTION
## Problem

`pip install -e ".[all]"` (or `[analysis]`) fails on Python 3.10+ with:

```
RuntimeError: Cannot install on Python version 3.12.13; only versions >=3.6,<3.10 are supported.
  help: `llvmlite` (v0.36.0) was included because ... umap-learn -> numba (v0.53.1) -> llvmlite
```

## Root cause

A dependency-resolution trap, not a real Python-3.12 incompatibility in `shanuz`:

1. The resolver picks the newest `numpy` (2.5.x) allowed by `numpy>=1.24`.
2. Modern `numba` (0.66) has a `numpy<2.5` upper bound. Rather than downgrade numpy, uv/pip walks `numba` *backwards* looking for one with looser numpy bounds.
3. It lands on the ancient `numba==0.53.1`, which pins `llvmlite==0.36.0` — and that llvmlite only builds on Python `>=3.6,<3.10`, causing the failure.

`umap-learn` only requires `numba>=0.51.2`, so nothing prevented the walk-back.

## Fix

Add a `numba>=0.59` floor to the `analysis` extra. The resolver then selects `numba==0.66` / `llvmlite==0.48`, which build cleanly on Python 3.10–3.13.

## Verification

- `uv pip compile --extra all` resolves consistently to `numba==0.66.0` / `llvmlite==0.48.0` on Python 3.10, 3.11, 3.12, and 3.13.
- Real `uv pip install -e ".[all]"` into a fresh Python 3.12 venv succeeds; `import shanuz, numba, llvmlite, umap` all import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)