### PR TITLE
feat: bimod (McDavid 2013) differential test in find_markers — closes v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Clustering** — `find_clusters` (Louvain via python-igraph, Leiden via leidenalg)
 - **UMAP** — `run_umap` (via umap-learn; embeds a reduction or a precomputed graph)
 - **PC significance** — `jack_straw`, `score_jackstraw` (JackStraw permutation test)
-- **Differential expression** — `find_markers`, `find_all_markers` (`wilcox` tie-corrected, `t`, `LR`, `negbinom`, `mast` hurdle, `deseq2` pseudobulk, `roc`), `find_conserved_markers` (cross-condition, Fisher-combined)
+- **Differential expression** — `find_markers`, `find_all_markers` (`wilcox` tie-corrected, `t`, `bimod`, `LR`, `negbinom`, `mast` hurdle, `deseq2` pseudobulk, `roc`), `find_conserved_markers` (cross-condition, Fisher-combined)
 - **Pseudobulk** — `aggregate_expression` (sum counts per group → matrix or one-cell-per-group object), pseudobulk DESeq2 via `find_markers(test_use="deseq2", sample_col=...)`
 - **Plotting** — `dim_plot`, `feature_plot`, `vln_plot`, `dot_plot`, `elbow_plot`, `do_heatmap`, `dim_heatmap`, `feature_scatter`, `variable_feature_plot`, `ridge_plot` (matplotlib/seaborn)
 - **AnnData interoperability** — `as_anndata`, `from_anndata`
