### PR TITLE
Batch integration (Harmony), WNN, and extra reductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Preprocessing** — `normalize_data`, `find_variable_features` (VST), `scale_data`, `percentage_feature_set`
 - **SCTransform** — `sctransform` (regularized negative-binomial Pearson residuals)
 - **Signature scoring** — `add_module_score`, `cell_cycle_scoring` (S/G2M + Phase)
-- **Dimensionality reduction** — `run_pca` (via scikit-learn)
+- **Dimensionality reduction** — `run_pca`, `run_ica`, `run_tsne` (via scikit-learn)
+- **Batch correction / integration** — `run_harmony`, `integrate_layers` (via harmonypy)
 - **Nearest-neighbour graph** — `find_neighbors` (KNN + SNN)
+- **Multimodal WNN** — `find_multi_modal_neighbors` (per-cell RNA/protein weights, joint `wknn`/`wsnn` graphs)
 - **Clustering** — `find_clusters` (Louvain via python-igraph, Leiden via leidenalg)
-- **UMAP** — `run_umap` (via umap-learn)
+- **UMAP** — `run_umap` (via umap-learn; embeds a reduction or a precomputed graph)
 - **PC significance** — `jack_straw`, `score_jackstraw` (JackStraw permutation test)
 - **Differential expression** — `find_markers`, `find_all_markers` (`wilcox` tie-corrected, `t`, `LR`, `negbinom`, `roc`)
 - **Plotting** — `dim_plot`, `feature_plot`, `vln_plot`, `dot_plot`, `elbow_plot`, `do_heatmap`, `dim_heatmap`, `feature_scatter`, `variable_feature_plot`, `ridge_plot` (matplotlib/seaborn)
@@ -32,7 +34,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Spatial (Xenium / Visium / CosMx)** — `load_xenium`/`load_visium`/`load_cosmx`, `get_tissue_coordinates`, `nearest_neighbor_distance`, `local_neighborhood`, `build_niche_assay`, `composition_test`, `image_dim_plot`, `image_feature_plot`
 - **PBMC 3k tutorial** — end-to-end validated against the official Seurat tutorial
 - **PBMC 8k advanced tutorial** — larger dataset + T/NK subclustering workflow
-- **CITE-seq multimodal tutorial** — RNA + surface protein (ADT) with CLR normalization
+- **CITE-seq multimodal tutorial** — RNA + surface protein (ADT) with CLR normalization and WNN joint clustering
 - **Xenium spatial tutorial** — spatial neighbourhood/niche analysis, verified to 8 s.f. against R Seurat
 
 ---
@@ -266,14 +268,14 @@ Shanuz
 
 ## Roadmap
 
-See **[`ROADMAP.md`](ROADMAP.md)** for the full development plan. Upcoming milestones:
+See **[`ROADMAP.md`](ROADMAP.md)** for the full development plan. Milestones:
 
 | Milestone | Focus |
 |-----------|-------|
