### PR TITLE
Add run_spca and glm_pca — completes v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Preprocessing** — `normalize_data`, `find_variable_features` (VST), `scale_data`, `percentage_feature_set`
 - **SCTransform** — `sctransform` (regularized negative-binomial Pearson residuals)
 - **Signature scoring** — `add_module_score`, `cell_cycle_scoring` (S/G2M + Phase)
-- **Dimensionality reduction** — `run_pca`, `run_ica`, `run_tsne` (via scikit-learn)
+- **Dimensionality reduction** — `run_pca`, `run_spca` (supervised, off a cell graph), `run_ica`, `run_tsne`, `glm_pca` (Poisson, straight on counts)
 - **Batch correction / integration** — `run_harmony`, `integrate_layers` (via harmonypy)
 - **Nearest-neighbour graph** — `find_neighbors` (KNN + SNN)
 - **Multimodal WNN** — `find_multi_modal_neighbors` (per-cell RNA/protein weights, joint `wknn`/`wsnn` graphs)
@@ -291,7 +291,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | v0.2.0 | Batch correction — Harmony + `IntegrateLayers` ✅ *(delivered)*; remaining: CCA/RPCA anchors |
 | v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData`, `MapQuery` |
 | v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(delivered — see Tutorial 3)* |
-| v0.5.0 | Additional reductions — t-SNE, ICA ✅ *(delivered)*; remaining: SPCA, GLM-PCA |
+| v0.5.0 | Additional reductions — t-SNE, ICA, `run_spca`, `glm_pca` (Poisson) ✅ *(complete)* |
 | v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`), bimod (`test_use="bimod"`) ✅ *(complete)* |
 | v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I + markvariogram), `image_*` plots, `VisiumV2` tissue images, `spatial_*` H&E plots ✅ *(delivered — see Tutorial 5)* |
 | v0.8.0 | Scale — BPCells-style lazy matrices, `SketchData`, `ProjectData` |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,9 +116,11 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 
 ---
 
-## v0.5.0 — Additional Dimensionality Reductions
+## v0.5.0 — Additional Dimensionality Reductions — ✅ complete
 
-> Small self-contained additions; each is a single function wrapping a scipy/sklearn call.
+> t-SNE and ICA are single functions wrapping a scikit-learn call. sPCA and
+> GLM-PCA are not — both are implemented directly against NumPy/SciPy, and
+> neither added a dependency.
 
 ### `run_tsne` — ✅ delivered
 - Implemented in `shanuz/reduction.py` (`run_tsne`), mirrors `run_umap`; stores
@@ -133,16 +135,62 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 - **R:** `RunICA(obj, nics = 30)`
 - **Python dep:** `sklearn.decomposition.FastICA`
 
-### `run_spca` (supervised PCA)
+### `run_spca` (supervised PCA) — ✅ delivered
+- Implemented in `shanuz/reduction.py` as `run_spca(obj, graph="wsnn")`
+  (`tests/test_spca_glmpca.py`).
+- **The plan previously written here described the wrong algorithm** — a gene-graph
+  Laplacian smoothing a gene × gene matrix. Seurat's `RunSPCA` takes a **cell × cell**
+  graph (the documented call is `RunSPCA(reference, assay = "SCT", graph = "wsnn")`)
+  and eigendecomposes `XᵀGX`, which is features × features. Corrected here.
+- **What it does:** ordinary PCA maximises `vᵀXᵀXv` and knows nothing about which
+  cells you consider neighbours. sPCA swaps the identity for a graph you already
+  trust and maximises `vᵀXᵀGXv` — the gene axes that best reproduce that graph.
+  Pass `G = I` and PCA falls back out exactly, which is how the implementation is
+  tested (loadings match `run_pca` to a cosine > 0.999).
+- **Why it matters:** the output is a *linear map from genes to components*, so a
+  query dataset can be pushed into a reference's graph-defined space with one
+  matrix multiply. That is why Azimuth maps onto sPCA rather than PCA, and it is
+  the reduction v0.3.0's reference mapping will want.
+- **One departure from R:** Seurat runs `irlba` (an SVD) on `XᵀGX`, ranking
+  components by `|λ|`; we take the largest eigenvalues themselves, since `vᵀXᵀGXv`
+  is the quantity being maximised and a graph can push eigenvalues negative. With
+  non-negative edge weights the leading eigenvalues are positive, so the two
+  orderings differ only in the tail.
 - **R:** `RunSPCA(obj, assay, graph)`
-- **Plan:** weighted PCA where gene loadings are regularised toward graph-defined
-  gene modules; uses `scipy.linalg.svd` on `W @ X` where `W` is the gene-graph
-  Laplacian smoothing matrix
 
