### PR TITLE
feat: pseudobulk DESeq2 test in find_markers (test_use="deseq2")

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Clustering** — `find_clusters` (Louvain via python-igraph, Leiden via leidenalg)
 - **UMAP** — `run_umap` (via umap-learn; embeds a reduction or a precomputed graph)
 - **PC significance** — `jack_straw`, `score_jackstraw` (JackStraw permutation test)
-- **Differential expression** — `find_markers`, `find_all_markers` (`wilcox` tie-corrected, `t`, `LR`, `negbinom`, `roc`), `find_conserved_markers` (cross-condition, Fisher-combined)
-- **Pseudobulk** — `aggregate_expression` (sum counts per group → matrix or one-cell-per-group object)
+- **Differential expression** — `find_markers`, `find_all_markers` (`wilcox` tie-corrected, `t`, `LR`, `negbinom`, `deseq2` pseudobulk, `roc`), `find_conserved_markers` (cross-condition, Fisher-combined)
+- **Pseudobulk** — `aggregate_expression` (sum counts per group → matrix or one-cell-per-group object), pseudobulk DESeq2 via `find_markers(test_use="deseq2", sample_col=...)`
 - **Plotting** — `dim_plot`, `feature_plot`, `vln_plot`, `dot_plot`, `elbow_plot`, `do_heatmap`, `dim_heatmap`, `feature_scatter`, `variable_feature_plot`, `ridge_plot` (matplotlib/seaborn)
 - **AnnData interoperability** — `as_anndata`, `from_anndata`
 - **Spatial (Xenium / Visium / CosMx)** — `load_xenium`/`load_visium`/`load_cosmx`, `get_tissue_coordinates`, `nearest_neighbor_distance`, `local_neighborhood`, `build_niche_assay`, `composition_test`, `image_dim_plot`, `image_feature_plot`
@@ -212,6 +212,11 @@ conserved = find_conserved_markers(pbmc, ident_1=1, grouping_var="condition")
 
 # Pseudobulk counts summed per (cell type × donor) — input for sample-level DE.
 pseudobulk = aggregate_expression(pbmc, group_by=["cell_type", "donor"])
+
+# Pseudobulk DESeq2 between two conditions, one profile per donor (needs
+# `pip install shanuz[deseq2]`). pbmc.idents must hold the two conditions.
+de = find_markers(pbmc, ident_1="stim", ident_2="ctrl",
+                  test_use="deseq2", sample_col="donor")
 ```
 
 ### Plotting
@@ -286,7 +291,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData`, `MapQuery` |
 | v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(delivered — see Tutorial 3)* |
 | v0.5.0 | Additional reductions — t-SNE, ICA ✅ *(delivered)*; remaining: SPCA, GLM-PCA |
