### PR TITLE
feat: find_spatially_variable_features — Moran's I (v0.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Pseudobulk** — `aggregate_expression` (sum counts per group → matrix or one-cell-per-group object), pseudobulk DESeq2 via `find_markers(test_use="deseq2", sample_col=...)`
 - **Plotting** — `dim_plot`, `feature_plot`, `vln_plot`, `dot_plot`, `elbow_plot`, `do_heatmap`, `dim_heatmap`, `feature_scatter`, `variable_feature_plot`, `ridge_plot` (matplotlib/seaborn)
 - **AnnData interoperability** — `as_anndata`, `from_anndata`
-- **Spatial (Xenium / Visium / CosMx / MERSCOPE)** — `load_xenium`/`load_visium`/`load_cosmx`/`load_merscope`, `get_tissue_coordinates`, `nearest_neighbor_distance`, `local_neighborhood`, `build_niche_assay`, `composition_test`, `image_dim_plot`, `image_feature_plot`
+- **Spatial (Xenium / Visium / CosMx / MERSCOPE)** — `load_xenium`/`load_visium`/`load_cosmx`/`load_merscope`, `get_tissue_coordinates`, `nearest_neighbor_distance`, `local_neighborhood`, `build_niche_assay`, `find_spatially_variable_features` (Moran's I), `composition_test`, `image_dim_plot`, `image_feature_plot`
 - **PBMC 3k tutorial** — end-to-end validated against the official Seurat tutorial
 - **PBMC 8k advanced tutorial** — larger dataset + T/NK subclustering workflow
 - **CITE-seq multimodal tutorial** — RNA + surface protein (ADT) with CLR normalization and WNN joint clustering
@@ -292,7 +292,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(delivered — see Tutorial 3)* |
 | v0.5.0 | Additional reductions — t-SNE, ICA ✅ *(delivered)*; remaining: SPCA, GLM-PCA |
 | v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`), bimod (`test_use="bimod"`) ✅ *(complete)* |
-| v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `image_*` plots ✅ *(largely delivered — see Tutorial 5)*; remaining: `FindSpatiallyVariableFeatures` (Moran's I), Visium tissue-image plots |
+| v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I), `image_*` plots ✅ *(largely delivered — see Tutorial 5)*; remaining: Visium tissue-image plots |
 | v0.8.0 | Scale — BPCells-style lazy matrices, `SketchData`, `ProjectData` |
 | v0.9.0 | Specialized — `HTODemux`, Mixscape (CRISPR screens) |
 | v0.10.0 | Infrastructure — PyPI, GitHub Actions CI, type annotations, MkDocs site |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -232,15 +232,24 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 - **R:** `LoadVizgen(data.dir)` (Vizgen MERSCOPE)
 - **File format:** `cell_by_gene.csv`, `cell_metadata.csv`
 
-### `FindSpatiallyVariableFeatures`
+### `FindSpatiallyVariableFeatures` — ✅ delivered (Moran's I)
+- Implemented as `find_spatially_variable_features(...)` in
+  `shanuz/spatial/variable_features.py`. Builds a row-standardised sparse KNN
+  weight matrix from `spatial_knn`, then computes
+  `I = (N/S0)·(zᵀWz)/(zᵀz)` vectorised across all genes in one sparse matmul.
+  Significance uses the closed-form `E[I] = −1/(N−1)` and normality-assumption
+  variance (computed once, since it depends only on W) → z-score → two-sided p,
+  plus BH adjustment. Writes `moransi` / `moransi_pval` / `moransi_padj` /
+  `moransi_rank` into the assay's feature metadata (as `find_variable_features`
+  does) and returns the ranked table. Pure NumPy/SciPy — no `libpysal` needed.
+  Validated against a brute-force double sum (`tests/test_spatially_variable_features.py`).
+- **Caveat documented in the docstring:** when a few strongly spatial genes
+  dominate library size, log-normalisation leaks their structure into flat genes
+  and inflates their I — a property of compositional normalisation, not of the
+  statistic.
+- **Still open:** the **markvariogram** method (Trendsceek) — `method=` currently
+  accepts only `"moransi"`.
 - **R:** `FindSpatiallyVariableFeatures(obj, method = "moransi")`
-- **Plan:**
-  1. **Moran's I** (primary): spatial autocorrelation statistic using the cell
-     adjacency/distance weight matrix (weights from `spatial_knn`); compute with
-     `esda.Moran` (`pysal` dep) or directly: `I = (N/W) * (z @ W @ z) / (z @ z)`
-  2. **Markvariogram** (alternative): from the `Trendsceek` method
-  3. Store results in `assay.var` (feature metadata), analogous to `FindVariableFeatures`
-- **Python dep:** `libpysal` or pure NumPy implementation
 
 ### Tissue-image spatial plots (Visium H&E)
 | Function | R equivalent | Notes |
@@ -375,7 +384,7 @@ If milestones are too large, these are the highest-value individual items:
 2. ~~**WNN** (`v0.4.0`)~~ — ✅ delivered (`find_multi_modal_neighbors` + `run_umap(graph=)`); CBMC tutorial section still open
 3. ~~**GitHub Actions CI** (`v0.10.0`)~~ — ✅ delivered
 4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — enables atlas-based annotation (next-cycle candidate; needs CCA/RPCA first)
-5. **`FindSpatiallyVariableFeatures` (Moran's I) + `SpatialFeaturePlot`** (`v0.7.0`) — the remaining spatial gaps (all four loaders — incl. `load_merscope` — plus niche/neighbourhood analysis already delivered)
+5. ~~**`FindSpatiallyVariableFeatures` (Moran's I)**~~ ✅ + **`SpatialFeaturePlot`** (`v0.7.0`) — all four loaders, niche/neighbourhood analysis and Moran's I delivered; only the Visium tissue-image plots remain
 6. ~~**`AggregateExpression` + DESeq2**~~ ✅ (`v0.6.0`) — `aggregate_expression`,
    `find_conserved_markers`, and pseudobulk DESeq2 (`test_use="deseq2"`) delivered;
    MAST (`test_use="mast"`) and bimod (`test_use="bimod"`) too — **v0.6.0 complete**

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -38,6 +38,7 @@ from .spatial import (
     create_molecules,
     create_segmentation,
     build_niche_assay,
+    find_spatially_variable_features,
     get_tissue_coordinates,
     local_neighborhood,
     nearest_neighbor_distance,
@@ -102,6 +103,7 @@ __all__ = [
     "nearest_neighbor_distance",
     "local_neighborhood",
     "build_niche_assay",
+    "find_spatially_variable_features",
     "composition_test",
     # Spatial loaders
     "load_xenium",

--- a/shanuz/spatial/__init__.py
+++ b/shanuz/spatial/__init__.py
@@ -11,6 +11,7 @@ from .analysis import (
     spatial_knn,
 )
 from .loaders import load_cosmx, load_merscope, load_visium, load_xenium
+from .variable_features import find_spatially_variable_features
 
 __all__ = [
     "SpatialImage",
@@ -29,6 +30,7 @@ __all__ = [
     "nearest_neighbor_distance",
     "local_neighborhood",
     "build_niche_assay",
+    "find_spatially_variable_features",
     # loaders
     "load_xenium",
     "load_visium",

--- a/shanuz/spatial/variable_features.py
+++ b/shanuz/spatial/variable_features.py
@@ -1,0 +1,197 @@
+"""Spatially variable feature detection.
+
+Mirrors Seurat's ``FindSpatiallyVariableFeatures(obj, method = "moransi")``:
+score each gene by its spatial autocorrelation (Moran's I) over a k-nearest-
+neighbour graph built from the cells' tissue coordinates.
+
+Pure NumPy/SciPy — the weight matrix comes from :func:`shanuz.spatial.spatial_knn`,
+so any object with populated ``images`` works (Xenium / Visium / CosMx / MERSCOPE,
+or ``from_anndata`` on a spatial ``obsm``).
+"""
+from __future__ import annotations
+
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+
+from ..composition import _bh
+from .analysis import get_tissue_coordinates, spatial_knn
+
+
+def _knn_weights(coords: np.ndarray, k: int, row_normalize: bool = True) -> sp.csr_matrix:
+    """Sparse spatial weight matrix W from a k-nearest-neighbour graph.
+
+    ``w_ij = 1`` when j is among i's k nearest neighbours (self excluded). With
+    ``row_normalize`` each row sums to 1 — the usual row-standardised weights, so
+    Moran's I is a plain neighbour-average correlation.
+    """
+    n = len(coords)
+    if n < 3:
+        raise ValueError("Need at least 3 cells to compute spatial autocorrelation.")
+    k = min(k, n - 1)
+    _, idx = spatial_knn(coords, k=k)
+    rows = np.repeat(np.arange(n), idx.shape[1])
+    cols = np.asarray(idx).ravel()
+    W = sp.csr_matrix((np.ones(rows.size), (rows, cols)), shape=(n, n))
+    W.setdiag(0.0)
+    W.eliminate_zeros()
+    if row_normalize:
+        rs = np.asarray(W.sum(axis=1)).ravel()
+        rs[rs == 0] = 1.0
+        W = sp.diags(1.0 / rs) @ W
+    return sp.csr_matrix(W)
+
+
+def _morans_i(Z: np.ndarray, W: sp.csr_matrix) -> np.ndarray:
+    """Moran's I for every row of ``Z`` (genes × cells, already mean-centred).
+
+    ``I = (N / S0) · (zᵀ W z) / (zᵀ z)``, vectorised across genes.
+    """
+    n = W.shape[0]
+    s0 = float(W.sum())
+    # (W @ Z.T).T[g, i] = Σ_j W[i, j] · Z[g, j]  →  row-wise zᵀWz below.
+    WZ = np.asarray((W @ Z.T).T)
+    num = np.einsum("gi,gi->g", Z, WZ)
+    den = np.einsum("gi,gi->g", Z, Z)
+    out = np.full(Z.shape[0], np.nan)
+    ok = den > 0
+    out[ok] = (n / s0) * num[ok] / den[ok]
+    return out
+
+
+def _morans_moments(W: sp.csr_matrix) -> tuple[float, float]:
+    """(expected I, variance of I) under the normality assumption.
+
+    Depends only on the weight matrix, so it is computed once for all genes.
+    """
+    n = W.shape[0]
+    s0 = float(W.sum())
+    A = W + W.T
+    s1 = 0.5 * float(A.multiply(A).sum())
+    row = np.asarray(W.sum(axis=1)).ravel()
+    col = np.asarray(W.sum(axis=0)).ravel()
+    s2 = float(np.sum((row + col) ** 2))
+    e_i = -1.0 / (n - 1)
+    var = (n**2 * s1 - n * s2 + 3 * s0**2) / (s0**2 * (n**2 - 1)) - e_i**2
+    return e_i, max(var, 0.0)
+
+
+def find_spatially_variable_features(
+    seurat,
+    features: Optional[list[str]] = None,
+    method: str = "moransi",
+    k: int = 10,
+    assay: Optional[str] = None,
+    layer: Optional[str] = None,
+    image: Optional[Union[str, Sequence[str]]] = None,
+) -> pd.DataFrame:
+    """Rank features by spatial autocorrelation (Moran's I).
+
+    Mirrors R's ``FindSpatiallyVariableFeatures(obj, method = "moransi")``.
+
+    Parameters
+    ----------
+    features : restrict to these genes (default: all in the assay). Passing the
+               variable features keeps this fast on large panels.
+    method   : only ``"moransi"`` is implemented (``"markvariogram"`` is planned).
+    k        : neighbours per cell in the spatial weight graph.
+    layer    : expression layer (default: the normalized ``data``).
+    image    : image name(s) to draw coordinates from (default: all).
+
+    Returns
+    -------
+    DataFrame indexed by gene with ``moransi`` (I, +ve = spatially clustered),
+    ``moransi_pval`` (two-sided, normality assumption), ``moransi_padj``
+    (Benjamini-Hochberg) and ``moransi_rank`` (1 = most spatially variable),
+    sorted by rank. The same columns are also written into the assay's
+    feature-level metadata, as ``find_variable_features`` does.
+
+    Notes
+    -----
+    Run this on log-normalized ``data`` (the default). Be aware that when a few
+    strongly spatial genes dominate a cell's library size, log-normalization
+    divides every gene by a spatially-structured total and leaks that structure
+    into otherwise-flat genes — inflating their I. That is a property of
+    compositional normalization, not of the statistic; it is negligible on real
+    panels but can bite on small synthetic ones.
+    """
+    from scipy.stats import norm
+
+    from ..markers import _get_expression_matrix
+
+    if method != "moransi":
+        raise NotImplementedError(
+            f"method={method!r} is not implemented; use 'moransi'."
+        )
+
+    coords = get_tissue_coordinates(seurat, image)
+    if coords.empty:
+        raise ValueError("Object has no spatial coordinates.")
+    # A cell can appear once per image; keep its first placement.
+    coords = coords.drop_duplicates(subset="cell")
+
+    assay_name = assay or seurat.active_assay
+    assay_obj = seurat.assays[assay_name]
+    data, feature_names = _get_expression_matrix(assay_obj, layer)
+
+    pos = {c: i for i, c in enumerate(seurat.cell_names())}
+    keep = [c for c in coords["cell"] if c in pos]
+    if len(keep) < 3:
+        raise ValueError("Fewer than 3 cells have both coordinates and expression.")
+    col_idx = [pos[c] for c in keep]
+    xy = coords.set_index("cell").loc[keep, ["x", "y"]].to_numpy(dtype=float)
+
+    if features is not None:
+        want = set(features)
+        rows = [i for i, f in enumerate(feature_names) if f in want]
+        if not rows:
+            raise ValueError("None of the requested features are in the assay.")
+    else:
+        rows = list(range(len(feature_names)))
+    genes = [feature_names[i] for i in rows]
+
+    sub = data[rows, :][:, col_idx]
+    X = np.asarray(sub.toarray() if sp.issparse(sub) else sub, dtype=float)
+    Z = X - X.mean(axis=1, keepdims=True)
+
+    W = _knn_weights(xy, k=k)
+    moran = _morans_i(Z, W)
+    e_i, var = _morans_moments(W)
+
+    if var > 0:
+        z = (moran - e_i) / np.sqrt(var)
+        pval = 2.0 * norm.sf(np.abs(z))
+    else:
+        pval = np.ones_like(moran)
+    pval = np.where(np.isnan(moran), 1.0, pval)
+
+    res = pd.DataFrame(
+        {
+            "moransi": moran,
+            "moransi_pval": pval,
+            "moransi_padj": _bh(pval),
+        },
+        index=genes,
+    )
+    # Rank 1 = most spatially variable (highest positive autocorrelation).
+    res["moransi_rank"] = res["moransi"].rank(ascending=False, method="min").astype(int)
+    res = res.sort_values("moransi_rank")
+
+    _write_feature_meta(assay_obj, res)
+    return res
+
+
+def _write_feature_meta(assay_obj, res: pd.DataFrame) -> None:
+    """Store the Moran's I columns in the assay's feature-level metadata."""
+    meta = getattr(assay_obj, "meta_features", None)
+    attr = "meta_features"
+    if meta is None:
+        meta = getattr(assay_obj, "meta_data", None)   # Assay5
+        attr = "meta_data"
+    if meta is None:
+        return
+    for col in ("moransi", "moransi_pval", "moransi_padj", "moransi_rank"):
+        meta.loc[res.index, col] = res[col]
+    setattr(assay_obj, attr, meta)

--- a/tests/test_spatially_variable_features.py
+++ b/tests/test_spatially_variable_features.py
@@ -1,0 +1,151 @@
+"""Tests for find_spatially_variable_features (Moran's I)."""
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+from shanuz import create_shanuz_object, find_spatially_variable_features
+from shanuz.preprocessing import normalize_data
+from shanuz.spatial.fov import create_fovs
+from shanuz.spatial.variable_features import (
+    _knn_weights,
+    _morans_i,
+    _morans_moments,
+)
+
+
+# ---------------------------------------------------------------------------
+# Statistic correctness
+# ---------------------------------------------------------------------------
+
+def test_morans_i_matches_brute_force():
+    """The vectorised (N/S0)·(zᵀWz)/(zᵀz) equals the explicit double sum."""
+    rng = np.random.default_rng(0)
+    n = 60
+    xy = rng.uniform(0, 10, (n, 2))
+    W = _knn_weights(xy, k=6)
+
+    Z = rng.normal(size=(4, n))
+    Z -= Z.mean(axis=1, keepdims=True)
+
+    mine = _morans_i(Z, W)
+    Wd = W.toarray()
+    s0 = Wd.sum()
+    brute = np.array([(n / s0) * (z @ Wd @ z) / (z @ z) for z in Z])
+    np.testing.assert_allclose(mine, brute)
+
+
+def test_morans_expected_value_is_minus_one_over_n_minus_1():
+    rng = np.random.default_rng(1)
+    xy = rng.uniform(0, 10, (50, 2))
+    W = _knn_weights(xy, k=5)
+    e_i, var = _morans_moments(W)
+    assert np.isclose(e_i, -1.0 / (50 - 1))
+    assert var > 0
+
+
+def test_knn_weights_are_row_normalised():
+    rng = np.random.default_rng(2)
+    xy = rng.uniform(0, 10, (30, 2))
+    W = _knn_weights(xy, k=5)
+    rowsums = np.asarray(W.sum(axis=1)).ravel()
+    np.testing.assert_allclose(rowsums, 1.0)
+    assert W.diagonal().sum() == 0        # no self-weight
+
+
+def test_knn_weights_reject_tiny_objects():
+    with pytest.raises(ValueError, match="at least 3 cells"):
+        _knn_weights(np.array([[0.0, 0.0], [1.0, 1.0]]), k=1)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end
+# ---------------------------------------------------------------------------
+
+N_RAND = 22
+RAND_GENES = [f"rand{i}" for i in range(N_RAND)]
+
+
+@pytest.fixture
+def spatial_obj():
+    """120 cells; grad_x/grad_y/blob are spatially structured, rand* are not.
+
+    The flat random genes deliberately dominate the library size. With only a
+    couple of background genes, log-normalisation divides every gene by a
+    spatially-structured total and leaks that structure into the random genes —
+    a real compositional artefact, not a Moran's I error, but not what this test
+    is measuring.
+    """
+    rng = np.random.default_rng(0)
+    n = 120
+    xy = rng.uniform(0, 10, (n, 2))
+    genes = ["grad_x", "grad_y", "blob"] + RAND_GENES
+    X = np.zeros((len(genes), n))
+    X[0] = xy[:, 0]
+    X[1] = xy[:, 1]
+    X[2] = np.exp(-((xy[:, 0] - 5) ** 2 + (xy[:, 1] - 5) ** 2) / 4) * 10
+    for i in range(N_RAND):
+        X[3 + i] = rng.poisson(5, n)
+
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(np.abs(X) * 3),
+        feature_names=genes,
+        cell_names=[f"c{i}" for i in range(n)],
+    )
+    coords = pd.DataFrame({"x": xy[:, 0], "y": xy[:, 1], "cell": obj.cell_names()})
+    obj.images = create_fovs(coords, assay="RNA", default_name="rna")
+    normalize_data(obj)
+    return obj
+
+
+def test_spatially_variable_ranks_structured_genes_first(spatial_obj):
+    res = find_spatially_variable_features(spatial_obj, k=8)
+
+    assert list(res.columns) == [
+        "moransi", "moransi_pval", "moransi_padj", "moransi_rank",
+    ]
+    # The three spatially structured genes take the top three ranks.
+    assert set(res.index[:3]) == {"grad_x", "grad_y", "blob"}
+    assert (res.loc[["grad_x", "grad_y", "blob"], "moransi"] > 0.5).all()
+    assert (res.loc[["grad_x", "grad_y", "blob"], "moransi_padj"] < 0.01).all()
+    # Spatially random genes: I near zero and not significant.
+    assert (res.loc[RAND_GENES, "moransi"].abs() < 0.2).all()
+    assert (res.loc[RAND_GENES, "moransi_padj"] > 0.05).all()
+    # Sorted by rank, 1 = most spatially variable.
+    assert res["moransi_rank"].is_monotonic_increasing
+    assert res["moransi_rank"].iloc[0] == 1
+
+
+def test_results_written_to_feature_metadata(spatial_obj):
+    res = find_spatially_variable_features(spatial_obj, k=8)
+    meta = spatial_obj.assays["RNA"].meta_data
+    for col in ("moransi", "moransi_pval", "moransi_padj", "moransi_rank"):
+        assert col in meta.columns
+    assert np.isclose(meta.loc["blob", "moransi"], res.loc["blob", "moransi"])
+
+
+def test_features_argument_restricts_output(spatial_obj):
+    res = find_spatially_variable_features(
+        spatial_obj, features=["blob", "rand0"], k=8)
+    assert set(res.index) == {"blob", "rand0"}
+    assert res.index[0] == "blob"          # the structured one ranks first
+
+
+def test_unknown_features_raise(spatial_obj):
+    with pytest.raises(ValueError, match="None of the requested features"):
+        find_spatially_variable_features(spatial_obj, features=["nope"], k=8)
+
+
+def test_unsupported_method_raises(spatial_obj):
+    with pytest.raises(NotImplementedError, match="markvariogram"):
+        find_spatially_variable_features(spatial_obj, method="markvariogram")
+
+
+def test_object_without_coordinates_raises():
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(np.ones((3, 5))),
+        feature_names=["a", "b", "c"],
+        cell_names=[f"c{i}" for i in range(5)],
+    )
+    with pytest.raises(ValueError, match="no spatial"):
+        find_spatially_variable_features(obj)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -327,6 +327,7 @@ de.head()   # p_val / avg_log2FC (DESeq2 log2FoldChange, +ve = up in stim) / pct
 | `FNN::get.knn` (nearest same-type) | `nearest_neighbor_distance(obj, group_by, reference)` |
 | *(hand-rolled neighbourhood counts)* | `local_neighborhood(obj, group_by, reference, k)` |
 | `BuildNicheAssay(obj, fov, group.by, niches.k)` | `build_niche_assay(obj, group_by, k, niches)` |
+| `FindSpatiallyVariableFeatures(obj, method="moransi")` | `find_spatially_variable_features(obj, k=10)` — Moran's I |
 | *(hand-rolled Fisher + `p.adjust`)* | `composition_test(obj, group_by, split_by)` |
 
 > **Plot output:** R renders to the graphics device automatically. Shanuz functions return a


### PR DESCRIPTION
Second of the remaining **v0.7.0 spatial gaps**. Mirrors Seurat's `FindSpatiallyVariableFeatures(method = "moransi")`. **Pure NumPy/SciPy — no `libpysal`/`esda` dependency** (the roadmap listed one as optional; it turned out unnecessary).

## What's added — `shanuz/spatial/variable_features.py`

- **`_knn_weights`** builds a row-standardised sparse KNN weight matrix from the existing `spatial_knn`, so any object with coordinates works — Xenium / Visium / CosMx / MERSCOPE, or `from_anndata` on a spatial `obsm`.
- **`_morans_i`** computes `I = (N/S0)·(zᵀWz)/(zᵀz)` **vectorised across all genes** in a single sparse matmul.
- **`_morans_moments`** gives the closed-form `E[I] = −1/(N−1)` and normality-assumption variance. It depends only on `W`, so it's computed **once** for all genes → z-score → two-sided p-value; BH adjustment reuses `composition._bh`.
- Writes `moransi` / `moransi_pval` / `moransi_padj` / `moransi_rank` into the assay's **feature metadata** (the `find_variable_features` convention) and returns the ranked table.
- `method="markvariogram"` raises `NotImplementedError` — still open.

## Tests (10)
The load-bearing one: the vectorised statistic is validated against a **brute-force double sum** of the formula. Also `E[I] == −1/(N−1)`, row-normalised weights with no self-weight, structured genes (gradient / blob) taking the top ranks with I≈0.7 and padj<0.01 while flat genes stay non-significant, feature-metadata writing, `features=` subsetting, and three error paths.

Full suite **184 → 194 passing**; all files ruff-clean.

## A caveat found while testing (documented in the docstring)
My first fixture had 3 spatial genes and only 2 flat ones — and a "random" gene came out significant. That is **not** a bug in the statistic: with few genes, the spatial genes dominate each cell's library size, so log-normalisation divides every gene by a spatially-structured total and **leaks that structure into flat genes**. Confirmed across seeds (2 background genes → up to 2/2 spurious hits; 22 background genes → 0/22). The fixture was rebuilt realistically and the caveat is now recorded in the function docstring, since it's a genuine trap on small or count-dominated panels.

## Compatibility
Purely additive — a new module and two exports. No existing behavior changed; tutorials unaffected.

## Docs
- `README.md`: spatial feature bullet + v0.7.0 roadmap row.
- `ROADMAP.md`: section marked delivered (markvariogram noted as still open); priority list updated.
- `tutorials/README.md`: spatial API-table row.

## Remaining in v0.7.0
Visium tissue-image support + `spatial_dim_plot` / `spatial_feature_plot` — the last item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)