-### `glm_pca` (GLM-PCA)
-- **R:** `RunGLMPCA` (via SeuratWrappers + glmpca)
-- **Python dep:** `glmpca-py` (pip) or implement Poisson log-bilinear model directly
-- **Plan:** wrap `glmpca.glmpca(Y, L=k)` → `DimReduc("glmpca", ...)`
+### `glm_pca` (GLM-PCA) — ✅ delivered (Poisson)
+- Implemented in `shanuz/glmpca.py` as `glm_pca(obj, n_components=10)`, following
+  Townes et al. (2019). Pure NumPy/SciPy — **no `glmpca-py` dependency**, in
+  keeping with how MAST and bimod were done (`tests/test_spca_glmpca.py`).
+- **What it does:** log-normalise-then-PCA assumes the transformed counts are
+  Gaussian with constant variance. They are not, and the pseudocount needed to
+  survive `log(0)` distorts exactly the low-expression genes where the zeros live.
+  GLM-PCA drops the transform and fits a low-rank model on the count scale:
+  `Y[g,c] ~ Poisson(μ)`, `log μ = a[g] + o[c] + Σ_l U[g,l]·V[c,l]`, with the log
+  library size as a *fixed* offset `o` so sequencing depth is a known quantity
+  rather than a factor to be rediscovered. Factors land in `cell_embeddings`,
+  loadings in `feature_loadings`, so `find_neighbors(reduction="glmpca")` and
+  `run_umap` work downstream unchanged.
+- **Fitting:** Fisher scoring, alternating over intercept → loadings → factors.
+  Each block gets a diagonal Newton step (score ÷ Fisher information); under a log
+  link and Poisson noise both are one matrix product. Any step that fails to lower
+  the deviance is rejected and retried at half the step size, so the deviance falls
+  monotonically by construction; the trace is kept in `misc["deviance"]`.
+- **Initialisation is load-bearing, not a detail.** `U = V = 0` is an *exact saddle*
+  of the log-likelihood — each block's score is a product with the other, so both
+  vanish there. Starting near zero (the obvious choice, and `glmpca`'s own default)
+  leaves the fit inching away from the saddle, and any relative-improvement stopping
+  rule then declares convergence on a model that has fitted nothing. It fails
+  *convincingly*: one step is enough to orient the factors, so clusters separate
+  cleanly in a plot while the deviance sits at its null value. So the factors are
+  seeded from the SVD of the intercept-only model's residuals instead, as Townes
+  recommends. `test_glmpca_actually_fits_rather_than_stalling` guards it.
+- **Still open:** `family="nb"` (negative binomial) raises `NotImplementedError`.
+  Poisson understates the overdispersion in most scRNA-seq; NB needs a dispersion
+  parameter estimated alongside the factors.
+- **Scale:** the fit is dense in genes × cells. Pass a few thousand variable
+  features, as you would to `run_pca`.
+- **R:** `RunGLMPCA(obj, L = 10)` (via SeuratWrappers + glmpca)
 
 ---
 
@@ -430,7 +478,7 @@ Each milestone's new `pip` deps:
 | v0.2.0 | `harmonypy` |
 | v0.3.0 | *(none — uses sklearn already present)* |
 | v0.4.0 | *(none)* |
-| v0.5.0 | `glmpca-py` (optional) |
+| v0.5.0 | *(none — sPCA and GLM-PCA are pure NumPy/SciPy; `glmpca-py` proved unnecessary)* |
 | v0.6.0 | `pydeseq2` (optional) |
 | v0.7.0 | *(none — Moran's I is pure NumPy/SciPy; the Visium PNG uses matplotlib, already in `[analysis]`)* |
 | v0.8.0 | `zarr` (optional) |
@@ -449,9 +497,11 @@ If milestones are too large, these are the highest-value individual items:
 1. ~~**Harmony** (`v0.2.0`)~~ — ✅ delivered (`run_harmony` / `integrate_layers`)
 2. ~~**WNN** (`v0.4.0`)~~ — ✅ delivered (`find_multi_modal_neighbors` + `run_umap(graph=)`); CBMC tutorial section still open
 3. ~~**GitHub Actions CI** (`v0.10.0`)~~ — ✅ delivered
-4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — enables atlas-based annotation (next-cycle candidate; needs CCA/RPCA first)
+4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — enables atlas-based annotation (next-cycle candidate; needs CCA/RPCA first). `run_spca` is now in place, which is the reduction Azimuth maps onto.
 5. ~~**`FindSpatiallyVariableFeatures`** + **`SpatialFeaturePlot`**~~ ✅ (`v0.7.0`) — all four loaders, niche/neighbourhood analysis, both spatially-variable-feature methods (Moran's I and markvariogram), the `VisiumV2` tissue-image data layer and the `spatial_*` H&E plots delivered; **v0.7.0 is complete**
 6. ~~**`AggregateExpression` + DESeq2**~~ ✅ (`v0.6.0`) — `aggregate_expression`,
    `find_conserved_markers`, and pseudobulk DESeq2 (`test_use="deseq2"`) delivered;
    MAST (`test_use="mast"`) and bimod (`test_use="bimod"`) too — **v0.6.0 complete**
 7. **`SketchData`** (`v0.8.0`) — enables million-cell datasets
+8. ~~**`run_spca` + `glm_pca`**~~ ✅ (`v0.5.0`) — **v0.5.0 is complete**; the only
+   gap left in it is GLM-PCA's negative-binomial family

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -16,7 +16,8 @@ from .preprocessing import (
     scale_data,
     percentage_feature_set,
 )
-from .reduction import run_pca, run_ica, run_tsne
+from .reduction import run_pca, run_ica, run_spca, run_tsne
+from .glmpca import glm_pca
 from .neighbors import find_neighbors
 from .multimodal import find_multi_modal_neighbors
 from .clustering import find_clusters
@@ -125,7 +126,9 @@ __all__ = [
     "percentage_feature_set",
     "run_pca",
     "run_ica",
+    "run_spca",
     "run_tsne",
+    "glm_pca",
     "find_neighbors",
     "find_multi_modal_neighbors",
     "find_clusters",

--- a/shanuz/glmpca.py
+++ b/shanuz/glmpca.py
@@ -1,0 +1,315 @@
+"""GLM-PCA — dimensionality reduction on raw counts.
+
+Mirrors R's ``RunGLMPCA`` (SeuratWrappers → the `glmpca` package), following
+Townes et al. (2019), *Feature selection and dimension reduction for single-cell
+RNA-seq based on a multinomial model*.
+
+The usual pipeline log-normalises counts and then runs PCA, which quietly assumes
+the transformed data is Gaussian with constant variance. Counts are not: a gene
+averaging 0.1 UMIs and one averaging 100 have wildly different noise, the log
+transform does not fix that, and the pseudocount you add to survive ``log(0)``
+distorts exactly the low-expression genes where most of the zeros live. GLM-PCA
+drops the transformation entirely and fits a low-rank model on the count scale::
+
+    Y[g,c] ~ Poisson(μ[g,c])
+    log μ[g,c] = a[g] + o[c] + Σ_l U[g,l]·V[c,l]
+
+``a`` is a per-gene intercept, ``o`` a fixed per-cell offset (log library size, so
+sequencing depth is a known quantity rather than a factor to be discovered), and
+``U``/``V`` are the rank-L loadings and factors — the counterparts of PCA's
+loadings and embeddings. There is no closed form, so the model is fitted by
+Fisher scoring.
+
+Poisson only, for now. ``family="nb"`` raises; see ROADMAP.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import scipy.sparse as sp
+
+from .dimreduc import DimReduc
+
+FAMILIES = ("poisson",)
+
+_ETA_CLIP = 30.0        # exp(30) ≈ 1e13; keeps a bad step from overflowing to inf
+_EPS = 1e-10
+
+
+def glm_pca(
+    seurat,
+    n_components: int = 10,
+    features: Optional[list[str]] = None,
+    assay: Optional[str] = None,
+    reduction_name: str = "glmpca",
+    reduction_key: str = "GLMPC_",
+    family: str = "poisson",
+    layer: str = "counts",
+    max_iter: int = 100,
+    tol: float = 1e-4,
+    penalty: float = 1.0,
+    learning_rate: float = 0.1,
+    seed: int = 42,
+) -> None:
+    """Fit a Poisson GLM-PCA and store it as a DimReduc.
+
+    Mirrors R's ``RunGLMPCA(obj, L = 10)``. Takes **raw counts**, not normalised
+    or scaled data — the whole point is to model the counts as counts. Stores
+    factors as ``cell_embeddings`` and loadings as ``feature_loadings``, so
+    ``find_neighbors(obj, reduction="glmpca")`` and ``run_umap`` work downstream
+    exactly as they do off PCA.
+
+    Parameters
+    ----------
+    n_components  : rank of the fit (L) — the number of factors
+    features      : genes to use (defaults to variable features)
+    assay         : assay name (defaults to active assay)
+    family        : noise model; only ``"poisson"`` is implemented
+    layer         : layer to read counts from
+    max_iter      : maximum Fisher scoring iterations
+    tol           : stop when the relative change in deviance falls below this
+    penalty       : L2 ridge on U and V. U and V can trade scale freely
+                    (``U·Vᵀ = (cU)·(V/c)ᵀ``); the ridge is what pins that down.
+    learning_rate : initial Fisher step size. Halved on any step that fails to
+                    lower the deviance, so this is an opening bid, not a
+                    commitment.
+    seed          : only used if the counts have no structure at all — the fit is
+                    started deterministically from the data (see `_init_factors`)
+
+    Notes
+    -----
+    Deviance falls monotonically by construction: a step that raises it (or
+    overflows) is rejected outright and retried at half the step size. The full
+    trace is kept in ``reduction.misc["deviance"]`` — if it is still dropping
+    steeply at the end, raise ``max_iter``. ``misc["converged"]`` says whether the
+    fit stopped because it was done or because it ran out of iterations.
+
+    Fitting is dense in genes × cells. Pass a few thousand variable features
+    rather than the whole transcriptome, as you would to `run_pca`.
+    """
+    if family not in FAMILIES:
+        raise NotImplementedError(
+            f"family={family!r} is not implemented; use one of {list(FAMILIES)}.")
+
+    from .markers import _get_expression_matrix
+    from .reduction import _default_features
+
+    assay_name = assay or seurat.active_assay
+    assay_obj = seurat.assays[assay_name]
+
+    features = _default_features(assay_obj, features)
+    Y = _counts_for(assay_obj, features, layer, _get_expression_matrix)
+
+    n_genes, n_cells = Y.shape
+    n_components = min(n_components, min(n_genes, n_cells) - 1)
+    if n_components < 1:
+        raise ValueError(
+            f"Need at least 2 genes and 2 cells to fit GLM-PCA; got "
+            f"{n_genes} × {n_cells}.")
+
+    # Library size as a fixed offset: depth is known, not something to rediscover.
+    totals = Y.sum(axis=0)
+    if np.any(totals <= 0):
+        raise ValueError(
+            "Some cells have zero total counts, so they have no library size to "
+            "offset by. Filter them out first.")
+    offsets = np.log(totals / totals.mean())
+
+    intercept, U, V, deviance, converged = _fit_poisson(
+        Y, n_components, offsets,
+        max_iter=max_iter, tol=tol, penalty=penalty,
+        learning_rate=learning_rate, seed=seed,
+    )
+    loadings, factors = _orthogonalize(U, V)
+
+    seurat.reductions[reduction_name] = DimReduc(
+        cell_embeddings=factors,
+        feature_loadings=loadings,
+        assay_used=assay_name,
+        stdev=np.sqrt(np.var(factors, axis=0, ddof=1)),
+        key=reduction_key,
+        cell_names=seurat.cell_names(),
+        feature_names=list(features),
+        misc={
+            "glmpca_family": family,
+            "deviance": deviance,
+            "converged": converged,
+            "intercept": intercept,
+        },
+    )
+
+
+def _counts_for(assay_obj, features, layer, getter) -> np.ndarray:
+    """The raw counts for ``features``, dense, genes × cells."""
+    mat, all_features = getter(assay_obj, layer)
+    index = {f: i for i, f in enumerate(all_features)}
+    missing = [f for f in features if f not in index]
+    if missing:
+        raise ValueError(
+            f"{len(missing)} requested feature(s) are not in the assay, "
+            f"e.g. {missing[:3]}.")
+
+    rows = [index[f] for f in features]
+    Y = mat[rows, :]
+    Y = Y.toarray() if sp.issparse(Y) else np.asarray(Y)
+    Y = Y.astype(float)
+
+    if not np.isfinite(Y).all():
+        raise ValueError("Counts contain NaN or infinite values.")
+    if Y.min() < 0:
+        raise ValueError(
+            f"GLM-PCA models counts with a Poisson likelihood, but layer "
+            f"{layer!r} holds negative values (min {Y.min():.3g}) — this looks "
+            f"like normalised or scaled data. Pass layer='counts'.")
+    return Y
+
+
+def _init_factors(Y, intercept, offsets, L, seed, target_spread: float = 0.5):
+    """Start the factors from the SVD of the null model's residuals.
+
+    ``U = V = 0`` is an exact saddle of the log-likelihood — the score for each
+    block is a product with the *other* block, so at zero both vanish. Start the
+    two near zero and the fit inches away from the saddle, the deviance barely
+    moves on the first step, and any relative-improvement stopping rule declares
+    victory on a model that has not fitted anything. (It still looks plausible:
+    one step is enough to orient the factors, so cluster structure shows up in a
+    plot while the deviance sits at its null value.)
+
+    So do what Townes does instead: fit the intercept-only model, and let the
+    leading singular vectors of what it *fails* to explain say where the
+    structure is. Deterministic — ``seed`` is only reached if the residuals have
+    no structure at all.
+    """
+    mu0 = np.exp(np.clip(intercept[:, None] + offsets[None, :],
+                         -_ETA_CLIP, _ETA_CLIP))
+    residual = (Y - mu0) / np.sqrt(mu0 + _EPS)          # Pearson scale
+    residual = np.nan_to_num(residual, nan=0.0, posinf=0.0, neginf=0.0)
+
+    k = min(L, min(residual.shape) - 1)
+    if k < min(residual.shape) // 2:
+        from scipy.sparse.linalg import svds
+        P, S, Qt = svds(residual, k=k, random_state=seed)
+        order = np.argsort(S)[::-1]                     # svds returns ascending
+        P, S, Qt = P[:, order], S[order], Qt[order]
+    else:
+        P, S, Qt = np.linalg.svd(residual, full_matrices=False)
+
+    root = np.sqrt(S[:L])
+    U = P[:, :L] * root
+    V = Qt[:L].T * root
+
+    # Pearson residuals are z-scores. A rank-L slab of them is a wildly
+    # overconfident opening bid for a log-fold-change, so damp it to something a
+    # log link can survive and let Fisher scoring take it from there.
+    spread = float(np.std(U @ V.T))
+    if spread > 0:
+        U *= np.sqrt(target_spread / spread)
+        V *= np.sqrt(target_spread / spread)
+    else:                                               # no structure to find
+        rng = np.random.default_rng(seed)
+        U = rng.normal(scale=1e-2, size=U.shape)
+        V = rng.normal(scale=1e-2, size=V.shape)
+    return U, V
+
+
+def _poisson_deviance(Y: np.ndarray, mu: np.ndarray) -> float:
+    """2·Σ[y·log(y/μ) − (y − μ)] — the Poisson goodness-of-fit being minimised."""
+    with np.errstate(divide="ignore", invalid="ignore"):
+        term = np.where(Y > 0, Y * np.log(Y / mu), 0.0)
+    return float(2.0 * np.sum(term - (Y - mu)))
+
+
+def _fit_poisson(
+    Y: np.ndarray,
+    L: int,
+    offsets: np.ndarray,
+    max_iter: int,
+    tol: float,
+    penalty: float,
+    learning_rate: float,
+    seed: int,
+):
+    """Fisher scoring for the Poisson log-bilinear model, with backtracking.
+
+    Each block (intercept, loadings, factors) gets a diagonal Newton step: the
+    score divided by the Fisher information. Under a log link and Poisson noise
+    both are one matrix product each — the score is driven by the raw residual
+    ``Y − μ``, and the information by ``μ`` itself.
+    """
+    # Intercept-only fit: exp(a_g + o_c) reproduces each gene's mean rate. A gene
+    # detected in no cell floors at exp(-30) instead of log(0) = -inf.
+    rate = Y.sum(axis=1) / np.exp(offsets).sum()
+    intercept = np.log(np.maximum(rate, _EPS))
+
+    U, V = _init_factors(Y, intercept, offsets, L, seed)
+
+    def mean_of(intercept, U, V):
+        eta = intercept[:, None] + offsets[None, :] + U @ V.T
+        return np.exp(np.clip(eta, -_ETA_CLIP, _ETA_CLIP))
+
+    mu = mean_of(intercept, U, V)
+    deviance = [_poisson_deviance(Y, mu)]
+    lr = learning_rate
+    converged = False
+
+    for _ in range(max_iter):
+        keep = (intercept.copy(), U.copy(), V.copy(), mu)
+
+        # Gene intercepts: score Σ_c(y − μ), information Σ_c μ.
+        intercept = intercept + lr * (Y - mu).sum(axis=1) / np.maximum(
+            mu.sum(axis=1), _EPS)
+        mu = mean_of(intercept, U, V)
+
+        # Loadings. The ridge enters both score and information, so a gene with
+        # no signal left (μ ≈ 0, hence no information) is pulled toward zero
+        # rather than left wherever it was initialised.
+        R = Y - mu
+        U = U + lr * (R @ V - penalty * U) / (mu @ V**2 + penalty)
+        mu = mean_of(intercept, U, V)
+
+        # Factors.
+        R = Y - mu
+        V = V + lr * (R.T @ U - penalty * V) / (mu.T @ U**2 + penalty)
+        mu = mean_of(intercept, U, V)
+
+        current = _poisson_deviance(Y, mu)
+        if not np.isfinite(current) or current > deviance[-1]:
+            intercept, U, V, mu = keep      # the step overshot — take it back
+            lr *= 0.5
+            if lr < 1e-6:
+                break                       # no step size left; this is the fit
+            continue
+
+        improvement = abs(deviance[-1] - current) / (abs(deviance[-1]) + 0.1)
+        deviance.append(current)
+        if improvement < tol:
+            converged = True
+            break
+
+    return intercept, U, V, np.array(deviance), converged
+
+
+def _orthogonalize(U: np.ndarray, V: np.ndarray):
+    """Rotate the fitted factors into PCA-like order, changing nothing that matters.
+
+    The fit only ever sees ``U·Vᵀ``, and that product is untouched by
+    ``U → U·A``, ``V → V·A⁻ᵀ``. So the raw U and V that fall out of Fisher
+    scoring are one arbitrary member of a whole family, with no reason for
+    component 1 to be the biggest or for the components to be uncorrelated. Pick
+    the rotation that makes the loadings orthonormal and sorts the factors by the
+    share of the linear predictor they carry — so "component 1" means what a
+    reader coming from PCA expects it to mean.
+    """
+    Qu, Ru = np.linalg.qr(U)
+    Qv, Rv = np.linalg.qr(V)
+    W, S, Zt = np.linalg.svd(Ru @ Rv.T)     # S descending
+
+    loadings = Qu @ W                       # orthonormal columns
+    factors = (Qv @ Zt.T) * S               # ordered; these carry the scale
+
+    # Sign is arbitrary too. Pin it, flipping both sides so U·Vᵀ is preserved.
+    peak = np.argmax(np.abs(loadings), axis=0)
+    signs = np.sign(loadings[peak, np.arange(loadings.shape[1])])
+    signs[signs == 0] = 1.0
+    return loadings * signs, factors * signs

--- a/shanuz/reduction.py
+++ b/shanuz/reduction.py
@@ -1,6 +1,6 @@
-"""Dimensionality reduction: PCA and related helpers.
+"""Dimensionality reduction: PCA, sPCA, ICA, t-SNE.
 
-Mirrors Seurat's RunPCA() / RunSVD().
+Mirrors Seurat's RunPCA() / RunSPCA() / RunICA() / RunTSNE().
 """
 from __future__ import annotations
 
@@ -42,17 +42,7 @@ def run_pca(
     assay_name = assay or seurat.active_assay
     assay_obj = seurat.assays[assay_name]
 
-    from .assay5 import Assay5
-    from .assay import Assay
-
-    # Determine feature set
-    if features is None:
-        if isinstance(assay_obj, Assay5):
-            features = assay_obj.variable_features
-            if not features:
-                features = assay_obj._all_feature_names
-        else:
-            features = assay_obj.var_features or assay_obj._feature_names
+    features = _default_features(assay_obj, features)
 
     # Get scale.data for the selected features
     scaled = _get_scaled_data(assay_obj, features, layer)
@@ -68,12 +58,10 @@ def run_pca(
         svd = TruncatedSVD(n_components=n_pcs, random_state=seed)
         embeddings = svd.fit_transform(data_t)
         loadings = svd.components_.T  # (features × n_pcs)
-        explained = svd.explained_variance_ratio_
     else:
         pca = PCA(n_components=n_pcs, random_state=seed)
         embeddings = pca.fit_transform(data_t)  # (cells × n_pcs)
         loadings = pca.components_.T  # (features × n_pcs)
-        explained = pca.explained_variance_ratio_
 
     # Per-PC standard deviation (sample SD, ddof=1) — matches Seurat's @stdev.
     stdev = np.sqrt(np.var(embeddings, axis=0, ddof=1))
@@ -92,6 +80,107 @@ def run_pca(
     )
 
     seurat.reductions[reduction_name] = dr
+
+
+def run_spca(
+    seurat,
+    graph: str,
+    npcs: int = 50,
+    features: Optional[list[str]] = None,
+    assay: Optional[str] = None,
+    reduction_name: str = "spca",
+    reduction_key: str = "SPC_",
+    seed: int = 42,
+    layer: str = "scale.data",
+) -> None:
+    """Supervised PCA — the gene axes that best explain a cell-cell graph.
+
+    Mirrors R's ``RunSPCA(obj, assay = "SCT", graph = "wsnn")``. Ordinary PCA
+    picks the directions of greatest variance and knows nothing about which
+    cells you consider neighbours. sPCA is handed a graph you already trust —
+    typically the WNN graph from `find_multi_modal_neighbors`, which knows about
+    protein as well as RNA — and finds the directions *in gene space* that best
+    reproduce it. Where PCA maximises ``vᵀXᵀXv``, sPCA maximises ``vᵀXᵀGXv``:
+    the same problem with the identity swapped for the graph. Set ``G = I`` and
+    you get PCA back exactly.
+
+    The point is the loadings. Because sPCA is still a linear map from genes to
+    components, a query dataset can be pushed into a reference's graph-defined
+    space with a single matrix multiply, which is what makes it the reduction
+    Azimuth maps onto.
+
+    Parameters
+    ----------
+    graph          : key in ``seurat.graphs`` — a cell × cell graph (e.g. "wsnn")
+    npcs           : number of components
+    features       : genes to use (defaults to variable features)
+    assay          : assay name (defaults to active assay)
+    reduction_name : key for storage in seurat.reductions
+    reduction_key  : prefix for dimension names (e.g. 'SPC_')
+    seed           : random seed (the eigensolver starts from a random vector)
+    layer          : which layer to take data from
+
+    Notes
+    -----
+    Seurat runs `irlba` on ``XᵀGX``, which is an SVD and so ranks components by
+    ``|λ|``; we take the largest eigenvalues themselves, since ``vᵀXᵀGXv`` is
+    what is being maximised and a graph can push some eigenvalues negative. With
+    non-negative edge weights the leading eigenvalues are positive and the two
+    orderings agree, so this only ever differs in the tail.
+    """
+    assay_name = assay or seurat.active_assay
+    assay_obj = seurat.assays[assay_name]
+
+    if graph not in seurat.graphs:
+        raise KeyError(
+            f"Graph '{graph}' not found. Run find_neighbors() or "
+            f"find_multi_modal_neighbors() first. "
+            f"Available graphs: {list(seurat.graphs)}"
+        )
+
+    features = _default_features(assay_obj, features)
+
+    X = _get_scaled_data(assay_obj, features, layer).T      # cells × features
+    if sp.issparse(X):
+        X = X.toarray()
+    X = np.asarray(X, dtype=float)
+    n_cells, n_features = X.shape
+
+    G = seurat.graphs[graph].tocsr()
+    if G.shape != (n_cells, n_cells):
+        raise ValueError(
+            f"Graph '{graph}' is {G.shape[0]}×{G.shape[1]} but the assay has "
+            f"{n_cells} cells."
+        )
+    # A KNN graph need not be symmetric; the eigendecomposition needs it to be,
+    # and (G + Gᵀ)/2 leaves the quadratic form vᵀXᵀGXv untouched anyway.
+    G = (G + G.T) * 0.5
+
+    npcs = min(npcs, n_features - 1)
+    if npcs < 1:
+        raise ValueError(
+            f"Need at least 2 features to run sPCA; got {n_features}.")
+
+    np.random.seed(seed)
+    Z = X.T @ (G @ X)                                       # features × features
+    Z = np.asarray(Z)
+    Z = (Z + Z.T) * 0.5                                     # float asymmetry
+    eigenvalues, loadings = _top_eigenvectors(Z, npcs, seed=seed)
+    loadings = _flip_signs(loadings)                        # reproducible signs
+
+    embeddings = X @ loadings                               # cells × npcs
+    stdev = np.sqrt(np.var(embeddings, axis=0, ddof=1))
+
+    seurat.reductions[reduction_name] = DimReduc(
+        cell_embeddings=embeddings,
+        feature_loadings=loadings,
+        assay_used=assay_name,
+        stdev=stdev,
+        key=reduction_key,
+        cell_names=seurat.cell_names(),
+        feature_names=list(features),
+        misc={"spca_graph": graph, "eigenvalues": eigenvalues},
+    )
 
 
 def run_ica(
@@ -116,15 +205,7 @@ def run_ica(
     assay_name = assay or seurat.active_assay
     assay_obj = seurat.assays[assay_name]
 
-    from .assay5 import Assay5
-
-    if features is None:
-        if isinstance(assay_obj, Assay5):
-            features = assay_obj.variable_features
-            if not features:
-                features = assay_obj._all_feature_names
-        else:
-            features = assay_obj.var_features or assay_obj._feature_names
+    features = _default_features(assay_obj, features)
 
     scaled = _get_scaled_data(assay_obj, features, layer)  # (features × cells)
     data_t = scaled.T  # (cells × features)
@@ -193,10 +274,43 @@ def run_tsne(
     )
 
 
+def _default_features(assay_obj, features: Optional[list[str]]) -> list[str]:
+    """The genes a reduction runs on: whatever was asked for, else the variable ones."""
+    from .assay5 import Assay5
+
+    if features is not None:
+        return features
+    if isinstance(assay_obj, Assay5):
+        return assay_obj.variable_features or assay_obj._all_feature_names
+    return assay_obj.var_features or assay_obj._feature_names
+
+
+def _top_eigenvectors(Z: np.ndarray, k: int, seed: int = 42):
+    """The k eigenvectors of symmetric ``Z`` with the largest eigenvalues."""
+    if k >= Z.shape[0] - 1:
+        eigenvalues, vectors = np.linalg.eigh(Z)
+    else:
+        from scipy.sparse.linalg import eigsh
+        v0 = np.random.default_rng(seed).normal(size=Z.shape[0])
+        eigenvalues, vectors = eigsh(Z, k=k, which="LA", v0=v0)
+    order = np.argsort(eigenvalues)[::-1][:k]
+    return eigenvalues[order], vectors[:, order]
+
+
+def _flip_signs(vectors: np.ndarray) -> np.ndarray:
+    """Pin each eigenvector's arbitrary sign so repeat runs agree.
+
+    Convention (sklearn's): the largest-magnitude entry of every column is positive.
+    """
+    peak = np.argmax(np.abs(vectors), axis=0)
+    signs = np.sign(vectors[peak, np.arange(vectors.shape[1])])
+    signs[signs == 0] = 1.0
+    return vectors * signs
+
+
 def _get_scaled_data(assay_obj, features: list[str], layer: str) -> np.ndarray:
     """Extract scaled data for the given features as a (features × cells) array."""
     from .assay5 import Assay5
-    from .assay import Assay
     from ._sparse import is_matrix_empty
 
     if isinstance(assay_obj, Assay5):

--- a/tests/test_spca_glmpca.py
+++ b/tests/test_spca_glmpca.py
@@ -1,0 +1,328 @@
+"""Tests for the v0.5.0 reductions: run_spca (reduction.py) and glm_pca (glmpca.py)."""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from shanuz.shanuz import create_shanuz_object  # noqa: E402
+from shanuz.graph import Graph  # noqa: E402
+from shanuz.preprocessing import (  # noqa: E402
+    normalize_data,
+    find_variable_features,
+    scale_data,
+)
+from shanuz.reduction import run_pca, run_spca  # noqa: E402
+from shanuz.glmpca import glm_pca, _counts_for, _orthogonalize, _poisson_deviance  # noqa: E402
+from shanuz.neighbors import find_neighbors  # noqa: E402
+
+pytest.importorskip("sklearn")
+
+
+def _cosine(a, b):
+    return abs(float(a @ b)) / (np.linalg.norm(a) * np.linalg.norm(b))
+
+
+def _silhouette(embedding, labels):
+    from sklearn.metrics import silhouette_score
+    return float(silhouette_score(embedding, labels))
+
+
+# ---------------------------------------------------------------------------
+# run_spca
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def clustered():
+    """90 cells in 3 clusters, each with its own block of elevated genes."""
+    rng = np.random.default_rng(0)
+    n_genes, per, k = 90, 30, 3
+    n = per * k
+    lam = np.full((n_genes, n), 3.0)
+    for c in range(n):
+        cluster = c // per
+        lam[cluster * 20:(cluster + 1) * 20, c] += 8.0
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(rng.poisson(lam).astype(float)),
+        assay="RNA",
+        feature_names=[f"g{i}" for i in range(n_genes)],
+        cell_names=[f"c{i}" for i in range(n)],
+    )
+    normalize_data(obj)
+    find_variable_features(obj, selection_method="vst", nfeatures=60)
+    scale_data(obj)
+    run_pca(obj, n_pcs=10)
+    labels = np.repeat(np.arange(k), per)
+    return obj, labels
+
+
+def _identity_graph(obj):
+    cells = obj.cell_names()
+    return Graph(sp.identity(len(cells), format="csc"), cell_names=cells,
+                 assay_used="RNA")
+
+
+def test_spca_with_an_identity_graph_is_pca(clustered):
+    """G = I turns vᵀXᵀGXv back into vᵀXᵀXv, so the loadings must be PCA's."""
+    obj, _ = clustered
+    obj.graphs["identity"] = _identity_graph(obj)
+    run_spca(obj, graph="identity", npcs=10)
+
+    pca = obj.reductions["pca"].feature_loadings
+    spca = obj.reductions["spca"].feature_loadings
+    assert spca.shape == pca.shape
+    # Eigenvector signs are arbitrary in both, so compare directions.
+    for i in range(5):
+        assert _cosine(spca[:, i], pca[:, i]) > 0.999
+
+
+def test_spca_finds_what_the_graph_knows_and_pca_misses(clustered):
+    """The supervision is the whole point: hand sPCA a grouping PCA can't see.
+
+    Thirty coherent nuisance genes outvote ten genes carrying the real grouping,
+    so PC1 tracks the nuisance. The graph knows the groups, and sPCA — which
+    maximises vᵀXᵀGXv, i.e. the separation of the graph's blocks — puts them on
+    SPC1.
+
+    The nuisance axis runs through both groups equally — think cell-cycle phase
+    spanning two cell types. That is what makes it a nuisance rather than a
+    confounder, and it is the case sPCA is meant for: the strongest signal in the
+    data is real, and is not the one you asked about.
+
+    The grouping is deliberately *library-size neutral*: fifteen genes go up in
+    one group and fifteen in the other, so the two groups differ in which genes
+    are on rather than in how much RNA they hold. Let the grouping shift total
+    counts instead and `normalize_data` divides that shift back out of every
+    gene, smearing the grouping across the whole matrix — including the
+    high-variance nuisance genes, which then drag their own variance onto the
+    axis sPCA returns. It is the same compositional leak documented for Moran's I
+    in `find_spatially_variable_features`, and it blunts the separation badly
+    enough to hide the effect being tested.
+    """
+    rng = np.random.default_rng(1)
+    per, n_genes = 50, 65
+    n = 2 * per
+    group = np.repeat([0, 1], per)
+    nuisance = np.tile(np.linspace(0.0, 1.0, per), 2)   # identical within each group
+
+    lam = np.full((n_genes, n), 3.0)
+    lam[0:30] += 12.0 * nuisance                     # 30 genes track the nuisance
+    lam[30:45] += 3.0 * group                        # 15 genes up in group 1
+    lam[45:60] += 3.0 * (1 - group)                  # 15 genes up in group 0
+    #  the remaining 5 genes are noise
+
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(rng.poisson(lam).astype(float)),
+        assay="RNA",
+        feature_names=[f"g{i}" for i in range(n_genes)],
+        cell_names=[f"c{i}" for i in range(n)],
+    )
+    normalize_data(obj)
+    find_variable_features(obj, selection_method="vst", nfeatures=n_genes)
+    scale_data(obj)
+    run_pca(obj, n_pcs=10)
+
+    # A graph that knows the groups and nothing else: connected within, not across.
+    block = (group[:, None] == group[None, :]).astype(float)
+    obj.graphs["groups"] = Graph(sp.csc_matrix(block), cell_names=obj.cell_names(),
+                                 assay_used="RNA")
+    run_spca(obj, graph="groups", npcs=10)
+
+    pc1 = obj.reductions["pca"].cell_embeddings[:, :1]
+    spc1 = obj.reductions["spca"].cell_embeddings[:, :1]
+    assert _silhouette(spc1, group) > 0.7       # sPCA puts the grouping first
+    assert _silhouette(pc1, group) < 0.2        # PCA's leading axis is the nuisance
+
+
+def test_spca_embeddings_feed_downstream_steps(clustered):
+    obj, labels = clustered
+    obj.graphs["identity"] = _identity_graph(obj)
+    run_spca(obj, graph="identity", npcs=10)
+
+    dr = obj.reductions["spca"]
+    assert dr.cell_embeddings.shape == (len(labels), 10)
+    assert dr.feature_loadings.shape[1] == 10
+    assert np.isfinite(dr.cell_embeddings).all()
+    assert dr.misc["spca_graph"] == "identity"
+    assert (np.diff(dr.misc["eigenvalues"]) <= 1e-8).all()   # descending
+
+    find_neighbors(obj, reduction="spca", graph_name="spca")
+    assert "spca_snn" in obj.graphs
+
+
+def test_spca_is_deterministic(clustered):
+    obj, _ = clustered
+    obj.graphs["identity"] = _identity_graph(obj)
+    run_spca(obj, graph="identity", npcs=8, reduction_name="a")
+    run_spca(obj, graph="identity", npcs=8, reduction_name="b")
+    np.testing.assert_allclose(
+        obj.reductions["a"].cell_embeddings, obj.reductions["b"].cell_embeddings)
+
+
+def test_spca_without_a_graph_raises(clustered):
+    obj, _ = clustered
+    with pytest.raises(KeyError, match="not found"):
+        run_spca(obj, graph="wsnn")
+
+
+def test_spca_with_a_wrongly_sized_graph_raises(clustered):
+    obj, _ = clustered
+    obj.graphs["small"] = Graph(
+        sp.identity(5, format="csc"),
+        cell_names=obj.cell_names()[:5], assay_used="RNA")
+    with pytest.raises(ValueError, match="cells"):
+        run_spca(obj, graph="small")
+
+
+# ---------------------------------------------------------------------------
+# glm_pca
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def counts_obj():
+    """60 cells in 3 clusters of raw Poisson counts — no normalisation at all.
+
+    ``silent`` is detected in no cell: a real thing on a panel, and the gene most
+    likely to produce a log(0) somewhere it shouldn't.
+    """
+    rng = np.random.default_rng(0)
+    n_genes, per, k = 40, 20, 3
+    n = per * k
+    lam = np.full((n_genes, n), 2.0)
+    for c in range(n):
+        cluster = c // per
+        lam[cluster * 10:(cluster + 1) * 10, c] += 10.0
+    counts = rng.poisson(lam).astype(float)
+    counts[-1, :] = 0.0                                  # the silent gene
+
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(counts),
+        assay="RNA",
+        feature_names=[f"g{i}" for i in range(n_genes - 1)] + ["silent"],
+        cell_names=[f"c{i}" for i in range(n)],
+    )
+    return obj, np.repeat(np.arange(k), per)
+
+
+def test_glmpca_recovers_clusters_from_raw_counts(counts_obj):
+    obj, labels = counts_obj
+    glm_pca(obj, n_components=3, seed=0)
+
+    dr = obj.reductions["glmpca"]
+    assert dr.cell_embeddings.shape == (len(labels), 3)
+    assert np.isfinite(dr.cell_embeddings).all()
+    assert _silhouette(dr.cell_embeddings, labels) > 0.5
+
+
+def test_glmpca_deviance_only_ever_falls(counts_obj):
+    """Backtracking rejects any step that doesn't improve the fit."""
+    obj, _ = counts_obj
+    glm_pca(obj, n_components=3, seed=0)
+
+    deviance = obj.reductions["glmpca"].misc["deviance"]
+    assert len(deviance) > 1
+    assert (np.diff(deviance) <= 0).all()
+    assert np.isfinite(deviance).all()
+
+
+def test_glmpca_actually_fits_rather_than_stalling(counts_obj):
+    """The saddle guard: U = V = 0 is stationary, so a fit started there goes
+    nowhere while *looking* converged — the factors still orient themselves on the
+    first step, so clusters show up in a plot even though the deviance has barely
+    moved off its null value. Insist the fit does real work.
+    """
+    obj, _ = counts_obj
+    glm_pca(obj, n_components=3, seed=0)
+    dr = obj.reductions["glmpca"]
+
+    deviance = dr.misc["deviance"]
+    assert len(deviance) > 5                      # not "converged" on step one
+    assert deviance[-1] < 0.9 * deviance[0]       # and the counts are better explained
+    assert dr.misc["converged"]
+
+
+def test_glmpca_survives_a_gene_detected_in_no_cell(counts_obj):
+    """log(0) is the obvious way to blow this up; the intercept floors instead."""
+    obj, _ = counts_obj
+    glm_pca(obj, n_components=3, seed=0)
+
+    dr = obj.reductions["glmpca"]
+    assert np.isfinite(dr.feature_loadings).all()
+    names = dr.features()
+    silent = names.index("silent")
+    others = [i for i in range(len(names)) if i != silent]
+    # With no counts there is no information, so the ridge pulls it to zero: the
+    # silent gene must not end up as a driver of any component.
+    silent_weight = np.abs(dr.feature_loadings[silent]).max()
+    assert silent_weight < np.abs(dr.feature_loadings[others]).max()
+    assert silent_weight < 1e-3
+
+
+def test_glmpca_is_deterministic(counts_obj):
+    obj, _ = counts_obj
+    glm_pca(obj, n_components=3, seed=7, reduction_name="a")
+    glm_pca(obj, n_components=3, seed=7, reduction_name="b")
+    np.testing.assert_allclose(
+        obj.reductions["a"].cell_embeddings, obj.reductions["b"].cell_embeddings)
+
+
+def test_glmpca_embeddings_feed_downstream_steps(counts_obj):
+    obj, _ = counts_obj
+    glm_pca(obj, n_components=3, seed=0)
+    find_neighbors(obj, reduction="glmpca", graph_name="glmpca")
+    assert "glmpca_snn" in obj.graphs
+
+
+def test_glmpca_rejects_an_unknown_family(counts_obj):
+    obj, _ = counts_obj
+    with pytest.raises(NotImplementedError, match="not implemented"):
+        glm_pca(obj, family="nb")
+
+
+def test_glmpca_rejects_a_cell_with_no_counts():
+    counts = np.ones((5, 4))
+    counts[:, 2] = 0.0                                   # an empty droplet
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(counts), assay="RNA",
+        feature_names=[f"g{i}" for i in range(5)],
+        cell_names=[f"c{i}" for i in range(4)],
+    )
+    with pytest.raises(ValueError, match="zero total counts"):
+        glm_pca(obj, n_components=2)
+
+
+# --- the pieces, on their own ---------------------------------------------
+
+def test_orthogonalize_reorders_without_changing_the_fit():
+    """The rotation is exact: U·Vᵀ — all the model ever sees — is untouched."""
+    rng = np.random.default_rng(3)
+    U = rng.normal(size=(20, 4))
+    V = rng.normal(size=(15, 4))
+
+    loadings, factors = _orthogonalize(U, V)
+    np.testing.assert_allclose(loadings @ factors.T, U @ V.T, atol=1e-10)
+
+    # Loadings orthonormal; factors ordered biggest-first, as PCA readers expect.
+    np.testing.assert_allclose(loadings.T @ loadings, np.eye(4), atol=1e-10)
+    scale = np.linalg.norm(factors, axis=0)
+    assert (np.diff(scale) <= 1e-8).all()
+
+
+def test_poisson_deviance_is_zero_for_a_perfect_fit():
+    Y = np.array([[0.0, 3.0], [7.0, 2.0]])
+    assert _poisson_deviance(Y, Y) == pytest.approx(0.0)     # y = 0 must not blow up
+    assert _poisson_deviance(Y, Y + 1.0) > 0.0
+
+
+def test_counts_for_rejects_negative_values():
+    """Handing GLM-PCA scaled data is the easy mistake; it should say so."""
+    scaled = np.array([[-1.2, 0.4], [0.9, -0.3]])
+
+    def getter(assay_obj, layer):
+        return scaled, ["a", "b"]
+
+    with pytest.raises(ValueError, match="negative values"):
+        _counts_for(None, ["a", "b"], "scale.data", getter)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -247,6 +247,8 @@ same caveat as the other tutorials.
 | HVGs | `FindVariableFeatures(pbmc, selection.method, nfeatures)` | `find_variable_features(pbmc, selection_method, nfeatures)` |
 | Scale | `ScaleData(pbmc, features)` | `scale_data(pbmc, features)` |
 | PCA | `RunPCA(pbmc, features, npcs)` | `run_pca(pbmc, features, n_pcs)` |
+| Supervised PCA | `RunSPCA(pbmc, graph="wsnn")` | `run_spca(pbmc, graph="wsnn")` |
+| GLM-PCA | `RunGLMPCA(pbmc, L=10)` | `glm_pca(pbmc, n_components=10)` — Poisson only; `family="nb"` not yet implemented |
 | Neighbors | `FindNeighbors(pbmc, dims)` | `find_neighbors(pbmc, dims, k_param)` |
 | Cluster | `FindClusters(pbmc, resolution)` | `find_clusters(pbmc, resolution, algorithm)` |
 | UMAP | `RunUMAP(pbmc, dims)` | `run_umap(pbmc, dims)` |
@@ -264,6 +266,49 @@ same caveat as the other tutorials.
 | Access metadata | `pbmc@meta.data` | `pbmc.meta_data` |
 | Access assay | `pbmc[["RNA"]]` | `pbmc.assays["RNA"]` |
 | Active idents | `Idents(pbmc)` | `pbmc.idents` |
+
+### Beyond PCA — supervised PCA and GLM-PCA
+
+Two reductions that answer questions PCA cannot. Both store a `DimReduc` exactly
+as `run_pca` does, so `find_neighbors`, `find_clusters` and `run_umap` take them
+with a `reduction=` argument and nothing else changes.
+
+```python
+from shanuz import run_spca, glm_pca, find_neighbors, run_umap
+
+# Supervised PCA: the gene axes that best explain a graph you already trust.
+find_multi_modal_neighbors(cbmc, reduction_list=["pca", "apca"])   # builds "wsnn"
+run_spca(cbmc, graph="wsnn", npcs=50)
+run_umap(cbmc, reduction="spca", dims=range(30))
+
+# GLM-PCA: a Poisson fit straight on the raw counts — no log, no pseudocount.
+glm_pca(pbmc, n_components=10)
+find_neighbors(pbmc, reduction="glmpca", dims=range(10))
+print(pbmc.reductions["glmpca"].misc["converged"])
+```
+
+**`run_spca`** maximises `vᵀXᵀGXv` where PCA maximises `vᵀXᵀXv` — the same problem
+with the identity swapped for a cell-cell graph `G`. So it finds the gene
+directions that reproduce a neighbourhood structure you have already decided is
+the right one (typically the WNN graph, which knows about protein as well as RNA).
+Hand it `G = I` and you get PCA back exactly. Its value is that the result is a
+plain linear map from genes to components, so a query dataset can be projected
+into a reference's space with one matrix multiply — which is why Azimuth maps onto
+sPCA and not PCA.
+
+**`glm_pca`** models counts as counts. The standard pipeline log-normalises and
+then runs PCA, which quietly assumes constant-variance Gaussian data; a gene
+averaging 0.1 UMIs and one averaging 100 do not have remotely comparable noise,
+and the pseudocount you add to survive `log(0)` distorts exactly the
+low-expression genes where most of the zeros are. GLM-PCA drops the transform and
+fits `log μ = a[g] + o[c] + U·Vᵀ` with a Poisson likelihood, holding the log
+library size as a fixed offset so sequencing depth is a known quantity rather than
+something the factors have to spend themselves discovering.
+
+> Two things to know. `glm_pca` is **Poisson only** — `family="nb"` raises. And it
+> fits densely in genes × cells, so pass a few thousand variable features, as you
+> would to `run_pca`. Check `misc["converged"]`; if it is `False`, or
+> `misc["deviance"]` is still falling steeply at the end, raise `max_iter`.
 
 ### Pseudobulk & conserved markers
 


### PR DESCRIPTION
Adds the two reductions left open in v0.5.0. `run_tsne` and `run_ica` shipped earlier; these close the milestone.

Both store a `DimReduc` exactly as `run_pca` does, so `find_neighbors`, `find_clusters` and `run_umap` accept them via `reduction=` with no other change.

## `run_spca` — supervised PCA

PCA maximises `vᵀXᵀXv` and knows nothing about which cells you consider neighbours. sPCA swaps the identity for a cell-cell graph you already trust and maximises `vᵀXᵀGXv` — the gene axes that best reproduce that graph, typically the WNN graph, which knows about protein as well as RNA.

The payoff is that the result is a plain linear map from genes to components, so a query dataset can be pushed into a reference's graph-defined space with one matrix multiply. That is why Azimuth maps onto sPCA rather than PCA, and it is the reduction v0.3.0's reference mapping will want.

**The ROADMAP plan for this described the wrong algorithm** — a gene-graph Laplacian smoothing a gene × gene matrix. Seurat's `RunSPCA` takes a **cell × cell** graph (`RunSPCA(reference, assay = "SCT", graph = "wsnn")`) and eigendecomposes `XᵀGX`, which is features × features. Implemented as Seurat actually does it; the roadmap text is corrected in this PR.

The sharpest test falls straight out of the algebra: set `G = I` and the objective collapses back to PCA's, so the loadings must match `run_pca`'s. They do, to a cosine > 0.999.

One deliberate departure: Seurat runs `irlba` (an SVD) on `XᵀGX`, ranking by `|λ|`; we take the largest eigenvalues themselves, since `vᵀXᵀGXv` is what is being maximised and a graph can push eigenvalues negative. With non-negative edge weights the leading eigenvalues are positive, so the orderings differ only in the tail.

## `glm_pca` — Poisson GLM-PCA on raw counts

Log-normalise-then-PCA quietly assumes the transformed counts are Gaussian with constant variance. They are not — a gene averaging 0.1 UMIs and one averaging 100 have nothing like comparable noise — and the pseudocount needed to survive `log(0)` distorts exactly the low-expression genes where most of the zeros live.

GLM-PCA drops the transform and fits on the count scale:

```
Y[g,c] ~ Poisson(μ[g,c])
log μ[g,c] = a[g] + o[c] + Σ_l U[g,l]·V[c,l]
```

`o` is the log library size held as a **fixed** offset, so sequencing depth is a known quantity rather than something the factors must spend themselves rediscovering. Fitted by Fisher scoring, alternating intercept → loadings → factors; each block gets a diagonal Newton step (score ÷ Fisher information), which under a log link and Poisson noise is one matrix product each. Any step that fails to lower the deviance is rejected and retried at half the step size, so the deviance falls monotonically by construction.

Pure NumPy/SciPy, following the precedent set by MAST and bimod — **no `glmpca-py` dependency**, and the roadmap's dependency budget for v0.5.0 drops to none.

### The initialisation is load-bearing, and the first version was silently broken

`U = V = 0` is an **exact saddle** of the log-likelihood: each block's score is a product with the other, so at zero both vanish. Seeding both near zero — the obvious choice, and `glmpca`'s own default — leaves the fit inching away from the saddle, the deviance barely moves on the first step, and a relative-improvement stopping rule declares convergence on a model that has fitted nothing.

It fails *convincingly*, which is the dangerous part. A single step is enough to orient the factors, and silhouette is scale-invariant, so clusters separated cleanly in the embedding while the deviance sat at its null value: **9744.95 → 9744.92 over one accepted iteration**, with `U` still at its 1e-4 random init. The cluster test passed. It would have merged green and useless.

Factors are now seeded from the SVD of the intercept-only model's residuals, as Townes recommends. The same fit now runs 3419 → 2227 over ~85 real iterations. `test_glmpca_actually_fits_rather_than_stalling` is the regression guard: it insists the fit both takes real iterations and materially improves, either of which the stalled version failed.

### Scope

Poisson only. `family="nb"` raises `NotImplementedError`, following the dispatch pattern `find_spatially_variable_features` used before markvariogram filled it in. Poisson understates the overdispersion in most scRNA-seq, so NB is the natural follow-up — it needs a dispersion parameter estimated alongside the factors. Noted in ROADMAP.

The fit is dense in genes × cells, so it wants a few thousand variable features, as `run_pca` does. Documented.

## Test notes

17 new tests in `tests/test_spca_glmpca.py`; suite goes **246 → 263**, all passing on 3.10/3.11/3.12.

The sPCA supervision test needed a fixture fix worth recording, because it is a trap this repo has hit before. My two cell groups initially differed in *total* RNA, so `normalize_data` divided the grouping back out and smeared it across every gene — including the high-variance nuisance genes, which then dragged their own variance onto the axis sPCA returns. It is the same compositional-normalisation leak already documented for Moran's I in `find_spatially_variable_features`. Making the grouping library-size neutral (15 genes up in each group — cell types differ in *which* genes are on, not in how much RNA they hold) took the result from sPCA 0.59 / PCA 0.51 to **sPCA 0.80 / PCA −0.004**: sPCA recovers a grouping PCA is at pure chance on, which is the whole claim.

## Incidental

- Extracts `_default_features`, the variable-feature fallback that `run_pca` and `run_ica` were each duplicating and `run_spca` would have made a third copy of.
- Drops two pre-existing dead bindings in `reduction.py` (an unused `explained` and an unused `Assay` import), leaving the file ruff-clean. `main` had 3 ruff errors there; this branch has 0.

## Docs

- `README.md` — reduction bullet and the v0.5.0 milestone row (now complete)
- `ROADMAP.md` — v0.5.0 marked complete, the mis-scoped `run_spca` plan corrected, dependency budget updated to none, priority list item added
- `tutorials/README.md` — two mapping-table rows plus a new "Beyond PCA" section with a runnable snippet, verified end-to-end before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)