-| v0.6.0 | Pseudobulk DE — `AggregateExpression`, `FindConservedMarkers` ✅ *(delivered)*; remaining: DESeq2, MAST, bimod |
+| v0.6.0 | Pseudobulk DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`) ✅ *(delivered)*; remaining: MAST, bimod |
 | v0.7.0 | Spatial — Xenium/Visium/CosMx loaders, niche/neighbourhood analysis, `image_*` plots ✅ *(largely delivered — see Tutorial 5)*; remaining: MERSCOPE loader, `FindSpatiallyVariableFeatures` (Moran's I), Visium tissue-image plots |
 | v0.8.0 | Scale — BPCells-style lazy matrices, `SketchData`, `ProjectData` |
 | v0.9.0 | Specialized — `HTODemux`, Mixscape (CRISPR screens) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -158,11 +158,16 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 - **R:** `AggregateExpression(obj, group.by = c("celltype","donor"))`
 - Intended input for `DESeq2`-style testing (see below).
 
-### DESeq2-style pseudobulk DE
+### DESeq2-style pseudobulk DE — ✅ delivered
+- Implemented as the `test_use="deseq2"` branch of `find_markers` (`_deseq2_pseudobulk`
+  in `shanuz/markers.py`). Sums counts to one pseudobulk profile per (group ×
+  `sample_col`) — the `AggregateExpression` operation — then fits
+  `pydeseq2.DeseqDataSet(design="~condition")` and contrasts group 1 vs group 2.
+  Returns Seurat-shaped columns (`p_val`/`avg_log2FC`/`pct.1`/`pct.2`/`p_val_adj`);
+  warns below 2 replicates per group. Enable with `pip install shanuz[deseq2]`
+  (`tests/test_deseq2_pseudobulk.py`).
 - **R:** `FindMarkers(obj, test.use = "DESeq2")` (via `DESeq2` R package)
-- **Python dep:** `pydeseq2` (pip)
-- **Plan:** add `"deseq2"` branch in `find_markers` dispatch; aggregates counts
-  with `AggregateExpression` then runs `pydeseq2.DeseqDataSet`
+- **Python dep:** `pydeseq2` (pip, optional `[deseq2]` extra)
 
 ### MAST
 - **R:** `FindMarkers(obj, test.use = "MAST")`
@@ -357,6 +362,7 @@ If milestones are too large, these are the highest-value individual items:
 3. ~~**GitHub Actions CI** (`v0.10.0`)~~ — ✅ delivered
 4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — enables atlas-based annotation (next-cycle candidate; needs CCA/RPCA first)
 5. **`FindSpatiallyVariableFeatures` (Moran's I) + `SpatialFeaturePlot`** (`v0.7.0`) — the remaining spatial gaps (loaders + niche/neighbourhood analysis already delivered)
-6. ~~**`AggregateExpression`**~~ ✅ + **DESeq2** (`v0.6.0`) — `aggregate_expression`
-   and `find_conserved_markers` delivered; DESeq2/MAST/bimod unlock multi-sample DE
+6. ~~**`AggregateExpression` + DESeq2**~~ ✅ (`v0.6.0`) — `aggregate_expression`,
+   `find_conserved_markers`, and pseudobulk DESeq2 (`test_use="deseq2"`) delivered;
+   MAST/bimod remain to round out multi-sample DE
 7. **`SketchData`** (`v0.8.0`) — enables million-cell datasets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ analysis = [
 ]
 anndata = ["anndata>=0.10"]
 integration = ["harmonypy>=0.0.9"]
+deseq2 = ["pydeseq2>=0.4"]
 dev = [
     "pytest>=7",
     "pytest-cov",
@@ -51,7 +52,7 @@ dev = [
     "build",
     "twine",
 ]
-all = ["shanuz[analysis,anndata,integration,dev]"]
+all = ["shanuz[analysis,anndata,integration,deseq2,dev]"]
 
 [project.urls]
 Homepage = "https://github.com/GenomicAI/shanuz"

--- a/shanuz/markers.py
+++ b/shanuz/markers.py
@@ -108,6 +108,7 @@ def find_markers(
     logfc_threshold: float = 0.25,
     features: Optional[list[str]] = None,
     latent_vars: Optional[list[str]] = None,
+    sample_col: Optional[str] = None,
     max_cells_per_ident: Optional[int] = None,
     random_seed: int = 1,
 ) -> pd.DataFrame:
@@ -121,13 +122,19 @@ def find_markers(
     ident_2         : cluster label(s) for group 2 (None = all others)
     test_use        : statistical test — 'wilcox' (default), 't', 'LR'
                       (logistic-regression LRT), 'negbinom' (negative-binomial
-                      GLM LRT on counts), or 'roc' (AUC classifier power).
+                      GLM LRT on counts), 'deseq2' (pseudobulk DESeq2 — sums
+                      counts per sample then tests sample-level, requires
+                      ``sample_col``; needs ``pip install shanuz[deseq2]``), or
+                      'roc' (AUC classifier power).
     only_pos        : only return positive markers
     min_pct         : minimum fraction cells expressing gene in either group
     logfc_threshold : minimum log2 fold-change filter
     features        : restrict to these genes (default: all)
     latent_vars     : metadata columns to regress out as covariates in the
                       'LR' and 'negbinom' models (Seurat's latent.vars).
+    sample_col      : metadata column identifying pseudobulk replicates (donor /
+                      sample); required for ``test_use='deseq2'``, ignored
+                      otherwise.
     max_cells_per_ident : downsample each group to this many cells
 
     Returns
@@ -252,6 +259,13 @@ def find_markers(
             columns=["p_val", "avg_log2FC", "pct.1", "pct.2", "p_val_adj"]
         )
 
+    # ---- pseudobulk DESeq2: sample-level test, not per-cell -------------------
+    if test_use == "deseq2":
+        return _deseq2_pseudobulk(
+            seurat, assay_obj, cells_1, cells_2, sample_col,
+            feature_names, test_indices, pct1, pct2, only_pos,
+        )
+
     # ---- p-value-based tests -------------------------------------------------
     p_vals = np.ones(len(test_indices))
 
@@ -304,7 +318,7 @@ def find_markers(
     else:
         raise ValueError(
             f"Unsupported test_use: {test_use!r}. "
-            "Use 'wilcox', 't', 'LR', 'negbinom', or 'roc'."
+            "Use 'wilcox', 't', 'LR', 'negbinom', 'deseq2', or 'roc'."
         )
 
     # Bonferroni correction (Seurat default: multiply by total gene count)
@@ -336,6 +350,7 @@ def find_all_markers(
     only_pos: bool = False,
     min_pct: float = 0.1,
     logfc_threshold: float = 0.25,
+    sample_col: Optional[str] = None,
     max_cells_per_ident: Optional[int] = None,
     random_seed: int = 1,
 ) -> pd.DataFrame:
@@ -360,6 +375,7 @@ def find_all_markers(
                 only_pos=only_pos,
                 min_pct=min_pct,
                 logfc_threshold=logfc_threshold,
+                sample_col=sample_col,
                 max_cells_per_ident=max_cells_per_ident,
                 random_seed=random_seed,
             )
@@ -488,6 +504,100 @@ def find_conserved_markers(
             for g in result.index
         ]
     return result.sort_values("combined_p_val")
+
+
+def _deseq2_pseudobulk(
+    seurat,
+    assay_obj,
+    cells_1: list[str],
+    cells_2: list[str],
+    sample_col: Optional[str],
+    feature_names: list[str],
+    test_indices: np.ndarray,
+    pct1: np.ndarray,
+    pct2: np.ndarray,
+    only_pos: bool,
+) -> pd.DataFrame:
+    """Pseudobulk DESeq2 test (Seurat's ``test.use = "DESeq2"``).
+
+    Sums raw counts to one pseudobulk profile per (group, ``sample_col``) — the
+    same aggregation as :func:`shanuz.aggregate.aggregate_expression` — then fits
+    a DESeq2 model with design ``~condition`` and contrasts group 1 vs group 2.
+    A positive ``avg_log2FC`` (DESeq2's ``log2FoldChange``) means up in group 1.
+    """
+    try:
+        from pydeseq2.dds import DeseqDataSet
+        from pydeseq2.ds import DeseqStats
+    except ImportError as e:  # pragma: no cover - exercised only without the dep
+        raise ImportError(
+            "test_use='deseq2' requires pydeseq2. Install with "
+            "`pip install shanuz[deseq2]`."
+        ) from e
+
+    if sample_col is None:
+        raise ValueError(
+            "test_use='deseq2' is a pseudobulk test and requires sample_col — the "
+            "replicate/donor column to aggregate cells into per-sample profiles."
+        )
+    if sample_col not in seurat.meta_data.columns:
+        raise KeyError(f"sample_col {sample_col!r} not found in meta_data.")
+
+    counts_mat, _ = _get_expression_matrix(assay_obj, "counts")
+    counts_sub = counts_mat[test_indices, :]  # tested genes × all cells
+    cell_pos = {c: i for i, c in enumerate(seurat.cell_names())}
+    samples = seurat.meta_data[sample_col].astype(str)
+    gene_names = [feature_names[i] for i in test_indices]
+
+    def _pseudobulk(group_cells: list[str], cond: str) -> dict[str, np.ndarray]:
+        by_sample: dict[str, list[int]] = {}
+        for c in group_cells:
+            by_sample.setdefault(samples[c], []).append(cell_pos[c])
+        cols: dict[str, np.ndarray] = {}
+        for samp, idxs in by_sample.items():
+            summed = counts_sub[:, idxs].sum(axis=1)
+            cols[f"{cond}::{samp}"] = np.asarray(summed).ravel()
+        return cols
+
+    pb = {**_pseudobulk(cells_1, "group1"), **_pseudobulk(cells_2, "group2")}
+    sample_names = list(pb)
+    condition = ["group1" if s.startswith("group1::") else "group2" for s in sample_names]
+
+    n1, n2 = condition.count("group1"), condition.count("group2")
+    if n1 < 2 or n2 < 2:
+        warnings.warn(
+            f"DESeq2 pseudobulk has {n1} vs {n2} replicate(s) in {sample_col!r}; "
+            "dispersion estimates are unreliable without ≥2 replicates per group.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    # pydeseq2 wants samples × genes, integer counts.
+    counts_df = pd.DataFrame(
+        np.column_stack([pb[s] for s in sample_names]).T.astype(int),
+        index=sample_names,
+        columns=gene_names,
+    )
+    metadata = pd.DataFrame({"condition": condition}, index=sample_names)
+
+    dds = DeseqDataSet(counts=counts_df, metadata=metadata, design="~condition", quiet=True)
+    dds.deseq2()
+    stat = DeseqStats(dds, contrast=["condition", "group1", "group2"], quiet=True)
+    stat.summary()
+    res = stat.results_df.reindex(gene_names)
+
+    out = pd.DataFrame(
+        {
+            "p_val": res["pvalue"].fillna(1.0).to_numpy(),
+            "avg_log2FC": res["log2FoldChange"].fillna(0.0).to_numpy(),
+            "pct.1": pct1[test_indices],
+            "pct.2": pct2[test_indices],
+            "p_val_adj": res["padj"].fillna(1.0).to_numpy(),
+        },
+        index=gene_names,
+    )
+    if only_pos:
+        out = out[out["avg_log2FC"] > 0]
+    return out.sort_values("p_val")
 
 
 # ------------------------------------------------------------------

--- a/tests/test_deseq2_pseudobulk.py
+++ b/tests/test_deseq2_pseudobulk.py
@@ -1,0 +1,86 @@
+"""Tests for the pseudobulk DESeq2 branch of find_markers (test_use='deseq2')."""
+import warnings
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+pytest.importorskip("pydeseq2")
+
+from shanuz import create_shanuz_object, find_markers  # noqa: E402
+from shanuz.preprocessing import normalize_data  # noqa: E402
+
+
+@pytest.fixture
+def pseudobulk_obj():
+    """120 cells, 40 genes, 6 donors (3 per condition). gene_0 up in A, gene_1 up in B."""
+    rng = np.random.default_rng(0)
+    n_genes, per = 40, 20
+    cond_of = {"d1": "A", "d2": "A", "d3": "A", "d4": "B", "d5": "B", "d6": "B"}
+    blocks, cells, donor_col, cond_col = [], [], [], []
+    for d, cond in cond_of.items():
+        X = rng.poisson(2.0, size=(n_genes, per)).astype(float)
+        X[0 if cond == "A" else 1] += rng.poisson(20, size=per)
+        blocks.append(X)
+        cells += [f"{d}_c{j}" for j in range(per)]
+        donor_col += [d] * per
+        cond_col += [cond] * per
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(np.hstack(blocks)),
+        feature_names=[f"gene_{i}" for i in range(n_genes)],
+        cell_names=cells,
+    )
+    obj.meta_data["donor"] = donor_col
+    obj.idents = cond_col
+    normalize_data(obj)
+    return obj
+
+
+def test_deseq2_recovers_planted_de_genes(pseudobulk_obj):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # silence pydeseq2 small-panel convergence notes
+        res = find_markers(
+            pseudobulk_obj, ident_1="A", ident_2="B", test_use="deseq2",
+            sample_col="donor", min_pct=0.0, logfc_threshold=0.0,
+        )
+
+    assert list(res.columns) == ["p_val", "avg_log2FC", "pct.1", "pct.2", "p_val_adj"]
+    # gene_0 is up in A -> positive LFC and significant.
+    assert res.loc["gene_0", "avg_log2FC"] > 0
+    assert res.loc["gene_0", "p_val_adj"] < 0.05
+    # gene_1 is up in B -> down in A.
+    assert res.loc["gene_1", "avg_log2FC"] < 0
+    assert res.loc["gene_1", "p_val_adj"] < 0.05
+    # A non-DE gene should not be significant.
+    assert res.loc["gene_5", "p_val_adj"] > 0.05
+    # Sorted by p_val ascending; a planted gene ranks first.
+    assert res.index[0] in {"gene_0", "gene_1"}
+    assert res["p_val"].is_monotonic_increasing
+
+
+def test_deseq2_requires_sample_col(pseudobulk_obj):
+    with pytest.raises(ValueError, match="sample_col"):
+        find_markers(pseudobulk_obj, ident_1="A", ident_2="B", test_use="deseq2")
+
+
+def test_deseq2_unknown_sample_col_raises(pseudobulk_obj):
+    with pytest.raises(KeyError, match="not found in meta_data"):
+        find_markers(
+            pseudobulk_obj, ident_1="A", ident_2="B",
+            test_use="deseq2", sample_col="nope",
+        )
+
+
+def test_deseq2_warns_on_too_few_replicates(pseudobulk_obj):
+    # A = 2 donors, B = 1 donor -> fewer than 2 replicates in group B.
+    keep = [c for c, d in zip(pseudobulk_obj.cell_names(), pseudobulk_obj.meta_data["donor"])
+            if d in ("d1", "d2", "d4")]
+    sub = pseudobulk_obj.subset(cells=keep)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        with pytest.warns(RuntimeWarning, match="replicate"):
+            res = find_markers(
+                sub, ident_1="A", ident_2="B", test_use="deseq2",
+                sample_col="donor", min_pct=0.0, logfc_threshold=0.0,
+            )
+    assert len(res) > 0

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -254,6 +254,7 @@ same caveat as the other tutorials.
 | All markers | `FindAllMarkers(pbmc, only.pos, logfc.threshold)` | `find_all_markers(pbmc, only_pos, logfc_threshold)` |
 | Conserved markers | `FindConservedMarkers(pbmc, ident.1, grouping.var)` | `find_conserved_markers(pbmc, ident_1, grouping_var)` |
 | Pseudobulk | `AggregateExpression(pbmc, group.by)` | `aggregate_expression(pbmc, group_by)` |
+| Pseudobulk DESeq2 | `FindMarkers(pbmc, test.use="DESeq2")` | `find_markers(pbmc, ident_1, test_use="deseq2", sample_col=...)` |
 | Rename idents | `RenameIdents(pbmc, new.ids)` | `pbmc.rename_idents(mapping_dict)` |
 | Subset cells | `subset(pbmc, subset = condition)` | `pbmc.subset(cells=keep_list)` |
 | Add assay | `pbmc[["ADT"]] <- CreateAssayObject(counts)` | `obj.assays["ADT"] = create_assay5_object(counts, key="adt_")` |
@@ -282,6 +283,18 @@ pb = aggregate_expression(obj, group_by=["cell_type", "donor"])
 cons = find_conserved_markers(obj, ident_1="B", grouping_var="condition",
                               only_pos=True)
 cons.head()   # per-condition stats + max_pval + combined_p_val, sorted by combined_p_val
+```
+
+Pseudobulk DESeq2 (`find_markers(test_use="deseq2")`) tests **between conditions**
+rather than between clusters: set `obj.idents` to the two conditions, aggregate to
+one profile per replicate (`sample_col`), and run DESeq2 on those samples. Needs
+`pip install shanuz[deseq2]`:
+
+```python
+obj.idents = obj.meta_data["condition"]              # e.g. "stim" vs "ctrl"
+de = find_markers(obj, ident_1="stim", ident_2="ctrl",
+                  test_use="deseq2", sample_col="donor")
+de.head()   # p_val / avg_log2FC (DESeq2 log2FoldChange, +ve = up in stim) / pct.1 / pct.2 / p_val_adj
 ```
 
 ### Plotting


