### PR TITLE
feat: MAST two-part hurdle test in find_markers (test_use="mast")

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Clustering** — `find_clusters` (Louvain via python-igraph, Leiden via leidenalg)
 - **UMAP** — `run_umap` (via umap-learn; embeds a reduction or a precomputed graph)
 - **PC significance** — `jack_straw`, `score_jackstraw` (JackStraw permutation test)
-- **Differential expression** — `find_markers`, `find_all_markers` (`wilcox` tie-corrected, `t`, `LR`, `negbinom`, `deseq2` pseudobulk, `roc`), `find_conserved_markers` (cross-condition, Fisher-combined)
+- **Differential expression** — `find_markers`, `find_all_markers` (`wilcox` tie-corrected, `t`, `LR`, `negbinom`, `mast` hurdle, `deseq2` pseudobulk, `roc`), `find_conserved_markers` (cross-condition, Fisher-combined)
 - **Pseudobulk** — `aggregate_expression` (sum counts per group → matrix or one-cell-per-group object), pseudobulk DESeq2 via `find_markers(test_use="deseq2", sample_col=...)`
 - **Plotting** — `dim_plot`, `feature_plot`, `vln_plot`, `dot_plot`, `elbow_plot`, `do_heatmap`, `dim_heatmap`, `feature_scatter`, `variable_feature_plot`, `ridge_plot` (matplotlib/seaborn)
 - **AnnData interoperability** — `as_anndata`, `from_anndata`
