### PR TITLE
feat: Visium H&E plots — spatial_dim_plot / spatial_feature_plot (v0.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Plotting** — `dim_plot`, `feature_plot`, `vln_plot`, `dot_plot`, `elbow_plot`, `do_heatmap`, `dim_heatmap`, `feature_scatter`, `variable_feature_plot`, `ridge_plot` (matplotlib/seaborn)
 - **AnnData interoperability** — `as_anndata`, `from_anndata`
 - **Spatial (Xenium / Visium / CosMx / MERSCOPE)** — `load_xenium`/`load_visium`/`load_cosmx`/`load_merscope`, `get_tissue_coordinates`, `nearest_neighbor_distance`, `local_neighborhood`, `build_niche_assay`, `find_spatially_variable_features` (Moran's I), `composition_test`, `image_dim_plot`, `image_feature_plot`
-- **Visium tissue images** — `load_visium` reads the H&E PNG + `scalefactors_json.json` into a `VisiumV2` image (Seurat v5's class): `get_image()`, `scale_factors`, `radius()`, `scale_coordinates()`
+- **Visium tissue images** — `load_visium` reads the H&E PNG + `scalefactors_json.json` into a `VisiumV2` image (Seurat v5's class): `get_image()`, `scale_factors`, `radius()`, `scale_coordinates()`; `spatial_dim_plot` / `spatial_feature_plot` draw spots over that image at their true diameter
 - **PBMC 3k tutorial** — end-to-end validated against the official Seurat tutorial
 - **PBMC 8k advanced tutorial** — larger dataset + T/NK subclustering workflow
 - **CITE-seq multimodal tutorial** — RNA + surface protein (ADT) with CLR normalization and WNN joint clustering
@@ -293,7 +293,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(delivered — see Tutorial 3)* |
 | v0.5.0 | Additional reductions — t-SNE, ICA ✅ *(delivered)*; remaining: SPCA, GLM-PCA |
 | v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`), bimod (`test_use="bimod"`) ✅ *(complete)* |
-| v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I), `image_*` plots, `VisiumV2` tissue images ✅ *(largely delivered — see Tutorial 5)*; remaining: `spatial_dim_plot` / `spatial_feature_plot` |
+| v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I), `image_*` plots, `VisiumV2` tissue images, `spatial_*` H&E plots ✅ *(largely delivered — see Tutorial 5)*; remaining: markvariogram |
 | v0.8.0 | Scale — BPCells-style lazy matrices, `SketchData`, `ProjectData` |
 | v0.9.0 | Specialized — `HTODemux`, Mixscape (CRISPR screens) |
 | v0.10.0 | Infrastructure — PyPI, GitHub Actions CI, type annotations, MkDocs site |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -216,9 +216,12 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 >   `nearest_neighbor_distance`, `local_neighborhood`, `build_niche_assay`
 >   (`BuildNicheAssay`), `composition_test`, `add_module_score(search=)`
 > - **Plots:** `image_dim_plot` (`ImageDimPlot`), `image_feature_plot`
->   (`ImageFeaturePlot`) — sub-cellular Xenium/CosMx centroids
+>   (`ImageFeaturePlot`) — sub-cellular Xenium/CosMx centroids; `spatial_dim_plot`
+>   (`SpatialDimPlot`), `spatial_feature_plot` (`SpatialFeaturePlot`) — Visium
+>   spots over the H&E tissue image
 >
-> Remaining open items:
+> The only item still open in this milestone is the **markvariogram** method for
+> `find_spatially_variable_features` (see below).
 
 ### `load_merscope` — ✅ delivered
 - Implemented in `shanuz/spatial/loaders.py` as `load_merscope(...)`, mirroring
@@ -270,16 +273,32 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
   neither installed the loader warns and skips the image rather than failing.
 - **R:** `Load10X_Spatial(data.dir)`, `GetImage(obj[["slice1"]])`, `ScaleFactors()`
 
-### Tissue-image spatial plots (Visium H&E) — still open
+### Tissue-image spatial plots (Visium H&E) — ✅ delivered
 | Function | R equivalent | Notes |
 |---|---|---|
 | `spatial_dim_plot` | `SpatialDimPlot` | clusters/ident over the H&E tissue image |
 | `spatial_feature_plot` | `SpatialFeaturePlot` | gene expression over the tissue image |
 
-The sub-cellular centroid variants (`image_dim_plot` / `image_feature_plot`) are
-done, and `VisiumV2` now supplies the image + scale factors these need; what
-remains is the drawing itself (`matplotlib.imshow` background + scaled `scatter`,
-with a graceful fallback to a plain scatter when no image is stored).
+- Both in `shanuz/plotting.py`. Each panel `imshow`s the photo held by the
+  `VisiumV2` image, then overlays the spots on top of it
+  (`tests/test_spatial_plots.py`).
+- **Spots are drawn at their true diameter**, not as scatter points: they are an
+  `EllipseCollection` in `units="xy"`, so a spot's size is expressed in *data*
+  units and stays registered against the tissue when the axes are zoomed or the
+  resolution changes. A `scatter(s=…)` size is in points² and would drift.
+  `pt_size_factor=` (default 1.6, as in Seurat) scales relative to the real spot.
+- **The image anchors the coordinate space.** Coordinates come from
+  `VisiumV2.scale_coordinates()` (fullres → image pixels) and the diameter from
+  `.spot_radius()`; `imshow` then supplies the frame. `crop=` (default `True`)
+  zooms to the spots rather than the whole slide, `image_alpha=` fades the
+  tissue, and `resolution=` overrides which PNG is drawn.
+- **Two independent fallbacks, because the bundle has two independent holes.** No
+  PNG (a plain `FOV`, or `load_visium(image=False)`) → a bare scatter of the same
+  spots, y-axis still pointing down so it looks the same. No
+  `scalefactors_json.json` → the photo still draws, but with no
+  `spot_diameter_fullres` there is nothing to size the spots *to*, so they degrade
+  to fixed-size scatter points.
+- **R:** `SpatialDimPlot(obj)`, `SpatialFeaturePlot(obj, features = "Gad1")`
 
 ---
 
@@ -405,7 +424,7 @@ If milestones are too large, these are the highest-value individual items:
 2. ~~**WNN** (`v0.4.0`)~~ — ✅ delivered (`find_multi_modal_neighbors` + `run_umap(graph=)`); CBMC tutorial section still open
 3. ~~**GitHub Actions CI** (`v0.10.0`)~~ — ✅ delivered
 4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — enables atlas-based annotation (next-cycle candidate; needs CCA/RPCA first)
-5. ~~**`FindSpatiallyVariableFeatures` (Moran's I)**~~ ✅ + **`SpatialFeaturePlot`** (`v0.7.0`) — all four loaders, niche/neighbourhood analysis, Moran's I and the `VisiumV2` tissue-image data layer delivered; only `spatial_dim_plot` / `spatial_feature_plot` remain
+5. ~~**`FindSpatiallyVariableFeatures` (Moran's I)** + **`SpatialFeaturePlot`**~~ ✅ (`v0.7.0`) — all four loaders, niche/neighbourhood analysis, Moran's I, the `VisiumV2` tissue-image data layer and the `spatial_*` H&E plots delivered; only the markvariogram method remains
 6. ~~**`AggregateExpression` + DESeq2**~~ ✅ (`v0.6.0`) — `aggregate_expression`,
    `find_conserved_markers`, and pseudobulk DESeq2 (`test_use="deseq2"`) delivered;
    MAST (`test_use="mast"`) and bimod (`test_use="bimod"`) too — **v0.6.0 complete**

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -67,6 +67,8 @@ from .plotting import (
     dot_plot,
     image_dim_plot,
     image_feature_plot,
+    spatial_dim_plot,
+    spatial_feature_plot,
 )
 
 __version__ = "0.2.0"
@@ -157,5 +159,7 @@ __all__ = [
     "dot_plot",
     "image_dim_plot",
     "image_feature_plot",
+    "spatial_dim_plot",
+    "spatial_feature_plot",
     "__version__",
 ]

--- a/shanuz/plotting.py
+++ b/shanuz/plotting.py
@@ -1136,6 +1136,240 @@ def image_feature_plot(
 
 
 # ---------------------------------------------------------------------------
+# Visium tissue-image plots — SpatialDimPlot / SpatialFeaturePlot
+# ---------------------------------------------------------------------------
+
+def _resolve_fovs(obj, image: Optional[Union[str, list]] = None) -> dict:
+    """The requested image slots, in order, as a ``{name: fov}`` dict."""
+    images = getattr(obj, "images", None) or {}
+    if not images:
+        raise ValueError("Object has no spatial images to plot.")
+    if image is None:
+        names = list(images)
+    elif isinstance(image, str):
+        names = [image]
+    else:
+        names = list(image)
+    missing = [n for n in names if n not in images]
+    if missing:
+        raise KeyError(
+            f"No such image(s): {missing}. Available: {list(images)}."
+        )
+    return {n: images[n] for n in names}
+
+
+def _spatial_panel(fov, resolution: Optional[str]):
+    """Draw-space coordinates, spot radius and background image for one FOV.
+
+    A ``VisiumV2`` carrying a tissue photo reports its coordinates in
+    full-resolution pixels, so they are scaled into the image's own pixel space
+    here. Any other FOV has no image; its coordinates are used as they stand.
+    """
+    img = fov.get_image()
+    if img is None:
+        return fov.get_tissue_coordinates(), fov.radius(), None
+    return fov.scale_coordinates(resolution=resolution), fov.spot_radius(resolution), img
+
+
+def _spot_collection(ax, coords, radius: Optional[float], pt_size_factor: float):
+    """Spots as true-to-scale circles, or None when the spot size is unknown."""
+    if radius is None or not np.isfinite(radius) or radius <= 0:
+        return None
+    from matplotlib.collections import EllipseCollection
+
+    d = 2.0 * float(radius) * pt_size_factor
+    offsets = np.column_stack([
+        coords["x"].to_numpy(dtype=float),
+        coords["y"].to_numpy(dtype=float),
+    ])
+    return EllipseCollection(
+        widths=d, heights=d, angles=0.0, units="xy",
+        offsets=offsets, offset_transform=ax.transData, linewidths=0.0,
+    )
+
+
+def _spatial_limits(ax, coords, radius: Optional[float], img, crop: bool) -> None:
+    """Frame the panel, always with y increasing downward (image convention)."""
+    if img is not None and not crop:
+        h, w = img.shape[:2]
+        ax.set_xlim(-0.5, w - 0.5)
+        ax.set_ylim(h - 0.5, -0.5)
+        return
+    x = coords["x"].to_numpy(dtype=float)
+    y = coords["y"].to_numpy(dtype=float)
+    pad = (radius or 0.0) + 0.02 * max(float(np.ptp(x)), float(np.ptp(y)), 1.0)
+    ax.set_xlim(x.min() - pad, x.max() + pad)
+    ax.set_ylim(y.max() + pad, y.min() - pad)
+
+
+def spatial_dim_plot(
+    obj,
+    group_by: Optional[str] = None,
+    image: Optional[Union[str, list]] = None,
+    cols: Optional[dict] = None,
+    pt_size_factor: float = 1.6,
+    size: float = 12.0,
+    alpha: float = 1.0,
+    image_alpha: float = 1.0,
+    resolution: Optional[str] = None,
+    crop: bool = True,
+    ncol: Optional[int] = None,
+    figsize: Optional[tuple] = None,
+) -> "plt.Figure":
+    """Plot spots on the tissue image, coloured by a grouping variable.
+
+    Matplotlib equivalent of Seurat's ``SpatialDimPlot``. Each panel draws the
+    H&E photo held by a :class:`~shanuz.spatial.visium.VisiumV2` image and
+    overlays the spots at their true diameter. An image slot with no photo (a
+    plain ``FOV``, or a Visium bundle loaded with ``image=False``) degrades to a
+    bare scatter of the same spots — the plot still works, it just has no
+    tissue underneath.
+
+    Parameters
+    ----------
+    group_by : metadata column (default: active idents) for spot colour.
+    image    : image name(s) to draw (default: all).
+    cols     : optional ``{group: colour}`` mapping.
+    pt_size_factor : scales the spots relative to their real diameter, as in
+        Seurat. Ignored when the image has no ``scalefactors_json.json``, in
+        which case ``size`` (a plain scatter point size) applies instead.
+    image_alpha : opacity of the tissue photo — drop it to make spots pop.
+    resolution : ``"hires"`` / ``"lowres"``; defaults to whatever was loaded.
+    crop     : zoom to the spots rather than showing the whole slide.
+    """
+    plt = _mpl()
+    fovs = _resolve_fovs(obj, image)
+
+    labels = _get_groups(obj, group_by)
+    lab_by_cell = dict(zip(obj.cell_names(), [str(v) for v in labels]))
+
+    panels = {}
+    for name, fov in fovs.items():
+        coords, radius, img = _spatial_panel(fov, resolution)
+        coords = coords.assign(group=[lab_by_cell.get(c) for c in coords.index])
+        coords = coords[coords["group"].notna()]
+        if not coords.empty:
+            panels[name] = (coords, radius, img)
+    if not panels:
+        raise ValueError("No spots left to plot: the images share no cells with the object.")
+
+    uniq = sorted({g for coords, _, _ in panels.values() for g in coords["group"]})
+    if cols is None:
+        cols = dict(zip(uniq, _palette(len(uniq))))
+
+    nrow, ncol = _subplot_grid(len(panels), ncol)
+    if figsize is None:
+        figsize = (5 * ncol, 4.5 * nrow)
+    fig, axes = plt.subplots(nrow, ncol, figsize=figsize, squeeze=False)
+    axes_flat = axes.ravel()
+
+    for ax, (name, (coords, radius, img)) in zip(axes_flat, panels.items()):
+        if img is not None:
+            ax.imshow(img, alpha=image_alpha)
+        face = [cols.get(g, "grey") for g in coords["group"]]
+        coll = _spot_collection(ax, coords, radius, pt_size_factor)
+        if coll is None:
+            ax.scatter(coords["x"], coords["y"], s=size, c=face,
+                       alpha=alpha, linewidths=0)
+        else:
+            coll.set_facecolor(face)
+            coll.set_alpha(alpha)
+            ax.add_collection(coll)
+        _spatial_limits(ax, coords, radius, img, crop)
+        ax.set_title(str(name), fontsize=9, fontweight="bold")
+        ax.set_aspect("equal")
+        ax.axis("off")
+    for ax in axes_flat[len(panels):]:
+        ax.axis("off")
+
+    handles = [plt.Line2D([], [], marker="o", linestyle="", markersize=6,
+                          markerfacecolor=cols.get(g, "grey"), markeredgewidth=0)
+               for g in uniq]
+    fig.legend(handles, uniq, title=group_by or "ident", loc="center right",
+               fontsize=8, title_fontsize=8, frameon=False)
+    fig.tight_layout(rect=(0, 0, 0.88, 1))
+    return fig
+
+
+def spatial_feature_plot(
+    obj,
+    feature: str,
+    image: Optional[Union[str, list]] = None,
+    cmap: str = "viridis",
+    pt_size_factor: float = 1.6,
+    size: float = 12.0,
+    alpha: float = 1.0,
+    image_alpha: float = 1.0,
+    assay: Optional[str] = None,
+    layer: Optional[str] = None,
+    resolution: Optional[str] = None,
+    crop: bool = True,
+    ncol: Optional[int] = None,
+    figsize: Optional[tuple] = None,
+) -> "plt.Figure":
+    """Plot spots on the tissue image, coloured by a feature's expression.
+
+    Matplotlib equivalent of Seurat's ``SpatialFeaturePlot``. Behaves exactly
+    like :func:`spatial_dim_plot` — same tissue background, same true-to-scale
+    spots, same fallback when no image is stored — but colours the spots by a
+    continuous value on a shared scale across panels.
+    """
+    plt = _mpl()
+    fovs = _resolve_fovs(obj, image)
+
+    expr = _get_expression(obj, feature, assay, layer)
+    expr_by_cell = dict(zip(obj.cell_names(), expr))
+
+    panels = {}
+    for name, fov in fovs.items():
+        coords, radius, img = _spatial_panel(fov, resolution)
+        coords = coords.assign(val=[expr_by_cell.get(c, np.nan) for c in coords.index])
+        coords = coords[coords["val"].notna()]
+        if not coords.empty:
+            panels[name] = (coords, radius, img)
+    if not panels:
+        raise ValueError("No spots left to plot: the images share no cells with the object.")
+
+    vals = np.concatenate([c["val"].to_numpy(dtype=float) for c, _, _ in panels.values()])
+    vmax = float(np.nanmax(vals)) if vals.size else 1.0
+    if not np.isfinite(vmax) or vmax <= 0:
+        vmax = 1.0
+
+    nrow, ncol = _subplot_grid(len(panels), ncol)
+    if figsize is None:
+        figsize = (5 * ncol, 4.5 * nrow)
+    fig, axes = plt.subplots(nrow, ncol, figsize=figsize, squeeze=False)
+    axes_flat = axes.ravel()
+
+    mappable = None
+    for ax, (name, (coords, radius, img)) in zip(axes_flat, panels.items()):
+        if img is not None:
+            ax.imshow(img, alpha=image_alpha)
+        v = coords["val"].to_numpy(dtype=float)
+        coll = _spot_collection(ax, coords, radius, pt_size_factor)
+        if coll is None:
+            mappable = ax.scatter(coords["x"], coords["y"], s=size, c=v, cmap=cmap,
+                                  vmin=0, vmax=vmax, alpha=alpha, linewidths=0)
+        else:
+            coll.set_array(v)
+            coll.set_cmap(cmap)
+            coll.set_clim(0, vmax)
+            coll.set_alpha(alpha)
+            ax.add_collection(coll)
+            mappable = coll
+        _spatial_limits(ax, coords, radius, img, crop)
+        ax.set_title(str(name), fontsize=9, fontweight="bold")
+        ax.set_aspect("equal")
+        ax.axis("off")
+    for ax in axes_flat[len(panels):]:
+        ax.axis("off")
+
+    if mappable is not None:
+        fig.colorbar(mappable, ax=axes_flat.tolist(), shrink=0.5, label=feature)
+    return fig
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -1153,4 +1387,6 @@ __all__ = [
     "dot_plot",
     "image_dim_plot",
     "image_feature_plot",
+    "spatial_dim_plot",
+    "spatial_feature_plot",
 ]

--- a/tests/test_spatial_plots.py
+++ b/tests/test_spatial_plots.py
@@ -1,0 +1,263 @@
+"""Tests for the Visium tissue-image plots (spatial_dim_plot / spatial_feature_plot)."""
+import json
+
+import matplotlib
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.io as sio
+import scipy.sparse as sp
+
+matplotlib.use("Agg")
+
+from matplotlib.collections import EllipseCollection  # noqa: E402
+
+from shanuz import load_visium, spatial_dim_plot, spatial_feature_plot  # noqa: E402
+from shanuz.preprocessing import normalize_data  # noqa: E402
+
+SPOT_DIAMETER = 20.0
+HIRES_SCALEF = 0.1
+LOWRES_SCALEF = 0.03
+# Spots reach x = 1000 fullres px, so the images must be big enough to hold
+# them once scaled: 1000 * 0.1 = 100 < 120 hires, 1000 * 0.03 = 30 < 40 lowres.
+HIRES_PX, LOWRES_PX = 120, 40
+
+GENES = ["Gad1", "Slc17a7", "Sox9"]
+N_SPOTS = 6
+
+
+def _write_visium(tmp_path, with_image=True, with_scalefactors=True):
+    """A minimal Visium bundle: MTX triplet + spatial/ (mirrors test_visium_image)."""
+    mtx = tmp_path / "filtered_feature_bc_matrix"
+    mtx.mkdir()
+    counts = sp.csr_matrix(np.arange(len(GENES) * N_SPOTS, dtype=float).reshape(
+        len(GENES), N_SPOTS))
+    sio.mmwrite(mtx / "matrix.mtx", counts)
+    barcodes = [f"AAAC{i}-1" for i in range(N_SPOTS)]
+    pd.DataFrame({"bc": barcodes}).to_csv(
+        mtx / "barcodes.tsv", sep="\t", header=False, index=False)
+    pd.DataFrame({"id": [f"ENSG{i}" for i in range(len(GENES))], "sym": GENES}).to_csv(
+        mtx / "genes.tsv", sep="\t", header=False, index=False)
+
+    spatial = tmp_path / "spatial"
+    spatial.mkdir()
+    pd.DataFrame({
+        "barcode": barcodes,
+        "in_tissue": [1] * N_SPOTS,
+        "array_row": np.arange(N_SPOTS),
+        "array_col": np.arange(N_SPOTS),
+        "pxl_row_in_fullres": np.arange(N_SPOTS, dtype=float) * 100.0,
+        "pxl_col_in_fullres": np.arange(N_SPOTS, dtype=float) * 200.0,
+    }).to_csv(spatial / "tissue_positions.csv", index=False)
+
+    if with_scalefactors:
+        with open(spatial / "scalefactors_json.json", "w") as fh:
+            json.dump({
+                "spot_diameter_fullres": SPOT_DIAMETER,
+                "fiducial_diameter_fullres": 30.0,
+                "tissue_hires_scalef": HIRES_SCALEF,
+                "tissue_lowres_scalef": LOWRES_SCALEF,
+            }, fh)
+
+    if with_image:
+        import matplotlib.image as mpimg
+        rng = np.random.default_rng(0)
+        for res, size in (("hires", HIRES_PX), ("lowres", LOWRES_PX)):
+            mpimg.imsave(spatial / f"tissue_{res}_image.png", rng.random((size, size, 3)))
+    return barcodes
+
+
+@pytest.fixture
+def visium(tmp_path):
+    barcodes = _write_visium(tmp_path)
+    obj = load_visium(tmp_path)
+    normalize_data(obj, assay="Spatial")
+    obj.add_meta_data(
+        pd.Series(["a", "b"] * (N_SPOTS // 2), index=barcodes), col_name="region")
+    return obj
+
+
+def _spots(fig):
+    """The spot collection of the first panel, if the spots were drawn to scale."""
+    for coll in fig.axes[0].collections:
+        if isinstance(coll, EllipseCollection):
+            return coll
+    return None
+
+
+def _diameters(coll):
+    """Spot diameters in data units. EllipseCollection keeps half-widths, privately."""
+    return np.asarray(coll._widths) * 2.0
+
+
+# ---------------------------------------------------------------------------
+# The image actually gets drawn
+# ---------------------------------------------------------------------------
+
+def test_spatial_dim_plot_draws_the_tissue_image(visium):
+    fig = spatial_dim_plot(visium, group_by="region")
+    ax = fig.axes[0]
+    assert len(ax.images) == 1
+    assert ax.images[0].get_array().shape[:2] == (HIRES_PX, HIRES_PX)
+
+
+def test_spatial_feature_plot_draws_the_tissue_image(visium):
+    fig = spatial_feature_plot(visium, "Gad1")
+    ax = fig.axes[0]
+    assert len(ax.images) == 1
+    # A colourbar axis is added alongside the panel.
+    assert len(fig.axes) >= 2
+
+
+def test_image_alpha_is_applied(visium):
+    fig = spatial_dim_plot(visium, group_by="region", image_alpha=0.3)
+    assert fig.axes[0].images[0].get_alpha() == pytest.approx(0.3)
+
+
+# ---------------------------------------------------------------------------
+# Spots land on the image, at the right size
+# ---------------------------------------------------------------------------
+
+def test_spots_are_scaled_into_image_pixel_space(visium):
+    fig = spatial_dim_plot(visium, group_by="region", crop=False)
+    offsets = _spots(fig).get_offsets()
+    # Fullres x = col * 200, y = row * 100; hires image is 0.1× that.
+    expected = np.column_stack([
+        np.arange(N_SPOTS) * 200.0 * HIRES_SCALEF,
+        np.arange(N_SPOTS) * 100.0 * HIRES_SCALEF,
+    ])
+    assert np.allclose(np.asarray(offsets), expected)
+    # ...and they land inside the image, which the raw fullres coords would not.
+    assert np.asarray(offsets).max() <= HIRES_PX
+
+
+def test_spot_diameter_matches_the_scale_factor(visium):
+    fig = spatial_dim_plot(visium, group_by="region", pt_size_factor=1.0)
+    coll = _spots(fig)
+    assert coll.get_offset_transform() is fig.axes[0].transData    # sized in data units
+    assert np.allclose(_diameters(coll), SPOT_DIAMETER * HIRES_SCALEF)
+
+
+def test_pt_size_factor_scales_the_spots(visium):
+    small = _diameters(_spots(spatial_dim_plot(visium, group_by="region",
+                                               pt_size_factor=1.0)))
+    big = _diameters(_spots(spatial_dim_plot(visium, group_by="region",
+                                             pt_size_factor=2.0)))
+    assert np.allclose(big, small * 2.0)
+
+
+def test_lowres_resolution_rescales_spots_and_image(tmp_path):
+    _write_visium(tmp_path)
+    obj = load_visium(tmp_path, image_resolution="lowres")
+    fig = spatial_dim_plot(obj, crop=False)
+    assert fig.axes[0].images[0].get_array().shape[:2] == (LOWRES_PX, LOWRES_PX)
+    offsets = np.asarray(_spots(fig).get_offsets())
+    assert np.allclose(offsets[:, 0], np.arange(N_SPOTS) * 200.0 * LOWRES_SCALEF)
+
+
+# ---------------------------------------------------------------------------
+# Framing
+# ---------------------------------------------------------------------------
+
+def test_y_axis_points_down_like_the_image(visium):
+    ax = spatial_dim_plot(visium, group_by="region").axes[0]
+    lo, hi = ax.get_ylim()
+    assert lo > hi          # inverted: row 0 at the top, as in the photo
+
+
+def test_crop_false_shows_the_whole_slide(visium):
+    ax = spatial_dim_plot(visium, group_by="region", crop=False).axes[0]
+    assert ax.get_xlim() == pytest.approx((-0.5, HIRES_PX - 0.5))
+    assert ax.get_ylim() == pytest.approx((HIRES_PX - 0.5, -0.5))
+
+
+def test_crop_zooms_to_the_spots(visium):
+    ax = spatial_dim_plot(visium, group_by="region", crop=True).axes[0]
+    x0, x1 = ax.get_xlim()
+    # Spots span x = 0..100 in hires px; cropping must be tighter than the slide.
+    assert x1 < HIRES_PX - 0.5
+    assert x0 > -HIRES_PX
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation — no image stored
+# ---------------------------------------------------------------------------
+
+def test_falls_back_to_a_scatter_without_an_image(tmp_path):
+    _write_visium(tmp_path)
+    obj = load_visium(tmp_path, image=False)          # plain FOV, no photo
+    normalize_data(obj, assay="Spatial")
+    fig = spatial_dim_plot(obj)
+    ax = fig.axes[0]
+    assert len(ax.images) == 0                        # nothing to draw underneath
+    assert len(ax.collections) == 1                   # but the spots are still there
+    lo, hi = ax.get_ylim()
+    assert lo > hi                                    # same orientation as with an image
+
+
+def test_fallback_keeps_fullres_coordinates(tmp_path):
+    _write_visium(tmp_path)
+    obj = load_visium(tmp_path, image=False)
+    ax = spatial_dim_plot(obj).axes[0]
+    offsets = np.asarray(ax.collections[0].get_offsets())
+    assert np.allclose(offsets[:, 0], np.arange(N_SPOTS) * 200.0)   # unscaled
+
+
+def test_feature_plot_falls_back_without_an_image(tmp_path):
+    _write_visium(tmp_path)
+    obj = load_visium(tmp_path, image=False)
+    normalize_data(obj, assay="Spatial")
+    fig = spatial_feature_plot(obj, "Gad1")
+    assert len(fig.axes[0].images) == 0
+    assert len(fig.axes) >= 2                          # colourbar still drawn
+
+
+def test_no_scalefactors_means_plain_scatter_points(tmp_path):
+    _write_visium(tmp_path, with_scalefactors=False)
+    obj = load_visium(tmp_path)
+    fig = spatial_dim_plot(obj)
+    # The photo is drawn, but with no spot_diameter_fullres we cannot size spots
+    # to scale, so they degrade to fixed-size scatter points.
+    assert len(fig.axes[0].images) == 1
+    assert _spots(fig) is None
+    assert len(fig.axes[0].collections) == 1
+
+
+# ---------------------------------------------------------------------------
+# Colouring and errors
+# ---------------------------------------------------------------------------
+
+def test_group_by_colours_and_legend(visium):
+    fig = spatial_dim_plot(visium, group_by="region",
+                           cols={"a": "#ff0000", "b": "#0000ff"})
+    faces = _spots(fig).get_facecolor()
+    assert np.allclose(faces[0][:3], (1.0, 0.0, 0.0))     # spot 0 is region "a"
+    assert np.allclose(faces[1][:3], (0.0, 0.0, 1.0))     # spot 1 is region "b"
+    assert [t.get_text() for t in fig.legends[0].get_texts()] == ["a", "b"]
+
+
+def test_feature_plot_colours_by_expression(visium):
+    fig = spatial_feature_plot(visium, "Gad1")
+    arr = np.asarray(_spots(fig).get_array(), dtype=float)
+    row = visium.assays["Spatial"].layer_data("data")[GENES.index("Gad1"), :]
+    expected = np.asarray(row.todense()).ravel() if sp.issparse(row) else np.ravel(row)
+    assert np.allclose(arr, expected)
+
+
+def test_unknown_image_name_raises(visium):
+    with pytest.raises(KeyError, match="No such image"):
+        spatial_dim_plot(visium, image="nope")
+
+
+def test_object_without_images_raises(visium):
+    visium.images = {}
+    with pytest.raises(ValueError, match="no spatial images"):
+        spatial_dim_plot(visium)
+
+
+def test_subset_object_still_plots(visium):
+    keep = visium.cell_names()[:3]
+    sub = visium[keep]
+    fig = spatial_dim_plot(sub, group_by="region")
+    assert len(fig.axes[0].images) == 1                  # image survives subsetting
+    assert len(_spots(fig).get_offsets()) == 3

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -315,6 +315,8 @@ de.head()   # p_val / avg_log2FC (DESeq2 log2FoldChange, +ve = up in stim) / pct
 | `RidgePlot(pbmc, features, ncol)` | `ridge_plot(pbmc, features, ncol)` |
 | `ImageDimPlot(obj, group.by)` | `image_dim_plot(obj, group_by)` |
 | `ImageFeaturePlot(obj, features)` | `image_feature_plot(obj, feature)` |
+| `SpatialDimPlot(obj, group.by)` | `spatial_dim_plot(obj, group_by)` — spots over the H&E image |
+| `SpatialFeaturePlot(obj, features)` | `spatial_feature_plot(obj, feature)` |
 
 ### Spatial
 
@@ -331,6 +333,8 @@ de.head()   # p_val / avg_log2FC (DESeq2 log2FoldChange, +ve = up in stim) / pct
 | *(hand-rolled Fisher + `p.adjust`)* | `composition_test(obj, group_by, split_by)` |
 | `GetImage(obj[["slice1"]])` | `obj.images["spatial"].get_image()` — the Visium H&E image |
 | `ScaleFactors(obj[["slice1"]])` | `obj.images["spatial"].scale_factors` |
+| `SpatialDimPlot(obj)` | `spatial_dim_plot(obj)` |
+| `SpatialFeaturePlot(obj, features)` | `spatial_feature_plot(obj, feature)` |
 
 > **Plot output:** R renders to the graphics device automatically. Shanuz functions return a
 > `matplotlib.Figure` — call `fig.savefig("out.png")` to save or display inline in Jupyter.
@@ -360,3 +364,27 @@ r  = fov.spot_radius()                      # matching spot radius, in image pix
 Pass `image_resolution="lowres"` for the smaller PNG, `image=False` to skip it
 entirely, or `filter_by_tissue=True` to keep only spots with `in_tissue == 1`. A
 bundle with no PNG still loads — you get a plain `FOV`, exactly as before.
+
+#### Plotting spots on the tissue
+
+`spatial_dim_plot` / `spatial_feature_plot` (`SpatialDimPlot` / `SpatialFeaturePlot`)
+draw the H&E photo and overlay the spots on top of it — the scaling above happens
+for you:
+
+```python
+from shanuz import spatial_dim_plot, spatial_feature_plot
+
+fig = spatial_dim_plot(obj, group_by="seurat_clusters")
+fig = spatial_feature_plot(obj, "Gad1", image_alpha=0.4)   # fade the tissue
+fig.savefig("visium.png", dpi=150, bbox_inches="tight")
+```
+
+Spots are drawn at their **true diameter** (from `spot_diameter_fullres`), not as
+fixed-size points, so they stay registered against the tissue at any zoom.
+`pt_size_factor=` (default 1.6, as in Seurat) scales them; `crop=False` shows the
+whole slide instead of zooming to the spots; `resolution="lowres"` draws the
+smaller PNG.
+
+Neither function needs an image to work. Plot an object loaded with `image=False`
+and you get a plain scatter of the same spots — useful for Xenium/CosMx, or for a
+Visium bundle whose PNG is missing.


### PR DESCRIPTION
Adds `spatial_dim_plot` / `spatial_feature_plot` (Seurat's `SpatialDimPlot` / `SpatialFeaturePlot`), drawing Visium spots over the H&E tissue image carried by the `VisiumV2` images that #16 introduced. This closes out the v0.7.0 plotting set — the existing `image_*` functions covered sub-cellular Xenium/CosMx centroids, but had no tissue photo to draw on.

## Design notes

**Spots are drawn at their true diameter, not as scatter points.** They are an `EllipseCollection` in `units="xy"`, so a spot's size is expressed in *data* units and stays registered against the tissue when the axes are zoomed or the resolution changes. A `scatter(s=…)` point size is in points² and would drift out of register with the image. `pt_size_factor=` (default 1.6, matching Seurat) scales relative to the real spot.

**The image anchors the coordinate space.** Coordinates come from `VisiumV2.scale_coordinates()` (fullres → image pixels) and the diameter from `.spot_radius()`; `imshow` then supplies the frame. `crop=` (default `True`) zooms to the spots rather than the whole slide, `image_alpha=` fades the tissue, and `resolution=` overrides which PNG is drawn.

**Two independent fallbacks, because the on-disk bundle has two independent holes.**
- No PNG (a plain `FOV`, or `load_visium(image=False)`) → a bare scatter of the same spots, y-axis still pointing down so it looks the same.
- No `scalefactors_json.json` → the photo still draws, but with no `spot_diameter_fullres` there is nothing to size the spots *to*, so they degrade to fixed-size scatter points.

## Testing

19 new tests in `tests/test_spatial_plots.py` — **227 passing**, up from 208. They cover: the image is drawn at the right resolution; spots land in image-pixel space; spot diameter equals `spot_diameter_fullres × scalef`; `pt_size_factor` scales linearly; `lowres` rescales both image and spots; y-axis inverted; `crop=False` (whole slide) vs `crop=True` (zoomed); both fallbacks; group colours and legend; feature values match the normalized layer; unknown image name and image-less object raise; a subset object still plots with its image intact.

Every snippet added to `tutorials/README.md` was run end-to-end against a synthetic Visium bundle before commit.

## Notes

- **No new dependency.** matplotlib is already in the `[analysis]` extra.
- Ruff on `shanuz/plotting.py` goes 24 → 26 errors; both additions are `-> "plt.Figure"` return annotations flagged as F821, the convention used by all 13 existing plot functions in the file. The new test file is ruff-clean.
- After this, the only item left in v0.7.0 is the **markvariogram** method for `find_spatially_variable_features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)