### PR DESCRIPTION
Second PR of the v0.6.0 (Pseudobulk DE) cycle, building on the `aggregate_expression` merged in #10. Adds the pseudobulk **DESeq2** test, mirroring Seurat's `FindMarkers(test.use = "DESeq2")` done the modern (roadmap-specified) way.

## What's added

### `test_use="deseq2"` branch of `find_markers` — `shanuz/markers.py`
- New **`sample_col`** parameter names the replicate/donor column. Cells are summed into one pseudobulk profile per (group × sample) — the same aggregation as `aggregate_expression` — then a DESeq2 model (`design="~condition"`) contrasts group 1 vs group 2 via `pydeseq2`.
- Seurat-shaped output: `p_val` (pvalue), `avg_log2FC` (DESeq2 `log2FoldChange`, **+ve = up in `ident_1`**), `pct.1`/`pct.2` (single-cell detection rates), `p_val_adj` (padj).
- Guardrails: clear `ImportError` → `pip install shanuz[deseq2]` if the dep is missing; `ValueError` if `sample_col` omitted; `KeyError` if the column is absent; `RuntimeWarning` when a group has <2 replicates.
- `sample_col` also threaded through `find_all_markers`.

### Packaging
New optional `deseq2 = ["pydeseq2>=0.4"]` extra, added to `[all]` so CI's `.[all]` install exercises the new tests.

## Compatibility
Purely additive — existing `find_markers` / `find_all_markers` behavior and signatures are unchanged (only a new keyword-defaulted `sample_col` and a new `test_use` value). Tutorials unaffected.

## Tests
- 4 new tests in `tests/test_deseq2_pseudobulk.py` (`importorskip`-guarded): recovers planted up/down genes with correct LFC sign + significance, non-DE gene stays non-significant, sorted output, and all three error/warning paths.
- Full suite **165 → 169 passing**; no new ruff findings.
- Smoke test (6 donors, 3v3): `gene_0` up in A (LFC 3.32, padj 0), `gene_1` down, non-DE genes non-significant.

## Docs
- `README.md`: DE feature bullet, DE code example, roadmap row (v0.6.0 DESeq2 `✅`).
- `ROADMAP.md`: DESeq2 section marked delivered; priority list updated.
- `tutorials/README.md`: API-table row + a pseudobulk-DESeq2 snippet.

## Remaining in v0.6.0
MAST and the `bimod` test — to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)