### PR TITLE
fix: correct Quick Start example so it actually produces 500 cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,14 @@ import numpy as np
 from shanuz import create_shanuz_object
 
 # Create a Shanuz object from a counts matrix
-counts = sp.random(2000, 500, density=0.05, format="csc")
+counts = sp.random(2000, 500, density=0.2, format="csc")
 sobj = create_shanuz_object(counts, project="my_project", min_cells=3, min_features=200)
 print(sobj)
-# Shanuz object: my_project
+# Shanuz object — my_project
 #   500 cells × 2000 features
 #   Active assay: 'RNA'
+#   Reductions: []
+#   Version: 5.4.0
 
 # Access metadata
 print(sobj.meta_data.head())


### PR DESCRIPTION
## Problem

Running the README's Quick Start example verbatim:

```python
counts = sp.random(2000, 500, density=0.05, format="csc")
sobj = create_shanuz_object(counts, project="my_project", min_cells=3, min_features=200)
```

produces `0 cells × 2000 features`, not the `500 cells × 2000 features` shown in the doc's sample output.

## Root cause

Not a bug in `create_shanuz_object`/`create_assay5_object` — the filtering logic is correct (verified: features filtered by row-nnz >= `min_cells`, cells filtered by column-nnz >= `min_features`). The example's own parameters are inconsistent:

- `density=0.05` on a 2000-feature matrix gives each cell an **expected ~100** detected genes (std dev ~10).
- `min_features=200` requires **at least 200** detected genes per cell.
- 200 is about 10 standard deviations above the expected value, so essentially every cell fails the filter — 0 survivors is the correct, deterministic outcome for those inputs, not a fluke.

## Fix

Raise `density` to `0.2` (expected ~400 detected genes/cell, comfortably above the 200 threshold), which reproduces the claimed `500 cells × 2000 features` output. Also corrected the printed repr in the doc comment to match the actual `__repr__` (em dash instead of colon, plus the `Reductions`/`Version` lines that are actually printed).

## Verification

Ran the corrected example directly:

```
Shanuz object — my_project
  500 cells × 2000 features
  Active assay: 'RNA'
  Reductions: []
  Version: 5.4.0
```

matching the documented output, with non-empty `meta_data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)