@@ -291,7 +291,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData`, `MapQuery` |
 | v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(delivered — see Tutorial 3)* |
 | v0.5.0 | Additional reductions — t-SNE, ICA ✅ *(delivered)*; remaining: SPCA, GLM-PCA |
-| v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`) ✅ *(delivered)*; remaining: bimod |
+| v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`), bimod (`test_use="bimod"`) ✅ *(complete)* |
 | v0.7.0 | Spatial — Xenium/Visium/CosMx loaders, niche/neighbourhood analysis, `image_*` plots ✅ *(largely delivered — see Tutorial 5)*; remaining: MERSCOPE loader, `FindSpatiallyVariableFeatures` (Moran's I), Visium tissue-image plots |
 | v0.8.0 | Scale — BPCells-style lazy matrices, `SketchData`, `ProjectData` |
 | v0.9.0 | Specialized — `HTODemux`, Mixscape (CRISPR screens) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,7 +146,7 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 
 ---
 
-## v0.6.0 — Pseudobulk DE & Advanced Marker Methods
+## v0.6.0 — Pseudobulk DE & Advanced Marker Methods — ✅ complete
 
 ### `AggregateExpression` (pseudobulk) — ✅ delivered
 - Implemented as `aggregate_expression(...)` in `shanuz/aggregate.py`. Sums raw
@@ -190,10 +190,14 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
   (`tests/test_pseudobulk_conserved.py`).
 - **R:** `FindConservedMarkers(obj, ident.1, grouping.var)`
 
-### `bimod` test (likelihood-ratio on bimodal model)
+### `bimod` test (likelihood-ratio on bimodal model) — ✅ delivered
+- Implemented as the `test_use="bimod"` branch of `find_markers` (`_bimod_pvalue`
+  / `_bimod_likelihood` in `shanuz/markers.py`), a faithful port of Seurat's
+  `DifferentialLRT`/`bimodLikData`: each group's expression is modelled as a
+  point mass at zero (Bernoulli detection rate) plus a Gaussian on the detected
+  values, and `2·(logLik₁ + logLik₂ − logLik_pooled)` is tested as χ²(df=3). Pure
+  Python, no new dep (`tests/test_bimod_de.py`).
 - **R:** `FindMarkers(obj, test.use = "bimod")`
-- **Plan:** McDavid 2013 bimodal likelihood-ratio test; fits a mixture of a
-  point mass at zero and a Gaussian; add `"bimod"` branch in `find_markers`
 
 ---
 
@@ -368,5 +372,5 @@ If milestones are too large, these are the highest-value individual items:
 5. **`FindSpatiallyVariableFeatures` (Moran's I) + `SpatialFeaturePlot`** (`v0.7.0`) — the remaining spatial gaps (loaders + niche/neighbourhood analysis already delivered)
 6. ~~**`AggregateExpression` + DESeq2**~~ ✅ (`v0.6.0`) — `aggregate_expression`,
    `find_conserved_markers`, and pseudobulk DESeq2 (`test_use="deseq2"`) delivered;
-   MAST (`test_use="mast"`) delivered too; only the bimod test remains in v0.6.0
+   MAST (`test_use="mast"`) and bimod (`test_use="bimod"`) too — **v0.6.0 complete**
 7. **`SketchData`** (`v0.8.0`) — enables million-cell datasets

--- a/shanuz/markers.py
+++ b/shanuz/markers.py
@@ -161,6 +161,47 @@ def _mast_pvalue(expr: np.ndarray, group: np.ndarray, latent: Optional[np.ndarra
     return float(chi2.sf(stat, df=df))
 
 
+def _bimod_likelihood(x: np.ndarray, xmin: float = 0.0) -> float:
+    """Log-likelihood of ``x`` under the McDavid 2013 bimodal model.
+
+    A point mass at/below ``xmin`` (the un-detected fraction, ``1 - α``) plus a
+    Gaussian on the detected values. Mirrors Seurat's ``bimodLikData``.
+    """
+    from scipy.stats import norm
+
+    n = len(x)
+    if n == 0:
+        return 0.0
+    x_pos = x[x > xmin]
+    n_pos = len(x_pos)
+    n_zero = n - n_pos
+    alpha = min(max(n_pos / n, 1e-5), 1 - 1e-5)  # detection rate, clamped
+    lik_a = n_zero * np.log(1 - alpha)
+    if n_pos == 0:
+        return float(lik_a)
+    sd = np.std(x_pos, ddof=1) if n_pos >= 2 else 1.0
+    if sd == 0:
+        sd = 1.0  # degenerate all-equal detected values (Seurat guards n<2 only)
+    lik_b = n_pos * np.log(alpha) + float(np.sum(norm.logpdf(x_pos, loc=x_pos.mean(), scale=sd)))
+    return float(lik_a + lik_b)
+
+
+def _bimod_pvalue(x1: np.ndarray, x2: np.ndarray, xmin: float = 0.0) -> float:
+    """McDavid 2013 bimodal likelihood-ratio test (Seurat's 'bimod').
+
+    ``2·(logLik(x1) + logLik(x2) − logLik(x1∪x2))`` under the bimodal model is
+    χ² with 3 df (the (α, μ, σ) triple that the pooled model constrains).
+    """
+    from scipy.stats import chi2
+
+    lrt = 2.0 * (
+        _bimod_likelihood(x1, xmin)
+        + _bimod_likelihood(x2, xmin)
+        - _bimod_likelihood(np.concatenate([x1, x2]), xmin)
+    )
+    return float(chi2.sf(max(lrt, 0.0), df=3))
+
+
 def find_markers(
     seurat,
     ident_1: Union[str, list[str]],
@@ -185,13 +226,14 @@ def find_markers(
     ----------
     ident_1         : cluster label(s) for group 1
     ident_2         : cluster label(s) for group 2 (None = all others)
-    test_use        : statistical test — 'wilcox' (default), 't', 'LR'
-                      (logistic-regression LRT), 'negbinom' (negative-binomial
-                      GLM LRT on counts), 'mast' (MAST two-part hurdle LRT on
-                      log-normalized data), 'deseq2' (pseudobulk DESeq2 — sums
-                      counts per sample then tests sample-level, requires
-                      ``sample_col``; needs ``pip install shanuz[deseq2]``), or
-                      'roc' (AUC classifier power).
+    test_use        : statistical test — 'wilcox' (default), 't', 'bimod'
+                      (McDavid 2013 bimodal LRT), 'LR' (logistic-regression LRT),
+                      'negbinom' (negative-binomial GLM LRT on counts), 'mast'
+                      (MAST two-part hurdle LRT on log-normalized data), 'deseq2'
+                      (pseudobulk DESeq2 — sums counts per sample then tests
+                      sample-level, requires ``sample_col``; needs
+                      ``pip install shanuz[deseq2]``), or 'roc' (AUC classifier
+                      power).
     only_pos        : only return positive markers
     min_pct         : minimum fraction cells expressing gene in either group
     logfc_threshold : minimum log2 fold-change filter
@@ -364,6 +406,9 @@ def find_markers(
             x2 = mat2[fi, :]
             _, p = ttest_ind(x1, x2, equal_var=False)
             p_vals[i] = p if not np.isnan(p) else 1.0
+    elif test_use == "bimod":
+        for i, fi in enumerate(test_indices):
+            p_vals[i] = _bimod_pvalue(mat1[fi, :], mat2[fi, :])
     elif test_use == "LR":
         n1, n2 = mat1.shape[1], mat2.shape[1]
         group = np.concatenate([np.ones(n1), np.zeros(n2)])
@@ -392,7 +437,7 @@ def find_markers(
     else:
         raise ValueError(
             f"Unsupported test_use: {test_use!r}. "
-            "Use 'wilcox', 't', 'LR', 'negbinom', 'mast', 'deseq2', or 'roc'."
+            "Use 'wilcox', 't', 'bimod', 'LR', 'negbinom', 'mast', 'deseq2', or 'roc'."
         )
 
     # Bonferroni correction (Seurat default: multiply by total gene count)

--- a/tests/test_bimod_de.py
+++ b/tests/test_bimod_de.py
@@ -1,0 +1,78 @@
+"""Tests for the bimod branch of find_markers (McDavid 2013 bimodal LRT)."""
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from scipy.stats import norm
+
+from shanuz import create_shanuz_object, find_markers
+from shanuz.markers import _bimod_likelihood, _bimod_pvalue
+from shanuz.preprocessing import normalize_data
+
+
+def test_bimod_likelihood_matches_mcdavid_formula():
+    """_bimod_likelihood equals the explicit point-mass + Gaussian log-likelihood."""
+    x = np.array([0.0, 0.0, 1.0, 2.0, 3.0])
+    x_pos = x[x > 0]
+    alpha = len(x_pos) / len(x)  # 0.6
+    expected = (
+        (len(x) - len(x_pos)) * np.log(1 - alpha)
+        + len(x_pos) * np.log(alpha)
+        + norm.logpdf(x_pos, x_pos.mean(), np.std(x_pos, ddof=1)).sum()
+    )
+    assert np.isclose(_bimod_likelihood(x), expected)
+
+
+def test_bimod_likelihood_edge_cases():
+    # All zero -> only the detection term, with clamped alpha.
+    assert np.isfinite(_bimod_likelihood(np.zeros(10)))
+    # Single detected value (n_pos < 2) uses sd=1 rather than blowing up.
+    assert np.isfinite(_bimod_likelihood(np.array([0.0, 0.0, 5.0])))
+    # Identical detected values (sd == 0) is guarded, not NaN/inf.
+    assert np.isfinite(_bimod_likelihood(np.array([0.0, 2.0, 2.0, 2.0])))
+
+
+def test_bimod_pvalue_separates_distributions():
+    rng = np.random.default_rng(1)
+    same = _bimod_pvalue(rng.normal(2, 1, 60), rng.normal(2, 1, 60))
+    diff = _bimod_pvalue(
+        np.r_[np.zeros(30), rng.normal(3, 0.5, 20)], rng.normal(0.1, 0.3, 50)
+    )
+    assert 0.0 <= same <= 1.0 and 0.0 <= diff <= 1.0
+    assert same > 0.1        # same distribution -> not significant
+    assert diff < 1e-6       # strongly different -> highly significant
+
+
+@pytest.fixture
+def bimod_obj():
+    """80 cells (A=40, B=40), 20 genes. g0 ↑A, g1 ↑B, g2 detection ↑A, g8 null."""
+    rng = np.random.default_rng(1)
+    n, G = 40, 20
+    A = rng.poisson(1.0, size=(G, n)).astype(float)
+    B = rng.poisson(1.0, size=(G, n)).astype(float)
+    A[0] += 8
+    B[1] += 8
+    A[2], B[2] = rng.poisson(3.0, n), rng.poisson(0.1, n)  # detection ↑ in A
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(np.hstack([A, B])),
+        feature_names=[f"g{i}" for i in range(G)],
+        cell_names=[f"c{i}" for i in range(2 * n)],
+    )
+    normalize_data(obj)
+    obj.idents = ["A"] * n + ["B"] * n
+    return obj
+
+
+def test_bimod_columns_and_marker_direction(bimod_obj):
+    res = find_markers(bimod_obj, ident_1="A", test_use="bimod",
+                       min_pct=0.0, logfc_threshold=0.0)
+
+    assert list(res.columns) == ["p_val", "avg_log2FC", "pct.1", "pct.2", "p_val_adj"]
+    assert res.loc["g0", "p_val_adj"] < 0.05 and res.loc["g0", "avg_log2FC"] > 0
+    assert res.loc["g1", "p_val_adj"] < 0.05 and res.loc["g1", "avg_log2FC"] < 0
+    # bimod's Bernoulli component catches a detection-only difference.
+    assert res.loc["g2", "pct.1"] > 0.8 and res.loc["g2", "pct.2"] < 0.4
+    assert res.loc["g2", "p_val_adj"] < 0.05
+    # Null gene stays non-significant after Bonferroni; output sorted by p_val.
+    assert res.loc["g8", "p_val_adj"] > 0.05
+    assert res.index[0] in {"g0", "g1", "g2"}
+    assert res["p_val"].is_monotonic_increasing

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -256,6 +256,7 @@ same caveat as the other tutorials.
 | Pseudobulk | `AggregateExpression(pbmc, group.by)` | `aggregate_expression(pbmc, group_by)` |
 | Pseudobulk DESeq2 | `FindMarkers(pbmc, test.use="DESeq2")` | `find_markers(pbmc, ident_1, test_use="deseq2", sample_col=...)` |
 | MAST hurdle DE | `FindMarkers(pbmc, test.use="MAST")` | `find_markers(pbmc, ident_1, test_use="mast")` |
+| Bimodal LRT DE | `FindMarkers(pbmc, test.use="bimod")` | `find_markers(pbmc, ident_1, test_use="bimod")` |
 | Rename idents | `RenameIdents(pbmc, new.ids)` | `pbmc.rename_idents(mapping_dict)` |
 | Subset cells | `subset(pbmc, subset = condition)` | `pbmc.subset(cells=keep_list)` |
 | Add assay | `pbmc[["ADT"]] <- CreateAssayObject(counts)` | `obj.assays["ADT"] = create_assay5_object(counts, key="adt_")` |


### PR DESCRIPTION
Final PR of the v0.6.0 (Pseudobulk & Advanced Marker Methods) cycle. Adds the **bimod** test — a faithful pure-Python port of Seurat's `DifferentialLRT` / `bimodLikData`, **no new dependency**.

## What's added

### `test_use="bimod"` branch of `find_markers` — `shanuz/markers.py`
- **`_bimod_likelihood`** models a gene's expression under the McDavid 2013 bimodal model: a point mass at zero (Bernoulli detection rate α, clamped to [1e-5, 1−1e-5]) plus a Gaussian on the detected values. Mirrors Seurat's formula, including the `sd`-fallback when fewer than 2 cells are detected (plus a guard for the degenerate all-equal case).
- **`_bimod_pvalue`** tests `2·(logLik(x1) + logLik(x2) − logLik(x1∪x2))` as **χ²(df=3)** — the (α, μ, σ) triple the pooled model constrains.
- Wired into the dispatch alongside `wilcox`/`t`; returns the standard `p_val / avg_log2FC / pct.1 / pct.2 / p_val_adj` table.

## Compatibility
Purely additive — a new `test_use` value only; existing behavior/signatures unchanged. Tutorials unaffected.

## Tests
- 4 new tests in `tests/test_bimod_de.py`: the likelihood **matches the explicit McDavid formula** (validates the port, not just self-consistency), edge cases (all-zero / single-detected / sd=0) stay finite, p-value separation (same-dist → ns, different → p<1e-6), and end-to-end column shape + marker direction incl. a **detection-only** gene caught by the Bernoulli component.
- Full suite **174 → 178 passing**; test file ruff-clean, no new markers.py lint.

## Docs
- `README.md`: DE feature bullet + roadmap row (v0.6.0 now ✅ *complete*).
- `ROADMAP.md`: bimod section delivered; **v0.6.0 milestone marked complete**; priority list updated.
- `tutorials/README.md`: API-table row.

## Milestone
This closes **v0.6.0** — `AggregateExpression`, `FindConservedMarkers`, DESeq2, MAST, and bimod are all delivered. `find_markers` now offers `wilcox`, `t`, `bimod`, `LR`, `negbinom`, `mast`, `deseq2`, and `roc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)