@@ -291,7 +291,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData`, `MapQuery` |
 | v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(delivered — see Tutorial 3)* |
 | v0.5.0 | Additional reductions — t-SNE, ICA ✅ *(delivered)*; remaining: SPCA, GLM-PCA |
-| v0.6.0 | Pseudobulk DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`) ✅ *(delivered)*; remaining: MAST, bimod |
+| v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`) ✅ *(delivered)*; remaining: bimod |
 | v0.7.0 | Spatial — Xenium/Visium/CosMx loaders, niche/neighbourhood analysis, `image_*` plots ✅ *(largely delivered — see Tutorial 5)*; remaining: MERSCOPE loader, `FindSpatiallyVariableFeatures` (Moran's I), Visium tissue-image plots |
 | v0.8.0 | Scale — BPCells-style lazy matrices, `SketchData`, `ProjectData` |
 | v0.9.0 | Specialized — `HTODemux`, Mixscape (CRISPR screens) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -169,12 +169,16 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 - **R:** `FindMarkers(obj, test.use = "DESeq2")` (via `DESeq2` R package)
 - **Python dep:** `pydeseq2` (pip, optional `[deseq2]` extra)
 
-### MAST
+### MAST — ✅ delivered
+- Implemented as the `test_use="mast"` branch of `find_markers` (`_mast_pvalue` in
+  `shanuz/markers.py`): a pure-Python two-part hurdle LRT — a logistic model of
+  detection (`expr > 0`) plus a Gaussian model of magnitude among detected cells,
+  each `~ group (+ latent)`. The combined statistic is the sum of the two
+  components' LR statistics on the sum of their df (components with no signal
+  drop out). No R dep — `statsmodels` is already present. Pass the cellular
+  detection rate via `latent_vars` to match Seurat's CDR covariate
+  (`tests/test_mast_de.py`).
 - **R:** `FindMarkers(obj, test.use = "MAST")`
-- **Python dep:** `rpy2` (call R's MAST) or pure-Python hurdle model
-- **Plan:** implement two-part hurdle model (logistic for detection + Gaussian for
-  magnitude given detection) using `statsmodels`; no R dep required
-- **Note:** `statsmodels` is already a dep (used by LR/negbinom tests)
 
 ### `FindConservedMarkers` — ✅ delivered
 - Implemented as `find_conserved_markers(...)` in `shanuz/markers.py`. Runs
@@ -364,5 +368,5 @@ If milestones are too large, these are the highest-value individual items:
 5. **`FindSpatiallyVariableFeatures` (Moran's I) + `SpatialFeaturePlot`** (`v0.7.0`) — the remaining spatial gaps (loaders + niche/neighbourhood analysis already delivered)
 6. ~~**`AggregateExpression` + DESeq2**~~ ✅ (`v0.6.0`) — `aggregate_expression`,
    `find_conserved_markers`, and pseudobulk DESeq2 (`test_use="deseq2"`) delivered;
-   MAST/bimod remain to round out multi-sample DE
+   MAST (`test_use="mast"`) delivered too; only the bimod test remains in v0.6.0
 7. **`SketchData`** (`v0.8.0`) — enables million-cell datasets

--- a/shanuz/markers.py
+++ b/shanuz/markers.py
@@ -96,6 +96,71 @@ def _negbinom_pvalue(counts: np.ndarray, group: np.ndarray, latent: Optional[np.
         return 1.0
 
 
+def _mast_pvalue(expr: np.ndarray, group: np.ndarray, latent: Optional[np.ndarray]) -> float:
+    """MAST two-part hurdle likelihood-ratio test (Finak 2015; Seurat's 'MAST').
+
+    Fits a *discrete* logistic model of detection (``expr > 0``) and a
+    *continuous* Gaussian model of the log-expression among detected cells, each
+    as ``~ group (+ latent)``. Because the hurdle likelihood factorises into its
+    detection and magnitude parts, the combined LR statistic is the sum of the
+    two components' statistics tested on the sum of their degrees of freedom.
+    Components that carry no information (constant detection, or magnitude seen in
+    only one group) contribute 0 df and are dropped.
+    """
+    import statsmodels.api as sm
+    from scipy.stats import chi2
+
+    n = len(expr)
+    detect = (expr > 0).astype(float)
+
+    def _design(mask: np.ndarray, include_group: bool) -> np.ndarray:
+        cols = [np.ones(int(mask.sum()))]
+        if include_group:
+            cols.append(group[mask])
+        if latent is not None and latent.size:
+            cols.append(latent[mask])
+        return np.column_stack(cols)
+
+    stat = 0.0
+    df = 0
+
+    # ---- discrete component: logistic LRT on the group term ------------------
+    if 0.0 < detect.sum() < n:  # detection varies → group term is estimable
+        allmask = np.ones(n, dtype=bool)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                full = sm.GLM(detect, _design(allmask, True),
+                              family=sm.families.Binomial()).fit()
+                red = sm.GLM(detect, _design(allmask, False),
+                             family=sm.families.Binomial()).fit()
+            d = red.deviance - full.deviance
+            if np.isfinite(d) and d > 0:
+                stat += d
+                df += 1
+        except Exception:
+            pass
+
+    # ---- continuous component: Gaussian LRT among detected cells -------------
+    pos = expr > 0
+    if pos.sum() >= 3 and np.unique(group[pos]).size > 1 and np.ptp(expr[pos]) > 0:
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                full = sm.OLS(expr[pos], _design(pos, True)).fit()
+                red = sm.OLS(expr[pos], _design(pos, False)).fit()
+            d = 2.0 * (full.llf - red.llf)
+            if np.isfinite(d) and d > 0:
+                stat += d
+                df += 1
+        except Exception:
+            pass
+
+    if df == 0:
+        return 1.0
+    return float(chi2.sf(stat, df=df))
+
+
 def find_markers(
     seurat,
     ident_1: Union[str, list[str]],
@@ -122,7 +187,8 @@ def find_markers(
     ident_2         : cluster label(s) for group 2 (None = all others)
     test_use        : statistical test — 'wilcox' (default), 't', 'LR'
                       (logistic-regression LRT), 'negbinom' (negative-binomial
-                      GLM LRT on counts), 'deseq2' (pseudobulk DESeq2 — sums
+                      GLM LRT on counts), 'mast' (MAST two-part hurdle LRT on
+                      log-normalized data), 'deseq2' (pseudobulk DESeq2 — sums
                       counts per sample then tests sample-level, requires
                       ``sample_col``; needs ``pip install shanuz[deseq2]``), or
                       'roc' (AUC classifier power).
@@ -131,7 +197,9 @@ def find_markers(
     logfc_threshold : minimum log2 fold-change filter
     features        : restrict to these genes (default: all)
     latent_vars     : metadata columns to regress out as covariates in the
-                      'LR' and 'negbinom' models (Seurat's latent.vars).
+                      'LR', 'negbinom', and 'mast' models (Seurat's latent.vars).
+                      For 'mast', pass the cellular detection rate here to match
+                      Seurat's default CDR covariate.
     sample_col      : metadata column identifying pseudobulk replicates (donor /
                       sample); required for ``test_use='deseq2'``, ignored
                       otherwise.
@@ -220,7 +288,7 @@ def find_markers(
 
     # Per-cell covariates for the regression-based tests (LR / negbinom).
     latent = None
-    if latent_vars and test_use in ("LR", "negbinom"):
+    if latent_vars and test_use in ("LR", "negbinom", "mast"):
         lat1 = seurat.meta_data.loc[cells_1, latent_vars].to_numpy(dtype=float)
         lat2 = seurat.meta_data.loc[cells_2, latent_vars].to_numpy(dtype=float)
         latent = np.vstack([lat1, lat2])
@@ -302,6 +370,12 @@ def find_markers(
         for i, fi in enumerate(test_indices):
             expr = np.concatenate([mat1[fi, :], mat2[fi, :]])
             p_vals[i] = _lr_pvalue(expr, group, latent)
+    elif test_use == "mast":
+        n1, n2 = mat1.shape[1], mat2.shape[1]
+        group = np.concatenate([np.ones(n1), np.zeros(n2)])
+        for i, fi in enumerate(test_indices):
+            expr = np.concatenate([mat1[fi, :], mat2[fi, :]])
+            p_vals[i] = _mast_pvalue(expr, group, latent)
     elif test_use == "negbinom":
         counts_mat, _ = _get_expression_matrix(assay_obj, "counts")
         if sp.issparse(counts_mat):
@@ -318,7 +392,7 @@ def find_markers(
     else:
         raise ValueError(
             f"Unsupported test_use: {test_use!r}. "
-            "Use 'wilcox', 't', 'LR', 'negbinom', 'deseq2', or 'roc'."
+            "Use 'wilcox', 't', 'LR', 'negbinom', 'mast', 'deseq2', or 'roc'."
         )
 
     # Bonferroni correction (Seurat default: multiply by total gene count)

--- a/tests/test_mast_de.py
+++ b/tests/test_mast_de.py
@@ -1,0 +1,82 @@
+"""Tests for the MAST two-part hurdle branch of find_markers (test_use='mast')."""
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from shanuz import create_shanuz_object, find_markers
+from shanuz.preprocessing import normalize_data
+
+
+@pytest.fixture
+def hurdle_obj():
+    """80 cells (A=40, B=40), 20 genes with planted signals of different kinds.
+
+    g0  magnitude up in A          g2  detection up in A (present A / mostly-absent B)
+    g1  magnitude up in B          g3  up in A among always-detected genes (continuous only)
+    g8  null
+    """
+    rng = np.random.default_rng(0)
+    n, G = 40, 20
+    A = rng.poisson(1.0, size=(G, n)).astype(float)
+    B = rng.poisson(1.0, size=(G, n)).astype(float)
+    A[0] += 8                                    # g0 magnitude ↑ in A
+    B[1] += 8                                    # g1 magnitude ↑ in B
+    A[2], B[2] = rng.poisson(3.0, n), rng.poisson(0.1, n)      # g2 detection ↑ in A (non-perfect)
+    A[3], B[3] = rng.poisson(5.0, n) + 5, rng.poisson(5.0, n)  # g3 always-detected, ↑ in A
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(np.hstack([A, B])),
+        feature_names=[f"g{i}" for i in range(G)],
+        cell_names=[f"c{i}" for i in range(2 * n)],
+    )
+    normalize_data(obj)
+    obj.idents = ["A"] * n + ["B"] * n
+    return obj
+
+
+def test_mast_columns_and_marker_direction(hurdle_obj):
+    res = find_markers(hurdle_obj, ident_1="A", test_use="mast",
+                       min_pct=0.0, logfc_threshold=0.0)
+
+    assert list(res.columns) == ["p_val", "avg_log2FC", "pct.1", "pct.2", "p_val_adj"]
+    # g0 up in A, g1 up in B (down in A) — both significant with the right sign.
+    assert res.loc["g0", "p_val_adj"] < 0.05 and res.loc["g0", "avg_log2FC"] > 0
+    assert res.loc["g1", "p_val_adj"] < 0.05 and res.loc["g1", "avg_log2FC"] < 0
+    # A null gene survives Bonferroni as non-significant.
+    assert res.loc["g8", "p_val_adj"] > 0.05
+    # A planted marker ranks first; output sorted by p_val.
+    assert res.index[0] in {"g0", "g1", "g2", "g3"}
+    assert res["p_val"].is_monotonic_increasing
+
+
+def test_mast_detects_detection_only_difference(hurdle_obj):
+    """The hurdle's discrete component flags a gene that differs mainly in
+    *detection rate* (present in A, mostly absent in B)."""
+    res = find_markers(hurdle_obj, ident_1="A", test_use="mast",
+                       min_pct=0.0, logfc_threshold=0.0)
+    assert res.loc["g2", "pct.1"] > 0.8 and res.loc["g2", "pct.2"] < 0.3
+    assert res.loc["g2", "p_val_adj"] < 0.05
+
+
+def test_mast_detects_continuous_only_difference(hurdle_obj):
+    """A gene detected in ~all cells but higher in A is caught by the continuous
+    (Gaussian) component when detection carries no signal."""
+    res = find_markers(hurdle_obj, ident_1="A", test_use="mast",
+                       min_pct=0.0, logfc_threshold=0.0)
+    assert res.loc["g3", "pct.1"] > 0.95 and res.loc["g3", "pct.2"] > 0.95
+    assert res.loc["g3", "p_val_adj"] < 0.05 and res.loc["g3", "avg_log2FC"] > 0
+
+
+def test_mast_accepts_latent_vars(hurdle_obj):
+    """Cellular detection rate as a latent covariate (Seurat's CDR default)."""
+    counts = hurdle_obj.assays["RNA"].layers["counts"]
+    detected = (counts > 0)
+    cdr = np.asarray(detected.mean(axis=0)).ravel()
+    hurdle_obj.meta_data["cdr"] = cdr
+    res = find_markers(hurdle_obj, ident_1="A", test_use="mast", latent_vars=["cdr"],
+                       min_pct=0.0, logfc_threshold=0.0)
+    assert res.loc["g0", "p_val_adj"] < 0.05
+
+
+def test_mast_unknown_test_still_errors(hurdle_obj):
+    with pytest.raises(ValueError, match="mast"):
+        find_markers(hurdle_obj, ident_1="A", test_use="not_a_test")

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -255,6 +255,7 @@ same caveat as the other tutorials.
 | Conserved markers | `FindConservedMarkers(pbmc, ident.1, grouping.var)` | `find_conserved_markers(pbmc, ident_1, grouping_var)` |
 | Pseudobulk | `AggregateExpression(pbmc, group.by)` | `aggregate_expression(pbmc, group_by)` |
 | Pseudobulk DESeq2 | `FindMarkers(pbmc, test.use="DESeq2")` | `find_markers(pbmc, ident_1, test_use="deseq2", sample_col=...)` |
+| MAST hurdle DE | `FindMarkers(pbmc, test.use="MAST")` | `find_markers(pbmc, ident_1, test_use="mast")` |
 | Rename idents | `RenameIdents(pbmc, new.ids)` | `pbmc.rename_idents(mapping_dict)` |
 | Subset cells | `subset(pbmc, subset = condition)` | `pbmc.subset(cells=keep_list)` |
 | Add assay | `pbmc[["ADT"]] <- CreateAssayObject(counts)` | `obj.assays["ADT"] = create_assay5_object(counts, key="adt_")` |


### PR DESCRIPTION
Third PR of the v0.6.0 (Pseudobulk & Advanced Marker Methods) cycle. Adds the **MAST** hurdle test — a pure-Python reimplementation, **no new dependency** (uses `statsmodels`, already in the `[analysis]` extra).

## What's added

### `test_use="mast"` branch of `find_markers` — `shanuz/markers.py`
`_mast_pvalue` fits MAST's two-part hurdle model on the log-normalized data:
- **Discrete** component — logistic model of detection (`expr > 0`) `~ group (+ latent)`.
- **Continuous** component — Gaussian model of magnitude among detected cells `~ group (+ latent)`.

Because the hurdle likelihood factorizes, the combined LR statistic is the **sum** of the two components' statistics tested on the **sum** of their degrees of freedom. Components that carry no information (constant detection, or magnitude present in only one group) contribute 0 df and drop out. Returns the standard `p_val / avg_log2FC / pct.1 / pct.2 / p_val_adj` table.

`latent_vars` now flows into MAST as well — pass the cellular detection rate here to match Seurat's default CDR covariate.

## Compatibility
Purely additive — a new `test_use` value only; existing `find_markers` / `find_all_markers` behavior and signatures are unchanged. Tutorials unaffected.

## Tests
- 5 new tests in `tests/test_mast_de.py`: column shape + marker direction; the **detection-only** gene (present in A, mostly absent in B) caught by the discrete half; the **continuous-only** gene (detected everywhere, higher in A) caught by the Gaussian half; `latent_vars` (CDR) passthrough; and the error path. Exercising both halves is what distinguishes MAST from a plain t-test.
- Full suite **169 → 174 passing**; test file ruff-clean, no new markers.py lint.

## Docs
- `README.md`: DE feature bullet + roadmap row (v0.6.0 MAST `✅`).
- `ROADMAP.md`: MAST section marked delivered; priority list updated.
- `tutorials/README.md`: API-table row.

## Remaining in v0.6.0
Only the `bimod` test (McDavid 2013 bimodal LRT) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)