### PR TITLE
Release 0.2.0: version bump + release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,15 @@ print(sobj.meta_data.head())
 
 Three end-to-end tutorials — from basic guided clustering to multimodal CITE-seq —
 each pairing R Seurat code side-by-side with the Python Shanuz equivalent.
-See **[`tutorials/README.md`](tutorials/README.md)** for the full index.
+See **[`tutorials/README.md`](https://github.com/GenomicAI/shanuz/blob/main/tutorials/README.md)** for the full index.
 
 | # | Tutorial | Dataset | Complexity |
 |---|----------|---------|-----------|
-| 1 | [PBMC 3k — Guided Clustering](tutorials/pbmc3k_tutorial.md) | 3k PBMCs · 10x Genomics | Beginner |
-| 2 | [PBMC 8k — Advanced Subclustering](tutorials/advanced_pbmc8k_subclustering.md) | 8k PBMCs · GRCh38 | Intermediate |
-| 3 | [CBMC CITE-seq — Multimodal](tutorials/multimodal_citeseq.md) | 8,600 CBMCs · RNA + 13 proteins | Advanced |
-| 4 | [PBMC 3k — SCTransform](tutorials/sctransform_vignette.md) | 3k PBMCs · 10x Genomics | Advanced |
-| 5 | [Xenium — Spatial (R vs Python)](tutorials/xenium_spatial_tutorial.md) | 36k cells · 10x Xenium mouse brain | Spatial |
+| 1 | [PBMC 3k — Guided Clustering](https://github.com/GenomicAI/shanuz/blob/main/tutorials/pbmc3k_tutorial.md) | 3k PBMCs · 10x Genomics | Beginner |
+| 2 | [PBMC 8k — Advanced Subclustering](https://github.com/GenomicAI/shanuz/blob/main/tutorials/advanced_pbmc8k_subclustering.md) | 8k PBMCs · GRCh38 | Intermediate |
+| 3 | [CBMC CITE-seq — Multimodal](https://github.com/GenomicAI/shanuz/blob/main/tutorials/multimodal_citeseq.md) | 8,600 CBMCs · RNA + 13 proteins | Advanced |
+| 4 | [PBMC 3k — SCTransform](https://github.com/GenomicAI/shanuz/blob/main/tutorials/sctransform_vignette.md) | 3k PBMCs · 10x Genomics | Advanced |
+| 5 | [Xenium — Spatial (R vs Python)](https://github.com/GenomicAI/shanuz/blob/main/tutorials/xenium_spatial_tutorial.md) | 36k cells · 10x Xenium mouse brain | Spatial |
 
 ```bash
 # Tutorial 1 — PBMC 3k
@@ -268,7 +268,7 @@ Shanuz
 
 ## Roadmap
 
-See **[`ROADMAP.md`](ROADMAP.md)** for the full development plan. Milestones:
+See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)** for the full development plan. Milestones:
 
 | Milestone | Focus |
 |-----------|-------|
@@ -350,7 +350,7 @@ https://www.10xgenomics.com/resources/datasets/3-k-pb-mcs-from-a-healthy-donor-1
 
 ## License
 
-MIT License — see [LICENSE](LICENSE) for details.
+MIT License — see [LICENSE](https://github.com/GenomicAI/shanuz/blob/main/LICENSE) for details.
 
 This software is an independent reimplementation for educational and research purposes.
 It is not affiliated with, endorsed by, or maintained by the Satija Lab or 10x Genomics.

--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ print(sobj.meta_data.head())
 
 ## Tutorials
 
-Three end-to-end tutorials — from basic guided clustering to multimodal CITE-seq —
-each pairing R Seurat code side-by-side with the Python Shanuz equivalent.
+Five end-to-end tutorials — from basic guided clustering through multimodal
+CITE-seq to Xenium spatial — each pairing R Seurat code side-by-side with the
+Python Shanuz equivalent.
 See **[`tutorials/README.md`](https://github.com/GenomicAI/shanuz/blob/main/tutorials/README.md)** for the full index.
 
 | # | Tutorial | Dataset | Complexity |

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ uv pip install -e ".[dev]"
 pytest tests/ -v
 ```
 
-All 144 unit tests pass.
+All 156 unit tests pass.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shanuz"
-version = "0.1.2"
+version = "0.2.0"
 description = "Python single-cell genomics toolkit — a port of Seurat's core data structures and analysis pipeline"
 readme = "README.md"
 license = { text = "MIT" }

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -64,7 +64,7 @@ from .plotting import (
     image_feature_plot,
 )
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"
 
 __all__ = [
     # Core classes

--- a/tutorials/multimodal_citeseq.md
+++ b/tutorials/multimodal_citeseq.md
@@ -283,9 +283,13 @@ dim_plot(obj, reduction="umap", group_by="protein_celltype", label=True)
 
 Steps 2–7 cluster on **RNA alone** and read protein on top. WNN (Hao et al.,
 *Cell* 2021) goes further: it learns, **per cell**, how much to trust each
-modality and clusters on a *joint* graph. Cells whose lineage is sharper in
-protein space (the CD4/CD8 T split) lean on ADT; cells the 13-protein panel
-can't resolve (platelets, erythroid, pDC) lean on RNA.
+modality and clusters on a *joint* graph, so a cell whose lineage is crisp in
+protein space (the CD4/CD8 T split) can be weighted toward ADT while one the
+13-protein panel doesn't cover (platelets, erythroid, pDC) is weighted toward
+RNA. On this dataset the learned weights sit close to 0.5 — both modalities
+carry usable signal for most cells — with only modest per-cell tilts; the value
+of WNN here is a *joint* embedding and clustering rather than a dramatic
+reweighting.
 
 The protein modality first gets its own reduction (`"apca"`); then
 `find_multi_modal_neighbors` builds the weighted `wknn`/`wsnn` graphs and writes
@@ -341,10 +345,10 @@ run_umap(obj, graph="wsnn", reduction_name="wnn_umap", seed=42)
 </table>
 
 Because the ADT panel has only 13 proteins, `apca` keeps every informative
-component (`n_pcs ≤ 12`). Inspecting the learned weights confirms the biology —
-grouping `ADT.weight` by the Step-7 labels, the T/NK/B/monocyte lineages (which
-the antibody panel targets) score highest, while panel-blind populations lean on
-RNA:
+component (`n_pcs ≤ 12`). You can inspect the learned weights by grouping
+`ADT.weight` by the Step-7 labels — on this dataset they cluster tightly around
+0.5 (roughly 0.51–0.52 for the antibody-targeted lineages), a gentle tilt rather
+than a clean split, reflecting that both modalities inform most cells:
 
 ```python
 obj.meta_data.groupby("protein_celltype")["ADT.weight"].mean().sort_values(ascending=False)

--- a/tutorials/multimodal_citeseq.md
+++ b/tutorials/multimodal_citeseq.md
@@ -9,7 +9,7 @@ cluster on RNA, attach the protein counts as a second assay, CLR-normalise them,
 and read protein levels on the RNA-derived UMAP.
 
 > **Dataset:** 8k CBMCs, CITE-seq — Stoeckius et al. 2017 (GSE100866)
-> **Python:** Shanuz v0.1.2
+> **Python:** Shanuz v0.2.0
 
 > **Scope note.** Shanuz stores and normalises multiple assays, visualises one
 > against another, **and** performs multimodal *integration* via Weighted


### PR DESCRIPTION
Release prep for **shanuz 0.2.0**, covering the Harmony/WNN/tsne-ICA work merged in #6.

## Changes
- **Version bump → 0.2.0** — `pyproject.toml` + `shanuz.__version__` in sync.
- **README** — test count 144 → 156; relative links (tutorials/*, ROADMAP, LICENSE) rewritten to absolute GitHub URLs so they render on the PyPI project page; "three tutorials" → "five".
- **Multimodal tutorial** — version note → v0.2.0; WNN (Step 8) narrative softened to match the real CBMC weights (they sit near 0.5, not a dramatic split).

## Validation
- **156 tests pass**; wheel + sdist build cleanly as `shanuz-0.2.0`, `twine check` PASSED.
- **Published to TestPyPI** (https://test.pypi.org/project/shanuz/0.2.0/) and verified in a clean `uv` venv: install resolves `shanuz==0.2.0`, the new `[integration]` extra pulls harmonypy, and a mini pipeline exercised `run_harmony` / `run_tsne` / `run_ica` / `run_umap(graph=)`.
- **All 9 tutorial scripts run `rc=0` against the TestPyPI-installed wheel** (run from outside the repo so `import shanuz` resolves to site-packages), producing 53 figures; the CBMC WNN section ran end-to-end on real data.

## Follow-ups (separate, explicit steps)
- Tag `v0.2.0` and publish to **real PyPI** after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)