### PR TITLE
docs: fix misleading R/Python figure comparisons in tutorials

### DIFF
--- a/tutorials/advanced_pbmc8k_subclustering.md
+++ b/tutorials/advanced_pbmc8k_subclustering.md
@@ -8,13 +8,18 @@ lymphoid compartment is isolated and re-analysed from scratch to separate naive
 CD4, memory CD4, CD8, and NK populations that the global clustering merges.
 
 > **Dataset:** 8k PBMCs from a Healthy Donor — 10x Genomics (GRCh38, v2)
-> **Python:** Shanuz v0.1.0
+> **Python:** Shanuz v0.2.0
 > **Methodology:** Satija et al. 2015 · Butler et al. 2018 · Hao et al. 2021
 
-> **Scope note.** Shanuz reproduces the **RNA graph-based clustering** workflow
-> these papers established. It does not (yet) implement anchor-based integration,
-> SCTransform, or multimodal WNN — so this tutorial stays within single-assay
-> RNA clustering and subclustering, which is exactly where subclustering shines.
+> **Scope note.** This tutorial stays within the single-assay **RNA
+> graph-based clustering** workflow these papers established — which is exactly
+> where subclustering shines. SCTransform and multimodal WNN are covered in the
+> other tutorials; anchor-based (CCA/RPCA) integration is not yet ported.
+
+> **About the figures.** Shanuz is a Python port, so **every figure below is
+> rendered by Shanuz** (`generate_advanced_plots.py`); the R snippets show the
+> equivalent Seurat API. Figures span the full width and are *not* a
+> left-R / right-Python comparison.
 
 Run everything with:
 
@@ -198,8 +203,10 @@ dim_plot(pbmc, reduction="umap", label=True)
 ```
 
 </td></tr>
-<tr><td><img src="figures_advanced/05_lineage_featureplots.png" width="420"/></td>
-<td><img src="figures_advanced/04_umap_global_celltypes.png" width="420"/></td></tr>
+<tr><td colspan="2"><em>Shanuz — lineage-marker FeaturePlots (<code>feature_plot</code>)</em><br>
+<img src="figures_advanced/05_lineage_featureplots.png" width="720"/></td></tr>
+<tr><td colspan="2"><em>Shanuz — broad cell types on the global UMAP (<code>dim_plot</code>)</em><br>
+<img src="figures_advanced/04_umap_global_celltypes.png" width="560"/></td></tr>
 </table>
 
 Top markers per cluster (DoHeatmap → `do_heatmap`):
@@ -298,10 +305,14 @@ dim_plot(tnk, reduction="umap", label=True)
 ```
 
 </td></tr>
-<tr><td><img src="figures_advanced/09_tnk_subset_featureplots.png" width="420"/></td>
-<td><img src="figures_advanced/08_umap_tnk_subsets.png" width="420"/></td></tr>
-<tr><td><img src="figures_advanced/10_tnk_subset_violins.png" width="420"/></td>
-<td><img src="figures_advanced/11_tnk_markers_heatmap.png" width="420"/></td></tr>
+<tr><td colspan="2"><em>Shanuz — T/NK subset marker FeaturePlots (<code>feature_plot</code>)</em><br>
+<img src="figures_advanced/09_tnk_subset_featureplots.png" width="760"/></td></tr>
+<tr><td colspan="2"><em>Shanuz — annotated T/NK subsets on the compartment UMAP (<code>dim_plot</code>)</em><br>
+<img src="figures_advanced/08_umap_tnk_subsets.png" width="560"/></td></tr>
+<tr><td colspan="2"><em>Shanuz — subset marker violins (<code>vln_plot</code>)</em><br>
+<img src="figures_advanced/10_tnk_subset_violins.png" width="600"/></td></tr>
+<tr><td colspan="2"><em>Shanuz — top subcluster markers heatmap (<code>do_heatmap</code>)</em><br>
+<img src="figures_advanced/11_tnk_markers_heatmap.png" width="640"/></td></tr>
 </table>
 
 ### What the subclustering reveals

