### PR TITLE
chore: bump to 0.1.2 (refresh PyPI README) + standalone-safe spatial figure path

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ cd shanuz
 pip install -e ".[analysis]"
 ```
 
+### Troubleshooting
+
+**`ModuleNotFoundError: No module named 'numpy._core._multiarray_umath'`** (or a
+similar broken NumPy/SciPy import) means the virtual environment has a corrupt or
+partially-installed NumPy — usually left over from an interrupted install or from
+mixing installers. It is not a shanuz issue. Fix it by reinstalling NumPy, or by
+recreating the environment:
+
+```bash
+uv pip install --reinstall --no-cache numpy      # quick fix
+# or start clean:
+rm -rf .venv && uv venv && uv pip install "shanuz[all]"
+```
+
 ---
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shanuz"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python single-cell genomics toolkit — a port of Seurat's core data structures and analysis pipeline"
 readme = "README.md"
 license = { text = "MIT" }
@@ -47,6 +47,8 @@ dev = [
     "pytest>=7",
     "pytest-cov",
     "ruff",
+    "build",
+    "twine",
 ]
 all = ["shanuz[analysis,anndata,dev]"]
 

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -62,7 +62,7 @@ from .plotting import (
     image_feature_plot,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __all__ = [
     # Core classes

--- a/tutorials/generate_spatial_plots.py
+++ b/tutorials/generate_spatial_plots.py
@@ -54,7 +54,10 @@ from shanuz.plotting import (
     vln_plot, dim_plot, image_dim_plot, image_feature_plot,
 )
 
-FIG = _ROOT / "tutorials" / "figures_spatial"
+# Write figures next to this script (tutorials/figures_spatial/ in the repo), so
+# it also works when the script is copied out and run standalone -- matches the
+# other generate_*.py scripts.
+FIG = Path(__file__).parent / "figures_spatial"
 FIG.mkdir(parents=True, exist_ok=True)
 
 # --- deterministic marker panels (all present in the 248-gene panel) ---------


### PR DESCRIPTION
## Summary
Prepares the 0.1.2 release. Two changes:

1. **Version bump 0.1.1 → 0.1.2.** 0.1.1's published README still says "not yet published to PyPI" because it was built before the Installation section was corrected, and PyPI won't let a published version's files be replaced. A new version is the only way to refresh the rendered project page.
2. **fix: `generate_spatial_plots.py` writes figures next to the script** (`Path(__file__).parent / "figures_spatial"`) instead of `_ROOT/"tutorials"/"figures_spatial"`, so it behaves correctly when copied out of the repo and run standalone — the way a pip-install user runs it. Identical behaviour inside the repo; now matches the other four `generate_*.py` scripts.

## Deep test (context)
A user reported a `ModuleNotFoundError: No module named 'numpy._core._multiarray_umath'` when running a tutorial after `pip install "shanuz[all]"`. I ran a full deep test:
- Fresh `uv venv` + `uv pip install "shanuz[all]"` from PyPI → `import numpy` (2.4.6) and `import shanuz` both work. The reported error is a **corrupt numpy in the user's specific venv**, not a shanuz bug (fix: recreate the venv / `--reinstall numpy`).
- Ran **all 10 tutorial/generate/compare scripts** end-to-end in the fresh venv — every one passes.
- Verified the published wheel exports every symbol the tutorials import.
- The only genuine defect surfaced was the standalone figure-path inconsistency, fixed here.

## Test plan
- [x] Full suite: 144 passed
- [x] Standalone run of the fixed script writes figures next to the script, nothing leaks to the parent dir
- [x] In-repo run unchanged (figures still land in `tutorials/figures_spatial/`)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>