### PR TITLE
feat: pseudobulk AggregateExpression + FindConservedMarkers (v0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Clustering** — `find_clusters` (Louvain via python-igraph, Leiden via leidenalg)
 - **UMAP** — `run_umap` (via umap-learn; embeds a reduction or a precomputed graph)
 - **PC significance** — `jack_straw`, `score_jackstraw` (JackStraw permutation test)
-- **Differential expression** — `find_markers`, `find_all_markers` (`wilcox` tie-corrected, `t`, `LR`, `negbinom`, `roc`)
+- **Differential expression** — `find_markers`, `find_all_markers` (`wilcox` tie-corrected, `t`, `LR`, `negbinom`, `roc`), `find_conserved_markers` (cross-condition, Fisher-combined)
+- **Pseudobulk** — `aggregate_expression` (sum counts per group → matrix or one-cell-per-group object)
 - **Plotting** — `dim_plot`, `feature_plot`, `vln_plot`, `dot_plot`, `elbow_plot`, `do_heatmap`, `dim_heatmap`, `feature_scatter`, `variable_feature_plot`, `ridge_plot` (matplotlib/seaborn)
 - **AnnData interoperability** — `as_anndata`, `from_anndata`
 - **Spatial (Xenium / Visium / CosMx)** — `load_xenium`/`load_visium`/`load_cosmx`, `get_tissue_coordinates`, `nearest_neighbor_distance`, `local_neighborhood`, `build_niche_assay`, `composition_test`, `image_dim_plot`, `image_feature_plot`
@@ -199,10 +200,18 @@ run_umap(pbmc, dims=range(10))
 ### Differential expression
 
 ```python
-from shanuz.markers import find_markers, find_all_markers
+from shanuz import (
+    find_markers, find_all_markers, find_conserved_markers, aggregate_expression,
+)
 
 markers = find_markers(pbmc, ident_1=1)
 all_markers = find_all_markers(pbmc, only_pos=True, logfc_threshold=0.25)
+
+# Markers up in cluster 1 across every condition (Fisher-combined p per gene).
+conserved = find_conserved_markers(pbmc, ident_1=1, grouping_var="condition")
+
+# Pseudobulk counts summed per (cell type × donor) — input for sample-level DE.
+pseudobulk = aggregate_expression(pbmc, group_by=["cell_type", "donor"])
 ```
 
 ### Plotting
@@ -277,7 +286,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData`, `MapQuery` |
 | v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(delivered — see Tutorial 3)* |
 | v0.5.0 | Additional reductions — t-SNE, ICA ✅ *(delivered)*; remaining: SPCA, GLM-PCA |
-| v0.6.0 | Pseudobulk DE — `AggregateExpression`, DESeq2, MAST, `FindConservedMarkers` |
+| v0.6.0 | Pseudobulk DE — `AggregateExpression`, `FindConservedMarkers` ✅ *(delivered)*; remaining: DESeq2, MAST, bimod |
 | v0.7.0 | Spatial — Xenium/Visium/CosMx loaders, niche/neighbourhood analysis, `image_*` plots ✅ *(largely delivered — see Tutorial 5)*; remaining: MERSCOPE loader, `FindSpatiallyVariableFeatures` (Moran's I), Visium tissue-image plots |
 | v0.8.0 | Scale — BPCells-style lazy matrices, `SketchData`, `ProjectData` |
 | v0.9.0 | Specialized — `HTODemux`, Mixscape (CRISPR screens) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -148,12 +148,15 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 
 ## v0.6.0 — Pseudobulk DE & Advanced Marker Methods
 
-### `AggregateExpression` (pseudobulk)
+### `AggregateExpression` (pseudobulk) — ✅ delivered
+- Implemented as `aggregate_expression(...)` in `shanuz/aggregate.py`. Sums raw
+  counts per group via a single sparse `counts @ indicator` matmul; `group_by`
+  accepts one or more metadata columns (joined with `"_"`, as Seurat does) or
+  `"ident"`. Returns a features×groups `pd.DataFrame` (a `dict` for multiple
+  assays), or a `Shanuz` object with one "cell" per group when
+  `return_object=True` (`tests/test_pseudobulk_conserved.py`).
 - **R:** `AggregateExpression(obj, group.by = c("celltype","donor"))`
-- **Plan:**
-  1. Sum raw counts per (`celltype`, `donor`) combination → pseudobulk count matrix
-  2. Return a new `Shanuz` object (one "cell" per group) or a plain `pd.DataFrame`
-  3. Intended input for `DESeq2`-style testing (see below)
+- Intended input for `DESeq2`-style testing (see below).
 
 ### DESeq2-style pseudobulk DE
 - **R:** `FindMarkers(obj, test.use = "DESeq2")` (via `DESeq2` R package)
@@ -168,11 +171,15 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
   magnitude given detection) using `statsmodels`; no R dep required
 - **Note:** `statsmodels` is already a dep (used by LR/negbinom tests)
 
-### `FindConservedMarkers`
+### `FindConservedMarkers` — ✅ delivered
+- Implemented as `find_conserved_markers(...)` in `shanuz/markers.py`. Runs
+  `find_markers` independently within each level of `grouping_var`, keeps genes
+  that are markers in *every* level, and combines their per-level p-values with
+  Fisher's method (`scipy.stats.combine_pvalues`). Output has per-level prefixed
+  stats plus `max_pval` and `combined_p_val` (sorted by the latter); levels
+  lacking a comparison group are skipped with a warning
+  (`tests/test_pseudobulk_conserved.py`).
 - **R:** `FindConservedMarkers(obj, ident.1, grouping.var)`
-- **Plan:** run `find_markers` independently per group, then combine p-values
-  (Fisher's method: `scipy.stats.combine_pvalues`) and report genes significant
-  in all groups; returns combined + per-group stats columns
 
 ### `bimod` test (likelihood-ratio on bimodal model)
 - **R:** `FindMarkers(obj, test.use = "bimod")`
@@ -350,5 +357,6 @@ If milestones are too large, these are the highest-value individual items:
 3. ~~**GitHub Actions CI** (`v0.10.0`)~~ — ✅ delivered
 4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — enables atlas-based annotation (next-cycle candidate; needs CCA/RPCA first)
 5. **`FindSpatiallyVariableFeatures` (Moran's I) + `SpatialFeaturePlot`** (`v0.7.0`) — the remaining spatial gaps (loaders + niche/neighbourhood analysis already delivered)
-6. **`AggregateExpression` + DESeq2** (`v0.6.0`) — unlocks multi-sample DE
+6. ~~**`AggregateExpression`**~~ ✅ + **DESeq2** (`v0.6.0`) — `aggregate_expression`
+   and `find_conserved_markers` delivered; DESeq2/MAST/bimod unlock multi-sample DE
 7. **`SketchData`** (`v0.8.0`) — enables million-cell datasets

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -22,7 +22,8 @@ from .multimodal import find_multi_modal_neighbors
 from .clustering import find_clusters
 from .umap import run_umap
 from .integration import run_harmony, integrate_layers
-from .markers import find_markers, find_all_markers
+from .markers import find_markers, find_all_markers, find_conserved_markers
+from .aggregate import aggregate_expression
 from .sctransform import sctransform
 from .module_score import add_module_score, cell_cycle_scoring, CC_GENES
 from .spatial import (
@@ -123,6 +124,8 @@ __all__ = [
     "integrate_layers",
     "find_markers",
     "find_all_markers",
+    "find_conserved_markers",
+    "aggregate_expression",
     "jack_straw",
     "score_jackstraw",
     "sctransform",

--- a/shanuz/aggregate.py
+++ b/shanuz/aggregate.py
@@ -1,0 +1,156 @@
+"""Pseudobulk aggregation.
+
+Mirrors Seurat's AggregateExpression(), which sums raw counts within groups of
+cells (e.g. per cell type × donor) to produce a pseudobulk matrix — the standard
+input for sample-level differential expression (DESeq2 / edgeR-style testing).
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+
+from .markers import _get_expression_matrix
+
+# Metadata keys that resolve to the object's active identities rather than a
+# meta_data column, matching Seurat's group.by = "ident".
+_IDENT_KEYS = ("ident", "idents", "seurat_annotations")
+
+
+def _group_labels(seurat, group_by: list[str]) -> pd.Series:
+    """Per-cell group label: the group_by columns joined with '_' (Seurat's rule)."""
+    cells = seurat.cell_names()
+    meta = seurat.meta_data
+    parts = pd.DataFrame(index=cells)
+    for col in group_by:
+        if col in _IDENT_KEYS and col not in meta.columns:
+            parts[col] = [str(i) for i in seurat.idents]
+        elif col in meta.columns:
+            parts[col] = meta.loc[cells, col].astype(str).to_numpy()
+        else:
+            raise KeyError(
+                f"group_by column {col!r} not found in meta_data "
+                f"(columns: {list(meta.columns)})."
+            )
+    return parts.astype(str).agg("_".join, axis=1)
+
+
+def aggregate_expression(
+    seurat,
+    group_by: Union[str, list[str]] = "ident",
+    assays: Optional[Union[str, list[str]]] = None,
+    features: Optional[list[str]] = None,
+    layer: str = "counts",
+    return_object: bool = False,
+):
+    """Sum counts within cell groups to form a pseudobulk profile.
+
+    Mirrors R's ``AggregateExpression(obj, group.by = c("celltype", "donor"))``.
+
+    Parameters
+    ----------
+    group_by      : metadata column(s) defining the groups. Multiple columns are
+                    combined into a single label joined by ``"_"`` (as Seurat
+                    does). ``"ident"`` uses the object's active identities.
+    assays        : assay name(s) to aggregate (default: the active assay).
+    features      : restrict to these features (default: all).
+    layer         : layer to aggregate (default ``"counts"`` — pseudobulk is
+                    defined on raw counts).
+    return_object : if True, return a new :class:`Shanuz` object with one "cell"
+                    per group; if False (default), return a ``pd.DataFrame``
+                    (features × groups), or a ``dict`` of them when several
+                    assays are requested.
+
+    Returns
+    -------
+    ``pd.DataFrame`` | ``dict[str, pd.DataFrame]`` | ``Shanuz``
+        A single DataFrame when one assay is aggregated, a dict keyed by assay
+        name when several are, or a Shanuz object when ``return_object=True``.
+    """
+    group_cols = [group_by] if isinstance(group_by, str) else list(group_by)
+    if assays is None:
+        assay_names = [seurat.active_assay]
+    else:
+        assay_names = [assays] if isinstance(assays, str) else list(assays)
+
+    labels = _group_labels(seurat, group_cols)
+    groups = sorted(labels.unique())
+    n_cells = len(labels)
+    n_groups = len(groups)
+
+    # One-hot cells × groups indicator; counts(features×cells) @ indicator
+    # sums each group's columns in a single sparse matmul.
+    group_index = {g: j for j, g in enumerate(groups)}
+    col_idx = np.fromiter((group_index[g] for g in labels), dtype=int, count=n_cells)
+    indicator = sp.csr_matrix(
+        (np.ones(n_cells), (np.arange(n_cells), col_idx)),
+        shape=(n_cells, n_groups),
+    )
+
+    agg_frames: dict[str, pd.DataFrame] = {}
+    for name in assay_names:
+        assay_obj = seurat.assays[name]
+        data, feature_names = _get_expression_matrix(assay_obj, layer)
+        if features is not None:
+            feat_set = set(features)
+            keep = np.array([f in feat_set for f in feature_names])
+            feature_names = [f for f, k in zip(feature_names, keep) if k]
+            data = data[keep, :]
+        summed = data @ indicator  # features × groups
+        if sp.issparse(summed):
+            summed = summed.toarray()
+        agg_frames[name] = pd.DataFrame(
+            np.asarray(summed), index=feature_names, columns=groups
+        )
+
+    if return_object:
+        return _to_shanuz(seurat, agg_frames, labels, groups, group_cols)
+
+    if len(assay_names) == 1:
+        return agg_frames[assay_names[0]]
+    return agg_frames
+
+
+def _to_shanuz(seurat, agg_frames, labels, groups, group_cols):
+    """Assemble aggregated frames into a Shanuz object (one 'cell' per group)."""
+    from .shanuz import create_shanuz_object
+
+    # Decode one representative row of group_by values per group.
+    decoded = pd.DataFrame(index=seurat.cell_names())
+    for col in group_cols:
+        if col in _IDENT_KEYS and col not in seurat.meta_data.columns:
+            decoded[col] = [str(i) for i in seurat.idents]
+        else:
+            decoded[col] = seurat.meta_data.loc[decoded.index, col].astype(str).to_numpy()
+    decoded["__group__"] = labels.to_numpy()
+    group_meta = (
+        decoded.drop_duplicates("__group__")
+        .set_index("__group__")
+        .loc[groups, group_cols]
+    )
+
+    primary = seurat.active_assay if seurat.active_assay in agg_frames else next(iter(agg_frames))
+    base = agg_frames[primary]
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(base.to_numpy()),
+        assay=primary,
+        feature_names=list(base.index),
+        cell_names=groups,
+        meta_data=group_meta,
+        project=seurat.project_name,
+    )
+    # Attach any additional aggregated assays as extra Assay5 layers-of-record.
+    for name, frame in agg_frames.items():
+        if name == primary:
+            continue
+        from .assay5 import create_assay5_object
+
+        obj.assays[name] = create_assay5_object(
+            counts=sp.csc_matrix(frame.to_numpy()),
+            feature_names=list(frame.index),
+            cell_names=groups,
+            key=f"{name.lower()}_",
+        )
+    return obj

--- a/shanuz/markers.py
+++ b/shanuz/markers.py
@@ -381,6 +381,115 @@ def find_all_markers(
     return combined.sort_values(["cluster", "p_val"])
 
 
+def find_conserved_markers(
+    seurat,
+    ident_1: Union[str, list[str]],
+    grouping_var: str,
+    ident_2: Optional[Union[str, list[str]]] = None,
+    assay: Optional[str] = None,
+    layer: Optional[str] = None,
+    test_use: str = "wilcox",
+    only_pos: bool = False,
+    min_pct: float = 0.1,
+    logfc_threshold: float = 0.25,
+    features: Optional[list[str]] = None,
+) -> pd.DataFrame:
+    """Find markers conserved across the levels of a grouping variable.
+
+    Mirrors R's ``FindConservedMarkers(obj, ident.1, grouping.var = "stim")``:
+    runs :func:`find_markers` for ``ident_1`` vs ``ident_2`` independently within
+    each level of ``grouping_var``, keeps only genes detected as markers in
+    *every* level, and combines their per-level p-values with Fisher's method
+    (:func:`scipy.stats.combine_pvalues`).
+
+    Parameters
+    ----------
+    ident_1      : cluster label(s) for group 1.
+    grouping_var : metadata column whose levels define the independent
+                   comparisons (e.g. condition, batch, donor).
+    ident_2      : cluster label(s) for group 2 (None = all other cells).
+    (remaining args are forwarded to :func:`find_markers`.)
+
+    Returns
+    -------
+    DataFrame indexed by gene with, for each level ``g``, the columns
+    ``{g}_p_val, {g}_avg_log2FC, {g}_pct.1, {g}_pct.2, {g}_p_val_adj`` plus
+    ``max_pval`` (worst per-level p-value) and ``combined_p_val`` (Fisher-combined
+    across levels), sorted by ``combined_p_val``. Only genes that are markers in
+    all levels are returned.
+    """
+    from scipy.stats import combine_pvalues
+
+    if grouping_var not in seurat.meta_data.columns:
+        raise KeyError(
+            f"grouping_var {grouping_var!r} not found in meta_data "
+            f"(columns: {list(seurat.meta_data.columns)})."
+        )
+
+    cells = seurat.cell_names()
+    group_of = seurat.meta_data.loc[cells, grouping_var].astype(str)
+    levels = sorted(group_of.unique())
+
+    per_level: dict[str, pd.DataFrame] = {}
+    for level in levels:
+        level_cells = [c for c, g in zip(cells, group_of) if g == level]
+        sub = seurat.subset(cells=level_cells)
+        try:
+            df = find_markers(
+                sub,
+                ident_1=ident_1,
+                ident_2=ident_2,
+                assay=assay,
+                layer=layer,
+                test_use=test_use,
+                only_pos=only_pos,
+                min_pct=min_pct,
+                logfc_threshold=logfc_threshold,
+                features=features,
+            )
+        except ValueError as e:
+            warnings.warn(
+                f"Skipping {grouping_var}={level!r}: {e}", RuntimeWarning, stacklevel=2
+            )
+            continue
+        if len(df) > 0:
+            per_level[level] = df
+
+    if not per_level:
+        raise ValueError(
+            f"No level of {grouping_var!r} yielded markers for the requested comparison."
+        )
+
+    # Genes must be markers in every retained level.
+    common = set.intersection(*(set(df.index) for df in per_level.values()))
+
+    used = list(per_level)
+    cols: dict[str, pd.Series] = {}
+    for level in used:
+        df = per_level[level].loc[list(common)]
+        for c in df.columns:
+            cols[f"{level}_{c}"] = df[c]
+    result = pd.DataFrame(cols, index=list(common))
+
+    if test_use == "roc":
+        # ROC has no p-value; conservation is summarised by the min power.
+        power_cols = [f"{level}_power" for level in used]
+        result["min_power"] = result[power_cols].min(axis=1)
+        return result.sort_values("min_power", ascending=False)
+
+    pval_cols = [f"{level}_p_val" for level in used]
+    result["max_pval"] = result[pval_cols].max(axis=1)
+    if len(used) == 1:
+        result["combined_p_val"] = result[pval_cols[0]]
+    else:
+        result["combined_p_val"] = [
+            combine_pvalues(result.loc[g, pval_cols].to_numpy(dtype=float),
+                            method="fisher").pvalue
+            for g in result.index
+        ]
+    return result.sort_values("combined_p_val")
+
+
 # ------------------------------------------------------------------
 # Helper
 # ------------------------------------------------------------------

--- a/tests/test_pseudobulk_conserved.py
+++ b/tests/test_pseudobulk_conserved.py
@@ -1,0 +1,130 @@
+"""Tests for AggregateExpression (pseudobulk) and FindConservedMarkers."""
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+import pytest
+
+from shanuz import aggregate_expression, find_conserved_markers, find_markers
+from shanuz.preprocessing import normalize_data
+
+
+# ---------------------------------------------------------------------------
+# aggregate_expression
+# ---------------------------------------------------------------------------
+
+def test_aggregate_sums_counts_per_group(small_seurat, small_counts):
+    small_seurat.meta_data["donor"] = ["d1", "d2"] * 10  # d1 = even, d2 = odd
+
+    agg = aggregate_expression(small_seurat, group_by="donor")
+
+    assert list(agg.columns) == ["d1", "d2"]
+    assert agg.shape == (50, 2)
+
+    dense = small_counts.toarray()
+    even = dense[:, ::2].sum(axis=1)
+    odd = dense[:, 1::2].sum(axis=1)
+    np.testing.assert_allclose(agg["d1"].to_numpy(), even)
+    np.testing.assert_allclose(agg["d2"].to_numpy(), odd)
+
+
+def test_aggregate_by_ident(small_seurat):
+    small_seurat.idents = ["A"] * 10 + ["B"] * 10
+    agg = aggregate_expression(small_seurat, group_by="ident")
+    assert set(agg.columns) == {"A", "B"}
+
+
+def test_aggregate_multiple_group_by_joins_with_underscore(small_seurat):
+    small_seurat.meta_data["donor"] = ["d1"] * 10 + ["d2"] * 10
+    small_seurat.meta_data["cond"] = ["x", "y"] * 10
+    agg = aggregate_expression(small_seurat, group_by=["donor", "cond"])
+    assert set(agg.columns) == {"d1_x", "d1_y", "d2_x", "d2_y"}
+
+
+def test_aggregate_return_object(small_seurat, small_counts):
+    small_seurat.meta_data["donor"] = ["d1", "d2"] * 10
+    obj = aggregate_expression(small_seurat, group_by="donor", return_object=True)
+
+    assert len(obj) == 2  # one "cell" per group
+    assert obj.cell_names() == ["d1", "d2"]
+    assert "donor" in obj.meta_data.columns
+
+    df = aggregate_expression(small_seurat, group_by="donor")
+    pb = obj.assays["RNA"].layers["counts"]
+    pb = pb.toarray() if sp.issparse(pb) else np.asarray(pb)
+    np.testing.assert_allclose(pb, df.to_numpy())
+
+
+def test_aggregate_features_subset(small_seurat):
+    small_seurat.meta_data["donor"] = ["d1", "d2"] * 10
+    genes = ["gene_0", "gene_5", "gene_9"]
+    agg = aggregate_expression(small_seurat, group_by="donor", features=genes)
+    assert list(agg.index) == genes
+
+
+def test_aggregate_unknown_group_by_raises(small_seurat):
+    with pytest.raises(KeyError):
+        aggregate_expression(small_seurat, group_by="nope")
+
+
+# ---------------------------------------------------------------------------
+# find_conserved_markers
+# ---------------------------------------------------------------------------
+
+def test_conserved_markers_basic(small_seurat):
+    normalize_data(small_seurat)
+    small_seurat.idents = ["A"] * 10 + ["B"] * 10
+    # Each batch holds both idents (5 A + 5 B).
+    small_seurat.meta_data["batch"] = (["x", "y"] * 5) + (["x", "y"] * 5)
+
+    res = find_conserved_markers(
+        small_seurat, ident_1="A", grouping_var="batch",
+        min_pct=0.0, logfc_threshold=0.0,
+    )
+
+    for pref in ("x_", "y_"):
+        assert f"{pref}p_val" in res.columns
+        assert f"{pref}avg_log2FC" in res.columns
+    assert "max_pval" in res.columns and "combined_p_val" in res.columns
+
+    # Genes must be markers in BOTH levels.
+    x_only = find_markers(small_seurat.subset(
+        cells=[c for c, b in zip(small_seurat.cell_names(),
+                                 small_seurat.meta_data["batch"]) if b == "x"]),
+        ident_1="A", min_pct=0.0, logfc_threshold=0.0)
+    assert set(res.index).issubset(set(x_only.index))
+
+    # combined_p_val is a valid probability and sorted ascending.
+    assert ((res["combined_p_val"] >= 0) & (res["combined_p_val"] <= 1)).all()
+    assert res["combined_p_val"].is_monotonic_increasing
+    # max_pval is the worst of the per-level p-values.
+    np.testing.assert_allclose(
+        res["max_pval"].to_numpy(),
+        res[["x_p_val", "y_p_val"]].max(axis=1).to_numpy(),
+    )
+
+
+def test_conserved_markers_skips_level_without_comparison_group(small_seurat):
+    normalize_data(small_seurat)
+    small_seurat.idents = ["A"] * 10 + ["B"] * 10
+    # "lonely" contains only ident A -> no comparison group -> skipped.
+    small_seurat.meta_data["cond"] = ["lonely"] * 5 + ["together"] * 15
+
+    with pytest.warns(RuntimeWarning, match="lonely"):
+        res = find_conserved_markers(
+            small_seurat, ident_1="A", grouping_var="cond",
+            min_pct=0.0, logfc_threshold=0.0,
+        )
+
+    # Only the "together" level survives; combined == that level's p_val.
+    assert any(c.startswith("together_") for c in res.columns)
+    assert not any(c.startswith("lonely_") for c in res.columns)
+    np.testing.assert_allclose(
+        res["combined_p_val"].to_numpy(), res["together_p_val"].to_numpy()
+    )
+
+
+def test_conserved_markers_unknown_grouping_var_raises(small_seurat):
+    normalize_data(small_seurat)
+    small_seurat.idents = ["A"] * 10 + ["B"] * 10
+    with pytest.raises(KeyError):
+        find_conserved_markers(small_seurat, ident_1="A", grouping_var="missing")

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -252,6 +252,8 @@ same caveat as the other tutorials.
 | UMAP | `RunUMAP(pbmc, dims)` | `run_umap(pbmc, dims)` |
 | Markers | `FindMarkers(pbmc, ident.1)` | `find_markers(pbmc, ident_1)` |
 | All markers | `FindAllMarkers(pbmc, only.pos, logfc.threshold)` | `find_all_markers(pbmc, only_pos, logfc_threshold)` |
+| Conserved markers | `FindConservedMarkers(pbmc, ident.1, grouping.var)` | `find_conserved_markers(pbmc, ident_1, grouping_var)` |
+| Pseudobulk | `AggregateExpression(pbmc, group.by)` | `aggregate_expression(pbmc, group_by)` |
 | Rename idents | `RenameIdents(pbmc, new.ids)` | `pbmc.rename_idents(mapping_dict)` |
 | Subset cells | `subset(pbmc, subset = condition)` | `pbmc.subset(cells=keep_list)` |
 | Add assay | `pbmc[["ADT"]] <- CreateAssayObject(counts)` | `obj.assays["ADT"] = create_assay5_object(counts, key="adt_")` |
@@ -259,6 +261,28 @@ same caveat as the other tutorials.
 | Access metadata | `pbmc@meta.data` | `pbmc.meta_data` |
 | Access assay | `pbmc[["RNA"]]` | `pbmc.assays["RNA"]` |
 | Active idents | `Idents(pbmc)` | `pbmc.idents` |
+
+### Pseudobulk & conserved markers
+
+Two multi-sample DE helpers (mirroring Seurat's `AggregateExpression` and
+`FindConservedMarkers`):
+
+```python
+from shanuz import aggregate_expression, find_conserved_markers
+
+# Pseudobulk: sum raw counts per (cell type × donor) → features × groups DataFrame.
+# Pass return_object=True to get a Shanuz object with one "cell" per group instead
+# (the standard input for pyDESeq2-style sample-level testing).
+pb = aggregate_expression(obj, group_by=["cell_type", "donor"])
+
+# Conserved markers: genes up in cluster "B" in *every* condition. Runs FindMarkers
+# per level of grouping_var, keeps genes significant in all, and combines their
+# p-values with Fisher's method (the `combined_p_val` column; `max_pval` is the
+# worst single-condition p-value).
+cons = find_conserved_markers(obj, ident_1="B", grouping_var="condition",
+                              only_pos=True)
+cons.head()   # per-condition stats + max_pval + combined_p_val, sorted by combined_p_val
+```
 
 ### Plotting
 


### PR DESCRIPTION
First PR of the v0.6.0 (Pseudobulk DE & Advanced Marker Methods) cycle. Adds two multi-sample DE building blocks, both mirroring Seurat.

## What's added

### `aggregate_expression` (`AggregateExpression`) — `shanuz/aggregate.py`
- Sums raw counts within cell groups via a single sparse `counts @ indicator` matmul (no per-group Python loop).
- `group_by` accepts one or more metadata columns (joined with `"_"`, as Seurat does) or `"ident"`.
- Returns a `features × groups` `DataFrame` (a `dict` for multiple assays), or a `Shanuz` object with one "cell" per group when `return_object=True` — the standard input for sample-level (pyDESeq2-style) testing.

### `find_conserved_markers` (`FindConservedMarkers`) — `shanuz/markers.py`
- Runs `find_markers` independently within each level of `grouping_var`, keeps genes that are markers in **every** level, and combines their per-level p-values with Fisher's method (`scipy.stats.combine_pvalues`).
- Output: per-level prefixed stats (`{level}_p_val`, `_avg_log2FC`, `_pct.1`, `_pct.2`, `_p_val_adj`) plus `max_pval` and `combined_p_val`, sorted by the combined p-value.
- Levels lacking a comparison group are skipped with a `RuntimeWarning`; forwards `test_use`/`min_pct`/`logfc_threshold`/etc. to `find_markers` (incl. a `roc` `min_power` path).

## Compatibility
Purely additive — no existing signatures or behavior changed. Both symbols are exported from the package top level. Existing tutorials are unaffected.

## Tests
- 9 new tests in `tests/test_pseudobulk_conserved.py` (exact-sum checks, ident/multi-column grouping, `return_object`, feature subsetting, conserved-marker column shape, skip-level warning, error cases).
- Full suite **156 → 165 passing**; `aggregate.py` is ruff-clean.
- End-to-end smoke test with a planted signal recovers it (pseudobulk sums exact; conserved-marker ranks the planted gene first, Fisher p ≈ 2e-13 across two batches).

## Docs
- `tutorials/README.md`: usage snippet + two API-table rows.
- `README.md`: feature list, DE example, roadmap row (v0.6.0 `✅ delivered`).
- `ROADMAP.md`: both items marked delivered; priority list updated.

## Not in this PR (rest of v0.6.0)
DESeq2 pseudobulk branch, MAST, bimod — to follow, building on `aggregate_expression`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)