--- a/tutorials/multimodal_citeseq.md
+++ b/tutorials/multimodal_citeseq.md
@@ -21,6 +21,11 @@ python tutorials/cbmc_citeseq_tutorial.py     # printed validation
 python tutorials/generate_multimodal_plots.py # writes figures_multimodal/
 ```
 
+> **About the figures.** This is a Python port, so **every figure below is
+> rendered by Shanuz** (`generate_multimodal_plots.py`); the R snippets show the
+> equivalent Seurat API. Figures span the full width and are *not* a
+> left-R / right-Python comparison.
+
 ---
 
 ## Step 1 · Load RNA + Protein, align barcodes
@@ -234,8 +239,10 @@ feature_scatter(obj, "CD4",  "CD8", assay="ADT")
 ```
 
 </td></tr>
-<tr><td><img src="figures_multimodal/05_adt_ridgeplots.png" width="420"/></td>
-<td><img src="figures_multimodal/06_adt_scatter_CD4_CD8.png" width="380"/><br>
+<tr><td colspan="2"><em>Shanuz — ADT ridge plots (<code>ridge_plot</code>)</em><br>
+<img src="figures_multimodal/05_adt_ridgeplots.png" width="560"/></td></tr>
+<tr><td colspan="2"><em>Shanuz — protein bivariate scatters (<code>feature_scatter</code>)</em><br>
+<img src="figures_multimodal/06_adt_scatter_CD4_CD8.png" width="380"/>
 <img src="figures_multimodal/07_adt_scatter_CD19_CD3.png" width="380"/></td></tr>
 </table>
 

--- a/tutorials/pbmc3k_tutorial.md
+++ b/tutorials/pbmc3k_tutorial.md
@@ -908,8 +908,9 @@ fig = ridge_plot(
 </td>
 </tr>
 <tr>
-<td><em>R Seurat RidgePlot (ggridges)</em></td>
-<td><img src="figures/12_ridge_plot.png" width="420"/></td>
+<td colspan="2"><em>Shanuz — RidgePlot equivalent (<code>ridge_plot</code>). The Seurat
+pbmc3k vignette publishes no RidgePlot figure, so only the Shanuz output is shown.</em><br>
+<img src="figures/12_ridge_plot.png" width="560"/></td>
 </tr>
 </table>
 


### PR DESCRIPTION
## Problem

Several tutorials placed figures inside the two-column **R (Seurat) | Python (Shanuz)** tables even where no R render exists. This made it read as a broken side-by-side comparison — different plot *types* on each side, or one side missing entirely.

The root cause: some tutorials are pure Python ports with **no R figures at all**, so any image dropped under the "R" column was misleading.

## Changes

**`advanced_pbmc8k_subclustering.md`** — Steps 5 & 7 split all-Shanuz figures across the R/Python columns as different plot types (FeaturePlot vs UMAP; Violin vs Heatmap). Converted to full-width, captioned Shanuz figures (matching the `colspan=2` rows the rest of the doc already uses). Also:
- Added an **"About the figures"** note clarifying every figure is Shanuz output.
- Bumped stale `v0.1.0` header → `v0.2.0`.
- Corrected the scope note (SCTransform/WNN are now shipped; only CCA/RPCA remains unported).

**`multimodal_citeseq.md`** — Step 6 placed the ridge plot under "R" and the protein scatters under "Python", though all three are Shanuz output. Made them full-width captioned rows + the same "About the figures" note.

**`pbmc3k_tutorial.md`** — the RidgePlot row had **no R image** (the Seurat vignette publishes none), just a text placeholder next to the Shanuz plot. Made it a full-width captioned Shanuz figure.

## Verified as correct, left unchanged

Tutorials with **genuine R renders** on the left column are legitimate comparisons and were not touched:
- `pbmc3k` & `sctransform` — link the real Seurat vignette images (satijalab.org URLs), correctly matched pairs.
- `xenium_spatial` — saved real R output locally as `r_*.png`; opened each to confirm the spatial `Image*` plots render (not blank) and pair correctly with their Shanuz counterparts.

Table tags balanced and all image references resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)