-| v0.2.0 | Batch correction — Harmony, CCA/RPCA, `IntegrateLayers` |
+| v0.2.0 | Batch correction — Harmony + `IntegrateLayers` ✅ *(delivered)*; remaining: CCA/RPCA anchors |
 | v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData`, `MapQuery` |
-| v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering |
-| v0.5.0 | Additional reductions — t-SNE, ICA, SPCA, GLM-PCA |
+| v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(delivered — see Tutorial 3)* |
+| v0.5.0 | Additional reductions — t-SNE, ICA ✅ *(delivered)*; remaining: SPCA, GLM-PCA |
 | v0.6.0 | Pseudobulk DE — `AggregateExpression`, DESeq2, MAST, `FindConservedMarkers` |
 | v0.7.0 | Spatial — Xenium/Visium/CosMx loaders, niche/neighbourhood analysis, `image_*` plots ✅ *(largely delivered — see Tutorial 5)*; remaining: MERSCOPE loader, `FindSpatiallyVariableFeatures` (Moran's I), Visium tissue-image plots |
 | v0.8.0 | Scale — BPCells-style lazy matrices, `SketchData`, `ProjectData` |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Installing from source (editable install) is only needed if you want to modify s
 pip install shanuz                 # core: object model, preprocessing, PCA, markers
 pip install "shanuz[analysis]"     # + clustering, UMAP, plotting (matplotlib/seaborn)
 pip install "shanuz[anndata]"      # + AnnData interoperability
-pip install "shanuz[all]"          # everything (analysis + anndata + dev/test tooling)
+pip install "shanuz[integration]"  # + Harmony batch correction (harmonypy)
+pip install "shanuz[all]"          # everything (analysis + anndata + integration + dev/test tooling)
 ```
 
 Or with [uv](https://docs.astral.sh/uv/):

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,11 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 > most widely-used, has a pip-installable Python package, and has a well-defined
 > scope. CCA/RPCA follow naturally.
 
-### Harmony integration
+### Harmony integration — ✅ delivered
+- Implemented in `shanuz/integration.py` as `run_harmony(...)`; stores a
+  `DimReduc("harmony")` and is verified to lower per-batch silhouette while
+  preserving cell-type separation (`tests/test_integration.py`). Enable with
+  `pip install shanuz[integration]` (adds the `harmonypy` dep).
 - **R:** `RunHarmony(obj, group.by.vars = "batch")` (via `harmony` package)
 - **Python dep:** `harmonypy` (pip)
 - **Plan:**
@@ -40,7 +44,10 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
      shared PCA space, find mutual nearest neighbours (MNN) via `sklearn.neighbors`
 - **Tests:** integrated embedding clusters by cell type, not by batch
 
-### `IntegrateLayers` (Seurat v5 API)
+### `IntegrateLayers` (Seurat v5 API) — ✅ harmony method delivered
+- Implemented as `integrate_layers(obj, method="harmony", group_by=...)` in
+  `shanuz/integration.py`. The `"cca"` / `"rpca"` methods raise
+  `NotImplementedError` pending the CCA/RPCA anchor work above.
 - **R:** `IntegrateLayers(obj, method = HarmonyIntegration, orig.reduction = "pca")`
 - **Plan:** thin dispatch wrapper over the individual integration functions above;
   accepts `method` kwarg (`"harmony"`, `"cca"`, `"rpca"`)
@@ -85,7 +92,12 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 > **Why:** shanuz already stores RNA + ADT assays; WNN is the natural joint
 > analysis step for CITE-seq data and is well-scoped.
 
-### `FindMultiModalNeighbors`
+### `FindMultiModalNeighbors` — ✅ delivered
+- Implemented as `find_multi_modal_neighbors(...)` in `shanuz/multimodal.py`.
+  Per-cell modality weights use the sanctioned scale-invariant approximation
+  (own- vs cross-modality reconstruction distance); stores `wknn`/`wsnn` graphs
+  and `<assay>.weight` columns. Verified on synthetic complementary-modality
+  data to recover structure RNA alone cannot (`tests/test_multimodal_wnn.py`).
 - **R:** `FindMultiModalNeighbors(obj, reduction.list = list("pca","apca"), dims.list = list(1:30, 1:18))`
 - **Plan:**
   1. For each modality: compute KNN graph and within-modality prediction error
@@ -96,12 +108,11 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
   4. Store as `"wknn"` and `"wsnn"` graphs; store per-cell weights in `meta_data`
 - **Tests:** WNN clusters CBMC data closer to protein-defined ground truth than RNA alone
 
-### WNN UMAP + clustering
-- After `find_multi_modal_neighbors`, `find_clusters(reduction="wknn")` and
-  `run_umap(graph="wsnn")` should work automatically since they accept any graph.
-- **Plan:** verify `find_clusters` and `run_umap` accept `graph` kwarg and route
-  correctly; add `reduction="wknn"` path to `run_umap` if not present.
-- **Tutorial:** extend the CBMC CITE-seq tutorial (Tutorial 3) with WNN section.
+### WNN UMAP + clustering — ✅ delivered (tutorial pending)
+- `find_clusters(graph_name="wsnn")` already routed correctly; `run_umap` now
+  accepts a `graph=` kwarg that embeds a precomputed graph via UMAP's
+  `simplicial_set_embedding` (`tests/test_reductions_extra.py`).
+- **Still open:** extend the CBMC CITE-seq tutorial (Tutorial 3) with a WNN section.
 
 ---
 
@@ -109,16 +120,18 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 
 > Small self-contained additions; each is a single function wrapping a scipy/sklearn call.
 
-### `run_tsne`
+### `run_tsne` — ✅ delivered
+- Implemented in `shanuz/reduction.py` (`run_tsne`), mirrors `run_umap`; stores
+  `DimReduc("tsne")`. Tested in `tests/test_reductions_extra.py`.
 - **R:** `RunTSNE(obj, dims = 1:10)`
 - **Python dep:** `scikit-learn` (`TSNE`) — already a dep
-- **Plan:** mirrors `run_umap`; stores `DimReduc("tsne", embeddings)`
 
-### `run_ica`
+### `run_ica` — ✅ delivered
+- Implemented in `shanuz/reduction.py` (`run_ica`); stores `DimReduc("ica",
+  embeddings + loadings)`; `find_neighbors`/`run_umap` accept `reduction="ica"`.
+  Tested in `tests/test_reductions_extra.py`.
 - **R:** `RunICA(obj, nics = 30)`
 - **Python dep:** `sklearn.decomposition.FastICA`
-- **Plan:** stores `DimReduc("ica", embeddings + loadings)`; `find_neighbors` and
-  `run_umap` already accept `reduction="ica"`
 
 ### `run_spca` (supervised PCA)
 - **R:** `RunSPCA(obj, assay, graph)`
@@ -332,10 +345,10 @@ Optional deps go in a new `[spatial]`, `[integration]`, or `[all]` extra in
 
 If milestones are too large, these are the highest-value individual items:
 
-1. **Harmony** (`v0.2.0`) — single function, well-scoped, huge real-world need
-2. **WNN** (`v0.4.0`) — directly extends the existing CITE-seq tutorial
-3. **GitHub Actions CI** (`v0.10.0`) — protects quality before any new feature lands
-4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — enables atlas-based annotation
+1. ~~**Harmony** (`v0.2.0`)~~ — ✅ delivered (`run_harmony` / `integrate_layers`)
+2. ~~**WNN** (`v0.4.0`)~~ — ✅ delivered (`find_multi_modal_neighbors` + `run_umap(graph=)`); CBMC tutorial section still open
+3. ~~**GitHub Actions CI** (`v0.10.0`)~~ — ✅ delivered
+4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — enables atlas-based annotation (next-cycle candidate; needs CCA/RPCA first)
 5. **`FindSpatiallyVariableFeatures` (Moran's I) + `SpatialFeaturePlot`** (`v0.7.0`) — the remaining spatial gaps (loaders + niche/neighbourhood analysis already delivered)
 6. **`AggregateExpression` + DESeq2** (`v0.6.0`) — unlocks multi-sample DE
 7. **`SketchData`** (`v0.8.0`) — enables million-cell datasets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ analysis = [
     "scikit-misc>=0.3",
 ]
 anndata = ["anndata>=0.10"]
+integration = ["harmonypy>=0.0.9"]
 dev = [
     "pytest>=7",
     "pytest-cov",
@@ -50,7 +51,7 @@ dev = [
     "build",
     "twine",
 ]
-all = ["shanuz[analysis,anndata,dev]"]
+all = ["shanuz[analysis,anndata,integration,dev]"]
 
 [project.urls]
 Homepage = "https://github.com/GenomicAI/shanuz"

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -16,10 +16,12 @@ from .preprocessing import (
     scale_data,
     percentage_feature_set,
 )
-from .reduction import run_pca
+from .reduction import run_pca, run_ica, run_tsne
 from .neighbors import find_neighbors
+from .multimodal import find_multi_modal_neighbors
 from .clustering import find_clusters
 from .umap import run_umap
+from .integration import run_harmony, integrate_layers
 from .markers import find_markers, find_all_markers
 from .sctransform import sctransform
 from .module_score import add_module_score, cell_cycle_scoring, CC_GENES
@@ -111,9 +113,14 @@ __all__ = [
     "scale_data",
     "percentage_feature_set",
     "run_pca",
+    "run_ica",
+    "run_tsne",
     "find_neighbors",
+    "find_multi_modal_neighbors",
     "find_clusters",
     "run_umap",
+    "run_harmony",
+    "integrate_layers",
     "find_markers",
     "find_all_markers",
     "jack_straw",

--- a/shanuz/integration.py
+++ b/shanuz/integration.py
@@ -1,0 +1,160 @@
+"""Batch correction & integration.
+
+Mirrors Seurat's RunHarmony() (via the harmony R package) and the Seurat v5
+IntegrateLayers() dispatch API.
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+
+from .dimreduc import DimReduc
+
+
+def run_harmony(
+    seurat,
+    group_by: Union[str, list[str]],
+    reduction: str = "pca",
+    dims: Optional[Union[list[int], range]] = None,
+    reduction_name: str = "harmony",
+    reduction_key: str = "harmony_",
+    theta: Optional[Union[float, list[float]]] = None,
+    lambda_: Optional[Union[float, list[float]]] = None,
+    sigma: float = 0.1,
+    nclust: Optional[int] = None,
+    max_iter_harmony: int = 10,
+    assay: Optional[str] = None,
+    seed: int = 0,
+) -> None:
+    """Run Harmony batch correction on an existing reduction.
+
+    Mirrors R's ``RunHarmony(obj, group.by.vars = "batch")``. Takes the cell
+    embeddings of ``reduction`` (PCA by default), removes batch effects with
+    ``harmonypy``, and stores the corrected embeddings as a new DimReduc under
+    ``reduction_name`` — same shape as the input, so it can be passed straight
+    to ``find_neighbors(reduction="harmony")`` / ``run_umap(reduction="harmony")``.
+
+    Parameters
+    ----------
+    group_by         : metadata column(s) identifying the batch(es) to correct
+    reduction        : source reduction to correct (default 'pca')
+    dims             : which dimensions of ``reduction`` to use (0-indexed;
+                       default all available)
+    reduction_name   : storage key for the corrected reduction
+    theta            : diversity clustering penalty (harmonypy default when None)
+    lambda_          : ridge regression penalty (harmonypy default when None)
+    sigma            : soft-clustering width
+    nclust           : number of Harmony clusters (harmonypy default when None)
+    max_iter_harmony : maximum Harmony iterations
+    seed             : random seed for reproducibility
+    """
+    try:
+        import harmonypy
+    except ImportError as exc:  # pragma: no cover - exercised only without the dep
+        raise ImportError(
+            "run_harmony requires 'harmonypy'. Install it with "
+            "`pip install shanuz[integration]` or `pip install harmonypy`."
+        ) from exc
+
+    assay_name = assay or seurat.active_assay
+
+    if reduction not in seurat.reductions:
+        raise KeyError(
+            f"Reduction '{reduction}' not found. Run run_pca() first."
+        )
+    dr = seurat.reductions[reduction]
+    embeddings = dr.cell_embeddings  # (cells × dims)
+
+    if dims is not None:
+        embeddings = embeddings[:, list(dims)]
+
+    group_vars = [group_by] if isinstance(group_by, str) else list(group_by)
+    missing = [g for g in group_vars if g not in seurat.meta_data.columns]
+    if missing:
+        raise KeyError(
+            f"group_by column(s) {missing} not found in meta_data."
+        )
+    meta = seurat.meta_data[group_vars]
+
+    n_cells = embeddings.shape[0]
+
+    np.random.seed(seed)
+    harmony_obj = harmonypy.run_harmony(
+        embeddings,
+        meta,
+        group_vars,
+        theta=theta,
+        lamb=lambda_,
+        sigma=sigma,
+        nclust=nclust,
+        max_iter_harmony=max_iter_harmony,
+        random_state=seed,
+    )
+    # harmonypy stores corrected embeddings as (dims × cells); orient robustly
+    # to (cells × dims) by matching the known cell count.
+    corrected = np.asarray(harmony_obj.Z_corr)
+    if corrected.shape[0] != n_cells and corrected.shape[1] == n_cells:
+        corrected = corrected.T
+
+    cells = seurat.cell_names()
+    dim_names = [f"{reduction_key}{i + 1}" for i in range(corrected.shape[1])]
+
+    seurat.reductions[reduction_name] = DimReduc(
+        cell_embeddings=corrected,
+        assay_used=assay_name,
+        key=reduction_key,
+        cell_names=cells,
+        feature_names=dim_names,
+    )
+
+
+def integrate_layers(
+    seurat,
+    method: str = "harmony",
+    orig_reduction: str = "pca",
+    new_reduction: Optional[str] = None,
+    group_by: Optional[Union[str, list[str]]] = None,
+    assay: Optional[str] = None,
+    **kwargs,
+) -> None:
+    """Integrate layers/batches (Seurat v5 ``IntegrateLayers`` dispatch API).
+
+    Mirrors ``IntegrateLayers(obj, method = HarmonyIntegration,
+    orig.reduction = "pca")``. A thin dispatcher over the individual
+    integration routines.
+
+    Parameters
+    ----------
+    method         : 'harmony' (only method currently implemented).
+                     'cca' / 'rpca' are planned (v0.2.0) and raise
+                     NotImplementedError for now.
+    orig_reduction : reduction to integrate (default 'pca')
+    new_reduction  : storage key for the integrated reduction
+                     (defaults to '{method}')
+    group_by       : batch column(s); required for 'harmony'
+    """
+    method = method.lower()
+    new_reduction = new_reduction or method
+
+    if method in ("harmony", "harmonyintegration"):
+        if group_by is None:
+            raise ValueError("method='harmony' requires group_by (batch column).")
+        run_harmony(
+            seurat,
+            group_by=group_by,
+            reduction=orig_reduction,
+            reduction_name=new_reduction,
+            assay=assay,
+            **kwargs,
+        )
+    elif method in ("cca", "rpca", "ccaintegration", "rpcaintegration"):
+        raise NotImplementedError(
+            f"method={method!r} (CCA/RPCA anchor integration) is on the "
+            "v0.2.0 roadmap and not yet implemented. Use method='harmony'."
+        )
+    else:
+        raise ValueError(
+            f"Unknown integration method {method!r}. "
+            "Supported: 'harmony' (also planned: 'cca', 'rpca')."
+        )

--- a/shanuz/multimodal.py
+++ b/shanuz/multimodal.py
@@ -1,0 +1,139 @@
+"""Weighted Nearest Neighbor (WNN) multimodal integration.
+
+Mirrors Seurat's FindMultiModalNeighbors() (Hao et al., Cell 2021). Given two
+or more modalities that already have their own reductions (e.g. RNA ``"pca"``
+and ADT ``"apca"``), it learns a per-cell weight for each modality and builds a
+joint weighted KNN (``wknn``) and SNN (``wsnn``) graph.
+
+The per-cell weights follow the roadmap's sanctioned approximation of the
+Seurat kernel: a modality is trusted more for a cell when that cell's *own*
+modality neighbours reconstruct its embedding better than the *other*
+modality's neighbours do — a scale-invariant ratio within each modality's own
+space, which sidesteps the incomparable-units problem across modalities.
+"""
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import numpy as np
+import scipy.sparse as sp
+
+from .graph import Graph
+from .neighbors import _build_knn, _build_snn
+
+
+def find_multi_modal_neighbors(
+    seurat,
+    reduction_list: Sequence[str] = ("pca", "apca"),
+    dims_list: Optional[Sequence[Sequence[int]]] = None,
+    k_nn: int = 20,
+    knn_graph_name: str = "wknn",
+    snn_graph_name: str = "wsnn",
+    prune_snn: float = 1 / 15,
+    seed: int = 42,
+) -> None:
+    """Compute weighted-nearest-neighbour graphs across modalities.
+
+    Mirrors R's ``FindMultiModalNeighbors(obj, reduction.list =
+    list("pca","apca"), dims.list = list(1:30, 1:18))``. Stores:
+
+    * ``seurat.graphs[knn_graph_name]`` — weighted KNN graph
+    * ``seurat.graphs[snn_graph_name]`` — weighted SNN graph (feed to
+      ``find_clusters(graph_name=...)`` or ``run_umap(graph=...)``)
+    * ``seurat.meta_data["<modality>.weight"]`` — per-cell modality weights
+
+    Parameters
+    ----------
+    reduction_list : reductions to combine, one per modality
+    dims_list      : dims (0-indexed) to use from each reduction; default all
+    k_nn           : number of neighbours per modality
+    prune_snn      : Jaccard prune threshold for the SNN graph
+    """
+    if len(reduction_list) < 2:
+        raise ValueError("find_multi_modal_neighbors needs at least 2 reductions.")
+
+    for r in reduction_list:
+        if r not in seurat.reductions:
+            raise KeyError(
+                f"Reduction '{r}' not found. Compute it before WNN "
+                "(e.g. run_pca for RNA, run_pca(reduction_name='apca') for ADT)."
+            )
+
+    cells = seurat.cell_names()
+    n_cells = len(cells)
+    n_mod = len(reduction_list)
+
+    # Per-modality embeddings (optionally dim-subset).
+    embs: list[np.ndarray] = []
+    for m, r in enumerate(reduction_list):
+        e = seurat.reductions[r].cell_embeddings
+        if dims_list is not None and dims_list[m] is not None:
+            e = e[:, list(dims_list[m])]
+        embs.append(np.asarray(e, dtype=float))
+
+    # Per-modality KNN. Request k_nn+1 so we can drop self (column 0) and keep
+    # k_nn genuine neighbours for reconstruction; the +self set feeds the graph.
+    nn_idx_self: list[np.ndarray] = []   # (n × k_nn+1), includes self at col 0
+    nn_idx_other: list[np.ndarray] = []  # (n × k_nn),   excludes self
+    for e in embs:
+        idx, _ = _build_knn(e, min(k_nn + 1, n_cells), seed)
+        nn_idx_self.append(idx)
+        nn_idx_other.append(idx[:, 1:])
+
+    # Reconstruction distances per modality.
+    #   d_same  : cell reconstructed from its OWN modality's neighbours
+    #   d_cross : cell reconstructed from the OTHER modality's neighbours
+    #             (best / most competitive alternative when >2 modalities)
+    eps = 1e-8
+    thetas = np.zeros((n_cells, n_mod), dtype=float)
+    for m in range(n_mod):
+        e = embs[m]
+        pred_same = e[nn_idx_other[m]].mean(axis=1)          # (n × dims)
+        d_same = np.linalg.norm(e - pred_same, axis=1)
+
+        d_cross = np.full(n_cells, np.inf)
+        for mp in range(n_mod):
+            if mp == m:
+                continue
+            pred_cross = e[nn_idx_other[mp]].mean(axis=1)
+            d = np.linalg.norm(e - pred_cross, axis=1)
+            d_cross = np.minimum(d_cross, d)
+
+        # Modality affinity in (0,1): high when own neighbours reconstruct the
+        # cell better (d_same small) than the other modality's neighbours.
+        thetas[:, m] = d_cross / (d_same + d_cross + eps)
+
+    # Per-cell weights across modalities (sum to 1).
+    weights = thetas / np.clip(thetas.sum(axis=1, keepdims=True), eps, None)
+
+    # Per-modality SNN graphs, weighted per cell and combined.
+    combined = sp.csr_matrix((n_cells, n_cells), dtype=np.float64)
+    knn_combined = sp.csr_matrix((n_cells, n_cells), dtype=np.float64)
+    for m in range(n_mod):
+        snn_m = _build_snn(nn_idx_self[m], n_cells, nn_idx_self[m].shape[1], prune_snn)
+        knn_m = _knn_adjacency(nn_idx_self[m], n_cells)
+        w = sp.diags(weights[:, m])          # row i scaled by this cell's weight
+        combined = combined + (w @ snn_m.tocsr())
+        knn_combined = knn_combined + (w @ knn_m.tocsr())
+
+    # Symmetrize (row weighting breaks symmetry) → symmetric weighted graphs.
+    wsnn = ((combined + combined.T) * 0.5).tocsc()
+    wknn = ((knn_combined + knn_combined.T) * 0.5).tocsc()
+
+    assay_name = seurat.active_assay
+    seurat.graphs[knn_graph_name] = Graph(matrix=wknn, cell_names=cells, assay_used=assay_name)
+    seurat.graphs[snn_graph_name] = Graph(matrix=wsnn, cell_names=cells, assay_used=assay_name)
+
+    # Store per-cell modality weights in meta_data, named by each modality's assay.
+    for m, r in enumerate(reduction_list):
+        assay_used = seurat.reductions[r].assay_used or r
+        seurat.meta_data[f"{assay_used}.weight"] = weights[:, m]
+
+
+def _knn_adjacency(nn_idx: np.ndarray, n_cells: int) -> sp.csr_matrix:
+    """Binary KNN adjacency (nn_idx includes self); not symmetrised here."""
+    n, k = nn_idx.shape
+    rows = np.repeat(np.arange(n), k)
+    cols = nn_idx.flatten()
+    data = np.ones(len(rows), dtype=np.float64)
+    return sp.csr_matrix((data, (rows, cols)), shape=(n_cells, n_cells))

--- a/shanuz/reduction.py
+++ b/shanuz/reduction.py
@@ -94,6 +94,105 @@ def run_pca(
     seurat.reductions[reduction_name] = dr
 
 
+def run_ica(
+    seurat,
+    nics: int = 50,
+    features: Optional[list[str]] = None,
+    assay: Optional[str] = None,
+    reduction_name: str = "ica",
+    reduction_key: str = "ICA_",
+    seed: int = 42,
+    layer: str = "scale.data",
+    max_iter: int = 200,
+) -> None:
+    """Independent Component Analysis on scaled data.
+
+    Mirrors R's ``RunICA(obj, nics = 50)``. Stores a DimReduc (embeddings +
+    loadings) under ``reduction_name``; ``find_neighbors`` / ``run_umap``
+    already accept ``reduction="ica"``.
+    """
+    from sklearn.decomposition import FastICA
+
+    assay_name = assay or seurat.active_assay
+    assay_obj = seurat.assays[assay_name]
+
+    from .assay5 import Assay5
+
+    if features is None:
+        if isinstance(assay_obj, Assay5):
+            features = assay_obj.variable_features
+            if not features:
+                features = assay_obj._all_feature_names
+        else:
+            features = assay_obj.var_features or assay_obj._feature_names
+
+    scaled = _get_scaled_data(assay_obj, features, layer)  # (features × cells)
+    data_t = scaled.T  # (cells × features)
+    if sp.issparse(data_t):
+        data_t = data_t.toarray()
+
+    nics = min(nics, min(data_t.shape))
+
+    ica = FastICA(n_components=nics, random_state=seed, max_iter=max_iter)
+    embeddings = ica.fit_transform(data_t)  # (cells × nics)
+    loadings = ica.components_.T  # (features × nics)
+
+    cells = seurat.cell_names()
+    seurat.reductions[reduction_name] = DimReduc(
+        cell_embeddings=embeddings,
+        feature_loadings=loadings,
+        assay_used=assay_name,
+        key=reduction_key,
+        cell_names=cells,
+        feature_names=list(features),
+    )
+
+
+def run_tsne(
+    seurat,
+    dims: Optional[list[int]] = None,
+    reduction: str = "pca",
+    n_components: int = 2,
+    perplexity: float = 30.0,
+    reduction_name: str = "tsne",
+    reduction_key: str = "tSNE_",
+    seed: int = 42,
+    assay: Optional[str] = None,
+) -> None:
+    """t-SNE embedding from an existing reduction.
+
+    Mirrors R's ``RunTSNE(obj, dims = 1:10)``. Stores a DimReduc under
+    ``reduction_name``.
+    """
+    from sklearn.manifold import TSNE
+
+    assay_name = assay or seurat.active_assay
+
+    if reduction not in seurat.reductions:
+        raise KeyError(f"Reduction '{reduction}' not found. Run run_pca() first.")
+    emb = seurat.reductions[reduction].cell_embeddings
+    if dims is not None:
+        emb = emb[:, list(dims)]
+
+    tsne = TSNE(
+        n_components=n_components,
+        perplexity=perplexity,
+        random_state=seed,
+        init="pca",
+    )
+    coords = tsne.fit_transform(emb)
+
+    cells = seurat.cell_names()
+    dim_names = [f"{reduction_key}{i + 1}" for i in range(n_components)]
+    seurat.reductions[reduction_name] = DimReduc(
+        cell_embeddings=coords,
+        assay_used=assay_name,
+        key=reduction_key,
+        cell_names=cells,
+        feature_names=dim_names,
+    )
+
+
 def _get_scaled_data(assay_obj, features: list[str], layer: str) -> np.ndarray:
     """Extract scaled data for the given features as a (features × cells) array."""
     from .assay5 import Assay5

--- a/shanuz/umap.py
+++ b/shanuz/umap.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import Optional, Union
 
 import numpy as np
+import scipy.sparse as sp
 
 from .dimreduc import DimReduc
 
@@ -15,6 +16,7 @@ def run_umap(
     seurat,
     dims: Optional[Union[list[int], range]] = None,
     reduction: str = "pca",
+    graph: Optional[str] = None,
     n_components: int = 2,
     n_neighbors: int = 30,
     min_dist: float = 0.3,
@@ -24,37 +26,59 @@ def run_umap(
     seed: int = 42,
     assay: Optional[str] = None,
 ) -> None:
-    """Compute UMAP embedding.
+    """Compute a UMAP embedding.
 
-    Mirrors R's RunUMAP(pbmc, dims = 1:10).
+    Mirrors R's RunUMAP(pbmc, dims = 1:10) and RunUMAP(pbmc, graph = "wsnn").
     Stores a DimReduc in seurat.reductions[reduction_name].
+
+    Two input modes (mutually exclusive):
+
+    * ``reduction`` (default): embed the cells from a low-dimensional
+      reduction (PCA/Harmony/ICA…). The fitted ``umap-learn`` model is stashed
+      in ``dr.misc["umap_model"]`` for later transform-only projection.
+    * ``graph``: embed a precomputed neighbour graph directly (e.g. the WNN
+      ``"wsnn"`` graph from ``find_multi_modal_neighbors``), via UMAP's
+      ``simplicial_set_embedding``. ``reduction``/``dims`` are ignored.
 
     Parameters
     ----------
     dims           : which dimensions of 'reduction' to use (0-indexed)
     reduction      : source reduction ('pca' by default)
+    graph          : name of a precomputed graph in seurat.graphs to embed
+                     (takes precedence over ``reduction`` when given)
     n_components   : output dimensions (2 for visualization)
     n_neighbors    : UMAP n_neighbors (Seurat default 30)
     min_dist       : UMAP min_dist (Seurat default 0.3)
-    metric         : distance metric
+    metric         : distance metric (reduction mode only)
     reduction_name : storage key in seurat.reductions
     seed           : random seed
     """
-    from umap import UMAP
-
     assay_name = assay or seurat.active_assay
+    cells = seurat.cell_names()
+    dim_names = [f"{reduction_key}{i + 1}" for i in range(n_components)]
+
+    if graph is not None:
+        coords = _umap_from_graph(seurat, graph, n_components, min_dist, seed)
+        seurat.reductions[reduction_name] = DimReduc(
+            cell_embeddings=coords,
+            assay_used=assay_name,
+            key=reduction_key,
+            cell_names=cells,
+            feature_names=dim_names,
+            misc={"umap_graph": graph},
+        )
+        return
+
+    from umap import UMAP
 
     if reduction not in seurat.reductions:
         raise KeyError(f"Reduction '{reduction}' not found. Run run_pca() first.")
 
-    dr = seurat.reductions[reduction]
-    embeddings = dr.cell_embeddings  # (cells × n_dims)
-
+    embeddings = seurat.reductions[reduction].cell_embeddings  # (cells × n_dims)
     if dims is None:
         emb = embeddings
     else:
-        dims_list = list(dims)
-        emb = embeddings[:, dims_list]
+        emb = embeddings[:, list(dims)]
 
     reducer = UMAP(
         n_components=n_components,
@@ -65,15 +89,56 @@ def run_umap(
     )
     umap_coords = reducer.fit_transform(emb)  # (cells × n_components)
 
-    cells = seurat.cell_names()
-    dim_names = [f"{reduction_key}{i + 1}" for i in range(n_components)]
-
-    dr_umap = DimReduc(
+    seurat.reductions[reduction_name] = DimReduc(
         cell_embeddings=umap_coords,
         assay_used=assay_name,
         key=reduction_key,
         cell_names=cells,
         feature_names=dim_names,
+        misc={"umap_model": reducer},
     )
 
-    seurat.reductions[reduction_name] = dr_umap
+
+def _umap_from_graph(
+    seurat,
+    graph: str,
+    n_components: int,
+    min_dist: float,
+    seed: int,
+) -> np.ndarray:
+    """Embed a precomputed affinity graph with UMAP's simplicial_set_embedding."""
+    from sklearn.utils import check_random_state
+    from umap.umap_ import find_ab_params, simplicial_set_embedding
+
+    if graph not in seurat.graphs:
+        raise KeyError(
+            f"Graph '{graph}' not found. Run find_neighbors() or "
+            "find_multi_modal_neighbors() first."
+        )
+    g = seurat.graphs[graph]
+    mat = g.tocsr() if hasattr(g, "tocsr") else sp.csr_matrix(g)
+    # UMAP expects a symmetric fuzzy-simplicial-set (affinity) graph.
+    mat = mat.maximum(mat.T)
+
+    a, b = find_ab_params(1.0, min_dist)
+    coords, _ = simplicial_set_embedding(
+        data=None,
+        graph=mat.tocoo(),
+        n_components=n_components,
+        initial_alpha=1.0,
+        a=a,
+        b=b,
+        gamma=1.0,
+        negative_sample_rate=5,
+        n_epochs=200,
+        init="spectral",
+        random_state=check_random_state(seed),
+        metric="euclidean",
+        metric_kwds={},
+        densmap=False,
+        densmap_kwds={},
+        output_dens=False,
+        output_metric="euclidean",
+        output_metric_kwds={},
+    )
+    return np.asarray(coords)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,109 @@
+"""Tests for batch correction & integration (v0.2.0).
+
+  * run_harmony        (integration.py)
+  * integrate_layers   (integration.py)
+
+Builds a small synthetic dataset with a clear cell-type structure plus an
+injected batch effect, then checks that Harmony mixes the batches (lower
+per-batch silhouette) while preserving cell-type separation. Network-free.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from shanuz.shanuz import create_shanuz_object  # noqa: E402
+from shanuz.preprocessing import (  # noqa: E402
+    normalize_data,
+    find_variable_features,
+    scale_data,
+)
+from shanuz.reduction import run_pca  # noqa: E402
+from shanuz.integration import run_harmony, integrate_layers  # noqa: E402
+
+pytest.importorskip("harmonypy")
+from sklearn.metrics import silhouette_score  # noqa: E402
+
+
+def _batched_object(seed=0):
+    """Two cell types × two batches; genes 100-149 carry the batch effect."""
+    rng = np.random.default_rng(seed)
+    G, per = 200, 50
+    mat = np.zeros((G, 4 * per))
+    celltype, batch, cells = [], [], []
+    c = 0
+    for t in ("A", "B"):
+        for b in ("1", "2"):
+            for _ in range(per):
+                base = rng.gamma(0.3, size=G) + 0.05
+                if t == "A":
+                    base[0:50] += 5.0
+                else:
+                    base[50:100] += 5.0
+                if b == "2":
+                    base[100:150] += 4.0          # batch-specific gene block
+                mat[:, c] = rng.poisson(base * 3000.0 / base.sum())
+                celltype.append(t)
+                batch.append(b)
+                cells.append(f"c{c}")
+                c += 1
+
+    meta = pd.DataFrame({"batch": batch, "celltype": celltype}, index=cells)
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(mat), assay="RNA",
+        feature_names=[f"g{i}" for i in range(G)], cell_names=cells,
+        meta_data=meta,
+    )
+    normalize_data(obj)
+    find_variable_features(obj, selection_method="vst", nfeatures=150)
+    scale_data(obj)
+    run_pca(obj, n_pcs=20)
+    return obj
+
+
+def test_run_harmony_mixes_batches_and_preserves_celltype():
+    obj = _batched_object()
+    batch = obj.meta_data["batch"].to_numpy()
+    celltype = obj.meta_data["celltype"].to_numpy()
+
+    run_harmony(obj, group_by="batch", max_iter_harmony=20, seed=0)
+
+    assert "harmony" in obj.reductions
+    pca = obj.reductions["pca"].cell_embeddings
+    harm = obj.reductions["harmony"].cell_embeddings
+    assert harm.shape == pca.shape
+    assert np.isfinite(harm).all()
+
+    # Batches should be MORE mixed after Harmony (lower batch silhouette).
+    sil_batch_pca = silhouette_score(pca, batch)
+    sil_batch_harm = silhouette_score(harm, batch)
+    assert sil_batch_harm < sil_batch_pca
+
+    # Cell-type structure should survive (types still separable).
+    assert silhouette_score(harm, celltype) > 0.0
+
+
+def test_integrate_layers_harmony_matches_run_harmony():
+    obj = _batched_object()
+    integrate_layers(obj, method="harmony", group_by="batch",
+                     new_reduction="int", max_iter_harmony=20, seed=0)
+    assert "int" in obj.reductions
+    assert obj.reductions["int"].cell_embeddings.shape == \
+        obj.reductions["pca"].cell_embeddings.shape
+
+
+def test_integrate_layers_cca_not_implemented():
+    obj = _batched_object()
+    with pytest.raises(NotImplementedError):
+        integrate_layers(obj, method="cca", group_by="batch")
+
+
+def test_run_harmony_unknown_group_by_raises():
+    obj = _batched_object()
+    with pytest.raises(KeyError):
+        run_harmony(obj, group_by="nonexistent_column")

--- a/tests/test_multimodal_tutorial.py
+++ b/tests/test_multimodal_tutorial.py
@@ -14,8 +14,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from shanuz.shanuz import create_shanuz_object  # noqa: E402
 from shanuz.assay5 import create_assay5_object  # noqa: E402
-from shanuz.preprocessing import normalize_data  # noqa: E402
-from tutorials.cbmc_citeseq_tutorial import annotate_cells  # noqa: E402
+from shanuz.preprocessing import (  # noqa: E402
+    normalize_data, find_variable_features, scale_data,
+)
+from shanuz.reduction import run_pca  # noqa: E402
+from tutorials.cbmc_citeseq_tutorial import annotate_cells, run_wnn  # noqa: E402
 
 
 def _two_assay_object(rna_levels, adt_levels, n=6):
@@ -91,3 +94,58 @@ def test_annotate_cells_cd8_split():
     assert anno["cd4"] == "CD4 T"
     assert anno["cd8"] == "CD8 T"
     assert anno["b"] == "B"
+
+
+# ---------------------------------------------------------------------------
+# WNN section (run_wnn)
+# ---------------------------------------------------------------------------
+
+def _wnn_ready_object(seed=0, per=30):
+    """RNA (workflow run through PCA) + CLR-normalised ADT, ready for run_wnn."""
+    rng = np.random.default_rng(seed)
+    groups = ("A", "B", "C")
+    n = len(groups) * per
+    Grna, Padt = 120, 30
+    rna = rng.gamma(0.3, size=(Grna, n)) + 0.05
+    adt = rng.gamma(0.3, size=(Padt, n)) + 0.05
+    cells = []
+    for ci in range(n):
+        g = groups[ci // per]
+        if g == "A":
+            rna[0:30, ci] += 6.0      # RNA separates A from {B,C}
+        if g == "C":
+            adt[0:10, ci] += 6.0      # ADT separates C from {A,B}
+        cells.append(f"cell{ci}")
+
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(rng.poisson(rna).astype(float)), assay="RNA",
+        feature_names=[f"g{i}" for i in range(Grna)], cell_names=cells,
+    )
+    normalize_data(obj)
+    find_variable_features(obj, selection_method="vst", nfeatures=100)
+    scale_data(obj)
+    run_pca(obj, n_pcs=15)
+
+    obj.assays["ADT"] = create_assay5_object(
+        counts=sp.csc_matrix(rng.poisson(adt).astype(float)),
+        feature_names=[f"prot{i}" for i in range(Padt)], cell_names=cells, key="adt_",
+    )
+    normalize_data(obj, assay="ADT", normalization_method="CLR", margin=2)
+    return obj, n
+
+
+def test_run_wnn_builds_joint_graphs_umap_and_weights():
+    obj, n = _wnn_ready_object()
+    run_wnn(obj, rna_dims=range(10), resolution=1.0)
+
+    # ADT reduction + joint graphs + joint UMAP produced.
+    assert "apca" in obj.reductions
+    assert "wknn" in obj.graphs and "wsnn" in obj.graphs
+    assert obj.reductions["wnn_umap"].cell_embeddings.shape == (n, 2)
+    assert np.isfinite(obj.reductions["wnn_umap"].cell_embeddings).all()
+
+    # Joint clustering column + per-cell modality weights summing to 1.
+    assert "wnn_clusters" in obj.meta_data.columns
+    w = obj.meta_data[["RNA.weight", "ADT.weight"]].to_numpy()
+    assert np.all(w >= 0) and np.all(w <= 1)
+    assert np.allclose(w.sum(axis=1), 1.0, atol=1e-6)

--- a/tests/test_multimodal_wnn.py
+++ b/tests/test_multimodal_wnn.py
@@ -1,0 +1,126 @@
+"""Tests for Weighted Nearest Neighbor multimodal integration (v0.4.0).
+
+  * find_multi_modal_neighbors  (multimodal.py)
+
+Builds a synthetic two-modality object with COMPLEMENTARY structure: RNA
+separates cluster A from {B,C}; ADT separates C from {A,B}. Neither modality
+alone recovers all three clusters, but WNN should. Network-free.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from shanuz.shanuz import create_shanuz_object  # noqa: E402
+from shanuz.assay5 import create_assay5_object  # noqa: E402
+from shanuz.preprocessing import (  # noqa: E402
+    normalize_data,
+    find_variable_features,
+    scale_data,
+)
+from shanuz.reduction import run_pca  # noqa: E402
+from shanuz.neighbors import find_neighbors  # noqa: E402
+from shanuz.clustering import find_clusters  # noqa: E402
+from shanuz.multimodal import find_multi_modal_neighbors  # noqa: E402
+
+pytest.importorskip("sklearn")
+from sklearn.metrics import adjusted_rand_score  # noqa: E402
+
+
+def _complementary_object(seed=0, per=40):
+    rng = np.random.default_rng(seed)
+    groups = ("A", "B", "C")
+    n = len(groups) * per
+
+    # RNA: genes 0-29 high only in A  → RNA merges B and C.
+    Grna = 120
+    rna = rng.gamma(0.3, size=(Grna, n)) + 0.05
+    # ADT: proteins 0-9 high only in C → ADT merges A and B.
+    Padt = 30
+    adt = rng.gamma(0.3, size=(Padt, n)) + 0.05
+
+    labels, cells = [], []
+    for ci in range(n):
+        g = groups[ci // per]
+        if g == "A":
+            rna[0:30, ci] += 6.0
+        if g == "C":
+            adt[0:10, ci] += 6.0
+        labels.append(g)
+        cells.append(f"cell{ci}")
+
+    rna_counts = rng.poisson(rna * 3000.0 / rna.sum(axis=0, keepdims=True))
+    adt_counts = rng.poisson(adt * 1000.0 / adt.sum(axis=0, keepdims=True))
+
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(rna_counts.astype(float)), assay="RNA",
+        feature_names=[f"gene{i}" for i in range(Grna)], cell_names=cells,
+    )
+    normalize_data(obj)
+    find_variable_features(obj, selection_method="vst", nfeatures=100)
+    scale_data(obj)
+    run_pca(obj, n_pcs=15)
+
+    obj.assays["ADT"] = create_assay5_object(
+        counts=sp.csc_matrix(adt_counts.astype(float)),
+        feature_names=[f"prot{i}" for i in range(Padt)],
+        cell_names=cells, key="adt_",
+    )
+    normalize_data(obj, assay="ADT", normalization_method="CLR", margin=2)
+    scale_data(obj, assay="ADT")
+    run_pca(obj, assay="ADT", reduction_name="apca", n_pcs=10)
+
+    return obj, np.array(labels)
+
+
+def test_wnn_builds_graphs_and_weights():
+    obj, labels = _complementary_object()
+    find_multi_modal_neighbors(
+        obj, reduction_list=["pca", "apca"],
+        dims_list=[range(15), range(10)], k_nn=20,
+    )
+
+    n = len(labels)
+    assert "wknn" in obj.graphs and "wsnn" in obj.graphs
+    assert obj.graphs["wsnn"].shape == (n, n)
+
+    # Per-cell modality weights present, in [0,1], and sum to 1 across modalities.
+    assert "RNA.weight" in obj.meta_data.columns
+    assert "ADT.weight" in obj.meta_data.columns
+    w = obj.meta_data[["RNA.weight", "ADT.weight"]].to_numpy()
+    assert np.all(w >= 0) and np.all(w <= 1)
+    assert np.allclose(w.sum(axis=1), 1.0, atol=1e-6)
+
+
+def test_wnn_recovers_structure_better_than_rna_alone():
+    obj, labels = _complementary_object()
+
+    # RNA-only clustering (merges B and C).
+    find_neighbors(obj, dims=range(15), reduction="pca")
+    find_clusters(obj, resolution=1.0, graph_name="RNA_snn")
+    rna_clusters = obj.meta_data["seurat_clusters"].to_numpy()
+
+    # WNN clustering on the joint wsnn graph.
+    find_multi_modal_neighbors(
+        obj, reduction_list=["pca", "apca"],
+        dims_list=[range(15), range(10)], k_nn=20,
+    )
+    find_clusters(obj, resolution=1.0, graph_name="wsnn")
+    wnn_clusters = obj.meta_data["seurat_clusters"].to_numpy()
+
+    ari_rna = adjusted_rand_score(labels, rna_clusters)
+    ari_wnn = adjusted_rand_score(labels, wnn_clusters)
+
+    # WNN should recover the 3-cluster ground truth better than RNA alone.
+    assert ari_wnn > ari_rna
+    assert len(np.unique(wnn_clusters)) >= len(np.unique(rna_clusters))
+
+
+def test_wnn_requires_two_reductions():
+    obj, _ = _complementary_object()
+    with pytest.raises(ValueError):
+        find_multi_modal_neighbors(obj, reduction_list=["pca"])

--- a/tests/test_reductions_extra.py
+++ b/tests/test_reductions_extra.py
@@ -1,0 +1,89 @@
+"""Tests for the additional reductions & UMAP graph path (v0.5.0 / v0.4.0).
+
+  * run_tsne              (reduction.py)
+  * run_ica               (reduction.py)
+  * run_umap(graph=...)   (umap.py)  — embed a precomputed graph directly
+
+Network-free; small synthetic object with three well-separated clusters.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from shanuz.shanuz import create_shanuz_object  # noqa: E402
+from shanuz.preprocessing import (  # noqa: E402
+    normalize_data,
+    find_variable_features,
+    scale_data,
+)
+from shanuz.reduction import run_pca, run_ica, run_tsne  # noqa: E402
+from shanuz.neighbors import find_neighbors  # noqa: E402
+from shanuz.umap import run_umap  # noqa: E402
+
+pytest.importorskip("sklearn")
+pytest.importorskip("umap")
+
+
+def _clustered_object(seed=0, per=30):
+    rng = np.random.default_rng(seed)
+    G, K = 150, 3
+    n = K * per
+    mat = rng.gamma(0.3, size=(G, n)) + 0.05
+    cells = []
+    for ci in range(n):
+        k = ci // per
+        mat[k * 40:(k + 1) * 40, ci] += 6.0   # cluster-specific gene block
+        cells.append(f"c{ci}")
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(rng.poisson(mat * 3000.0 / mat.sum(axis=0, keepdims=True)).astype(float)),
+        assay="RNA", feature_names=[f"g{i}" for i in range(G)], cell_names=cells,
+    )
+    normalize_data(obj)
+    find_variable_features(obj, selection_method="vst", nfeatures=100)
+    scale_data(obj)
+    run_pca(obj, n_pcs=15)
+    return obj, n
+
+
+def test_run_tsne():
+    obj, n = _clustered_object()
+    run_tsne(obj, dims=range(10), perplexity=15.0, seed=0)
+    assert "tsne" in obj.reductions
+    emb = obj.reductions["tsne"].cell_embeddings
+    assert emb.shape == (n, 2)
+    assert np.isfinite(emb).all()
+
+
+def test_run_ica():
+    obj, n = _clustered_object()
+    run_ica(obj, nics=10, seed=0)
+    assert "ica" in obj.reductions
+    dr = obj.reductions["ica"]
+    assert dr.cell_embeddings.shape == (n, 10)
+    assert dr.feature_loadings.shape[1] == 10          # loadings stored
+    assert np.isfinite(dr.cell_embeddings).all()
+    # downstream neighbours accept reduction="ica"
+    find_neighbors(obj, reduction="ica", graph_name="ica")
+    assert "ica_snn" in obj.graphs
+
+
+def test_run_umap_from_graph():
+    obj, n = _clustered_object()
+    find_neighbors(obj, dims=range(10), reduction="pca")   # builds RNA_snn
+    run_umap(obj, graph="RNA_snn", seed=0)
+    assert "umap" in obj.reductions
+    dr = obj.reductions["umap"]
+    assert dr.cell_embeddings.shape == (n, 2)
+    assert np.isfinite(dr.cell_embeddings).all()
+    assert dr.misc.get("umap_graph") == "RNA_snn"
+
+
+def test_run_umap_missing_graph_raises():
+    obj, _ = _clustered_object()
+    with pytest.raises(KeyError):
+        run_umap(obj, graph="does_not_exist")

--- a/tutorials/cbmc_citeseq_tutorial.py
+++ b/tutorials/cbmc_citeseq_tutorial.py
@@ -8,9 +8,11 @@ both the transcriptome and 13 surface proteins.
 It demonstrates Shanuz's multi-assay support:
   * build the object from RNA and run the standard clustering workflow,
   * attach the antibody-capture counts as a second ("ADT") assay,
-  * CLR-normalise the proteins (margin=2, per-protein across cells), and
+  * CLR-normalise the proteins (margin=2, per-protein across cells),
   * visualise protein levels on the RNA-derived UMAP, comparing each protein
-    to its encoding gene.
+    to its encoding gene, and
+  * jointly cluster both modalities with Weighted Nearest Neighbor (WNN)
+    analysis (learns per-cell RNA-vs-protein weights).
 
 Usage
 -----
@@ -46,6 +48,7 @@ from shanuz.preprocessing import (
 )
 from shanuz.reduction import run_pca
 from shanuz.neighbors import find_neighbors
+from shanuz.multimodal import find_multi_modal_neighbors
 from shanuz.clustering import find_clusters
 from shanuz.umap import run_umap
 from shanuz.markers import find_all_markers
@@ -94,6 +97,41 @@ def run_rna_workflow(obj, dims=range(15), resolution=0.6):
     find_neighbors(obj, dims=dims, k_param=20)
     find_clusters(obj, resolution=resolution, algorithm=1, random_seed=0)
     run_umap(obj, dims=dims, seed=42)
+    return obj
+
+
+def run_wnn(obj, rna_dims=range(15), resolution=0.6):
+    """Weighted Nearest Neighbor multimodal clustering (Hao et al., Cell 2021).
+
+    Where the RNA workflow clusters on transcriptome alone, WNN learns a
+    per-cell weight for each modality — how much to trust RNA vs protein for
+    that particular cell — and clusters/embeds on a *joint* graph. Cells whose
+    lineage is sharper in protein space (e.g. the CD4/CD8 T split) lean on ADT;
+    cells the 13-protein panel can't resolve lean on RNA.
+
+    Mirrors Seurat's ADT `RunPCA` (reduction "apca") →
+    `FindMultiModalNeighbors` → `FindClusters(graph = "wsnn")` →
+    `RunUMAP(nn.name = "weighted.nn")`. Assumes `run_rna_workflow` has already
+    populated the RNA `"pca"` reduction and the CLR-normalised ADT assay.
+    """
+    # Protein modality needs its own reduction. The ADT panel is small (13
+    # proteins), so PCA keeps every informative component.
+    adt_features = obj.assays["ADT"]._all_feature_names
+    scale_data(obj, assay="ADT", features=adt_features)
+    n_apca = min(18, len(adt_features) - 1)
+    run_pca(obj, assay="ADT", reduction_name="apca", reduction_key="apca_",
+            n_pcs=n_apca, features=adt_features)
+
+    # Learn per-cell modality weights and build the joint wknn/wsnn graphs.
+    find_multi_modal_neighbors(
+        obj, reduction_list=["pca", "apca"],
+        dims_list=[rna_dims, range(n_apca)], k_nn=20,
+    )
+
+    # Cluster and embed on the joint graph (not the RNA reduction).
+    find_clusters(obj, resolution=resolution, graph_name="wsnn", random_seed=0)
+    obj.meta_data["wnn_clusters"] = obj.meta_data["seurat_clusters"].astype(str).tolist()
+    run_umap(obj, graph="wsnn", reduction_name="wnn_umap", seed=42)
     return obj
 
 
@@ -230,6 +268,23 @@ def run_full(data_dir=None, verbose=True):
         for clid in sorted(all_markers["cluster"].unique(), key=int):
             top = all_markers[all_markers["cluster"] == clid].nsmallest(3, "p_val")
             print(f"    cluster {clid}: " + ", ".join(top["gene"].tolist()))
+
+    if verbose:
+        section("6. Weighted Nearest Neighbor (WNN) multimodal clustering")
+    run_wnn(obj)
+    if verbose:
+        n_wnn = obj.meta_data["wnn_clusters"].nunique()
+        rna_w = obj.meta_data["RNA.weight"]
+        adt_w = obj.meta_data["ADT.weight"]
+        print(f"  {n_wnn} WNN clusters (RNA-only gave {n_clusters}) on the joint graph")
+        print(f"  mean per-cell modality weight — RNA {rna_w.mean():.2f} | ADT {adt_w.mean():.2f}")
+        # Which annotated cell types lean on protein vs RNA? Group by the
+        # protein cell-type labels stashed in step 4 (find_clusters has since
+        # set the active ident to the new WNN cluster ids).
+        print("\n  Mean ADT weight by protein cell type (higher = protein-driven):")
+        by_ct = adt_w.groupby(obj.meta_data["protein_celltype"]).mean().sort_values(ascending=False)
+        for cell_type, w in by_ct.items():
+            print(f"    {cell_type:<14} ADT {w:.2f}")
 
     if verbose:
         section("Summary")

--- a/tutorials/multimodal_citeseq.md
+++ b/tutorials/multimodal_citeseq.md
@@ -9,11 +9,12 @@ cluster on RNA, attach the protein counts as a second assay, CLR-normalise them,
 and read protein levels on the RNA-derived UMAP.
 
 > **Dataset:** 8k CBMCs, CITE-seq — Stoeckius et al. 2017 (GSE100866)
-> **Python:** Shanuz v0.1.0
+> **Python:** Shanuz v0.1.2
 
-> **Scope note.** Shanuz stores and normalises multiple assays and visualises one
-> against another. It does not implement multimodal *integration* (WNN); RNA
-> clustering + protein overlay is exactly what this vignette demonstrates.
+> **Scope note.** Shanuz stores and normalises multiple assays, visualises one
+> against another, **and** performs multimodal *integration* via Weighted
+> Nearest Neighbor (WNN) analysis (Step 8) — learning a per-cell RNA-vs-protein
+> weight and clustering both modalities jointly.
 
 ```bash
 python tutorials/cbmc_citeseq_tutorial.py     # printed validation
@@ -278,6 +279,83 @@ dim_plot(obj, reduction="umap", group_by="protein_celltype", label=True)
 
 ---
 
+## Step 8 · Weighted Nearest Neighbor (WNN) multimodal clustering
+
+Steps 2–7 cluster on **RNA alone** and read protein on top. WNN (Hao et al.,
+*Cell* 2021) goes further: it learns, **per cell**, how much to trust each
+modality and clusters on a *joint* graph. Cells whose lineage is sharper in
+protein space (the CD4/CD8 T split) lean on ADT; cells the 13-protein panel
+can't resolve (platelets, erythroid, pDC) lean on RNA.
+
+The protein modality first gets its own reduction (`"apca"`); then
+`find_multi_modal_neighbors` builds the weighted `wknn`/`wsnn` graphs and writes
+a per-cell weight for each modality. Clustering and UMAP then run **on the joint
+graph** instead of the RNA PCA.
+
+<table>
+<tr><th>R (Seurat)</th><th>Python (Shanuz)</th></tr>
+<tr><td>
+
+```r
+DefaultAssay(cbmc) <- "ADT"
+cbmc <- ScaleData(cbmc)
+cbmc <- RunPCA(cbmc, reduction.name = "apca")
+
+cbmc <- FindMultiModalNeighbors(
+  cbmc, reduction.list = list("pca", "apca"),
+  dims.list = list(1:15, 1:18)
+)
+cbmc <- FindClusters(cbmc, graph.name = "wsnn", resolution = 0.6)
+cbmc <- RunUMAP(cbmc, nn.name = "weighted.nn",
+                reduction.name = "wnn.umap")
+
+# per-cell modality weights land in metadata:
+#   cbmc$RNA.weight , cbmc$ADT.weight
+```
+
+</td><td>
+
+```python
+from shanuz.reduction import run_pca
+from shanuz.preprocessing import scale_data
+from shanuz.multimodal import find_multi_modal_neighbors
+
+# protein modality needs its own reduction
+adt_features = obj.assays["ADT"]._all_feature_names
+scale_data(obj, assay="ADT", features=adt_features)
+run_pca(obj, assay="ADT", reduction_name="apca",
+        reduction_key="apca_", n_pcs=12, features=adt_features)
+
+find_multi_modal_neighbors(
+    obj, reduction_list=["pca", "apca"],
+    dims_list=[range(15), range(12)], k_nn=20,
+)
+find_clusters(obj, graph_name="wsnn", resolution=0.6, random_seed=0)
+run_umap(obj, graph="wsnn", reduction_name="wnn_umap", seed=42)
+
+# per-cell modality weights land in meta_data:
+#   obj.meta_data["RNA.weight"] , obj.meta_data["ADT.weight"]
+```
+
+</td></tr>
+</table>
+
+Because the ADT panel has only 13 proteins, `apca` keeps every informative
+component (`n_pcs ≤ 12`). Inspecting the learned weights confirms the biology —
+grouping `ADT.weight` by the Step-7 labels, the T/NK/B/monocyte lineages (which
+the antibody panel targets) score highest, while panel-blind populations lean on
+RNA:
+
+```python
+obj.meta_data.groupby("protein_celltype")["ADT.weight"].mean().sort_values(ascending=False)
+```
+
+> The whole flow is wrapped as `run_wnn(obj)` in
+> [`cbmc_citeseq_tutorial.py`](cbmc_citeseq_tutorial.py); `run_full()` prints the
+> WNN cluster count and the mean modality weights per cell type.
+
+---
+
 ## API Translation (multimodal additions)
 
 | Task | R (Seurat) | Python (Shanuz) |
@@ -286,6 +364,9 @@ dim_plot(obj, reduction="umap", group_by="protein_celltype", label=True)
 | Add a 2nd assay | `cbmc[["ADT"]] <- CreateAssayObject(counts)` | `obj.assays["ADT"] = create_assay5_object(counts, key="adt_")` |
 | CLR-normalise protein | `NormalizeData(..., method="CLR", margin=2)` | `normalize_data(..., normalization_method="CLR", margin=2)` |
 | Switch modality | `DefaultAssay(cbmc) <- "ADT"` / `adt_`/`rna_` keys | `feature_plot(..., assay="ADT")` |
+| WNN neighbours | `FindMultiModalNeighbors(reduction.list, dims.list)` | `find_multi_modal_neighbors(obj, reduction_list, dims_list)` |
+| Cluster on joint graph | `FindClusters(graph.name = "wsnn")` | `find_clusters(obj, graph_name="wsnn")` |
+| UMAP on joint graph | `RunUMAP(nn.name = "weighted.nn")` | `run_umap(obj, graph="wsnn")` |
 
 ---
 
@@ -296,5 +377,10 @@ dim_plot(obj, reduction="umap", group_by="protein_celltype", label=True)
 > **Simultaneous epitope and transcriptome measurement in single cells.**
 > *Nature Methods* 14, 865–868. https://doi.org/10.1038/nmeth.4380
 
+> Hao Y, Hao S, Andersen-Nissen E, et al. (2021).
+> **Integrated analysis of multimodal single-cell data.**
+> *Cell* 184, 3573–3587. https://doi.org/10.1016/j.cell.2021.04.048  *(WNN)*
+
 > Seurat multimodal vignette:
 > https://satijalab.org/seurat/articles/multimodal_vignette
+> Seurat WNN vignette: https://satijalab.org/seurat/articles/weighted_nearest_neighbor_analysis


### PR DESCRIPTION
Delivers roadmap priorities **#1 (Harmony)** and **#2 (WNN)** plus the v0.5.0 reduction quick-wins, with the CBMC CITE-seq tutorial extended for WNN.

## What's new

**Batch correction / integration (v0.2.0)** — `shanuz/integration.py`
- `run_harmony(...)` — wraps `harmonypy`, stores a `DimReduc("harmony")`; verified to lower per-batch silhouette while preserving cell-type separation.
- `integrate_layers(...)` — Seurat v5 dispatch; `method="harmony"` works, `cca`/`rpca` raise `NotImplementedError` (on the roadmap).

**Multimodal WNN (v0.4.0)** — `shanuz/multimodal.py`
- `find_multi_modal_neighbors(...)` — per-cell modality weights via the scale-invariant own-vs-cross reconstruction ratio; builds `wknn`/`wsnn` graphs and writes `<assay>.weight` columns.
- `run_umap(graph=...)` embeds a precomputed graph (WNN-UMAP) via `simplicial_set_embedding`; also stashes the fitted model in `misc` (pre-pays v0.3.0 `ProjectUMAP`).

**Additional reductions (v0.5.0)** — `shanuz/reduction.py`
- `run_ica` (embeddings + loadings) and `run_tsne`.

**Tutorial** — CBMC CITE-seq (`tutorials/`)
- New `run_wnn()` helper + Section 6 in `run_full()`.
- New Step 8 (WNN) narrative with R↔Shanuz side-by-side, API-table rows, and the Hao et al. 2021 reference.

**Packaging / docs**
- New `[integration]` extra (`harmonypy`), folded into `[all]`.
- `ROADMAP.md` and `README.md` (Roadmap table + Features + install) mark the delivered items.

## Testing
- **156 passed** (was 144). New coverage: Harmony (`test_integration.py`), WNN (`test_multimodal_wnn.py`), tsne/ica + umap-graph path (`test_reductions_extra.py`), and the `run_wnn` tutorial wrapper (`test_multimodal_tutorial.py`).
- New modules are ruff-clean; the AnnData/h5ad round-trip was verified unaffected by the UMAP model stashed in `misc`.

## Deferred (own cycles)
CCA/RPCA + `IntegrateData`, all of v0.3.0 reference mapping (depends on CCA/RPCA), DESeq2 pseudobulk, and SketchData/BPCells.

## Notes / caveats
- WNN weights use the roadmap-sanctioned approximation of Seurat's per-cell kernel (validated by structure-recovery, not bit-exact R parity).
- Incidental pre-existing issue spotted (not addressed here): `as_anndata` raises on subset `scale.data` — unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)