### PR TITLE
Add CCA/RPCA anchor integration (IntegrateData / IntegrateLayers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **SCTransform** — `sctransform` (regularized negative-binomial Pearson residuals)
 - **Signature scoring** — `add_module_score`, `cell_cycle_scoring` (S/G2M + Phase)
 - **Dimensionality reduction** — `run_pca`, `run_spca` (supervised, off a cell graph), `run_ica`, `run_tsne`, `glm_pca` (Poisson or negative binomial, straight on counts)
-- **Batch correction / integration** — `run_harmony`, `integrate_layers` (via harmonypy)
+- **Batch correction / integration** — `run_harmony` (via harmonypy), CCA/RPCA anchors (`find_integration_anchors` + `integrate_data`), and the `integrate_layers` dispatcher (`method="harmony"|"cca"|"rpca"`)
 - **Nearest-neighbour graph** — `find_neighbors` (KNN + SNN)
 - **Multimodal WNN** — `find_multi_modal_neighbors` (per-cell RNA/protein weights, joint `wknn`/`wsnn` graphs)
 - **Clustering** — `find_clusters` (Louvain via python-igraph, Leiden via leidenalg)
@@ -288,7 +288,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 
 | Milestone | Focus |
 |-----------|-------|
-| v0.2.0 | Batch correction — Harmony + `IntegrateLayers` ✅ *(delivered)*; remaining: CCA/RPCA anchors |
+| v0.2.0 | Batch correction — Harmony, CCA/RPCA anchors, `IntegrateLayers` dispatcher ✅ *(complete)* |
 | v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData`, `MapQuery` |
 | v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(delivered — see Tutorial 3)* |
 | v0.5.0 | Additional reductions — t-SNE, ICA, `run_spca`, `glm_pca` (Poisson + negative binomial) ✅ *(complete)* |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,11 +15,15 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 
 ---
 
-## v0.2.0 — Batch Correction & Integration
+## v0.2.0 — Batch Correction & Integration — ✅ complete
 
 > **Why first:** batch effects are unavoidable in real datasets; Harmony is the
 > most widely-used, has a pip-installable Python package, and has a well-defined
 > scope. CCA/RPCA follow naturally.
+>
+> **Status:** all three integration paths delivered — Harmony (`run_harmony`),
+> CCA/RPCA anchors (`find_integration_anchors` / `integrate_data`), and the
+> `integrate_layers` dispatcher (`method="harmony"|"cca"|"rpca"`).
 
 ### Harmony integration — ✅ delivered
 - Implemented in `shanuz/integration.py` as `run_harmony(...)`; stores a
@@ -35,22 +39,33 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
   4. Downstream: pass `reduction="harmony"` to `find_neighbors` / `run_umap`
 - **Tests:** corrected embeddings have lower silhouette separation by batch than raw PCA
 
-### CCA / RPCA integration (`IntegrateData` v4 API)
+### CCA / RPCA integration (`IntegrateData` v4 API) — ✅ delivered
+- Implemented in `shanuz/anchors.py` as `find_integration_anchors(...)` +
+  `integrate_data(...)`, with the `IntegrationAnchors` result container. Anchors
+  are mutual nearest neighbours in a shared CCA (SVD of the cross-covariance
+  `AᵀB`) or reciprocal-PCA space, scored by neighbourhood consistency and
+  filtered against the raw expression space; `integrate_data` corrects each
+  query onto the reference with a Gaussian-weighted sum of anchor correction
+  vectors and returns a merged object carrying an active `"integrated"` assay.
+  Verified (`tests/test_integration.py`) to cluster by cell type, not batch.
 - **R:** `FindIntegrationAnchors(list, reduction="cca")` → `IntegrateData(anchors)`
-- **Plan:**
-  1. `find_integration_anchors(objects, dims, reduction, k_anchor, k_filter)` → `IntegrationAnchors`
-  2. `integrate_data(anchors, dims)` → corrected `"integrated"` assay on merged object
-  3. CCA: `scipy.linalg.svd` on cross-covariance; RPCA: project each dataset into
-     shared PCA space, find mutual nearest neighbours (MNN) via `sklearn.neighbors`
-- **Tests:** integrated embedding clusters by cell type, not by batch
+- **Implemented:**
+  1. `find_integration_anchors(objects, reduction, dims, k_anchor, k_filter, k_score, reference)` → `IntegrationAnchors`
+  2. `integrate_data(anchors, new_assay, k_weight, sd_weight)` → corrected `"integrated"` assay on merged object
+  3. CCA: `numpy.linalg.svd` on the cross-covariance; RPCA: reciprocal PCA
+     projections, MNN via `sklearn.neighbors`
+- **Note:** *reference-based* — anchors link each dataset to `reference=0`, and
+  every other dataset is corrected onto it (one of Seurat's supported modes).
+  A full guide-tree over all pairwise anchors is a later refinement.
+- **Reuse:** the same `IntegrationAnchors` object is what v0.3.0's reference
+  mapping (`FindTransferAnchors` / `TransferData`) is built to consume.
 
-### `IntegrateLayers` (Seurat v5 API) — ✅ harmony method delivered
-- Implemented as `integrate_layers(obj, method="harmony", group_by=...)` in
-  `shanuz/integration.py`. The `"cca"` / `"rpca"` methods raise
-  `NotImplementedError` pending the CCA/RPCA anchor work above.
+### `IntegrateLayers` (Seurat v5 API) — ✅ delivered (harmony + cca + rpca)
+- Implemented as `integrate_layers(obj, method=..., group_by=...)` in
+  `shanuz/integration.py`. `method="harmony"` corrects an existing reduction;
+  `method="cca"` / `"rpca"` split the object by `group_by`, run the anchor
+  pipeline above, and store the batch-corrected embedding as a new reduction.
 - **R:** `IntegrateLayers(obj, method = HarmonyIntegration, orig.reduction = "pca")`
-- **Plan:** thin dispatch wrapper over the individual integration functions above;
-  accepts `method` kwarg (`"harmony"`, `"cca"`, `"rpca"`)
 - **Dep:** Harmony and CCA/RPCA functions above
 
 ---
@@ -504,7 +519,7 @@ If milestones are too large, these are the highest-value individual items:
 1. ~~**Harmony** (`v0.2.0`)~~ — ✅ delivered (`run_harmony` / `integrate_layers`)
 2. ~~**WNN** (`v0.4.0`)~~ — ✅ delivered (`find_multi_modal_neighbors` + `run_umap(graph=)`); CBMC tutorial section still open
 3. ~~**GitHub Actions CI** (`v0.10.0`)~~ — ✅ delivered
-4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — enables atlas-based annotation (next-cycle candidate; needs CCA/RPCA first). `run_spca` is now in place, which is the reduction Azimuth maps onto.
+4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — enables atlas-based annotation (next-cycle candidate). CCA/RPCA anchors are now in place (`shanuz/anchors.py`, with a reusable `IntegrationAnchors`), as is `run_spca` — the reduction Azimuth maps onto. This is now unblocked.
 5. ~~**`FindSpatiallyVariableFeatures`** + **`SpatialFeaturePlot`**~~ ✅ (`v0.7.0`) — all four loaders, niche/neighbourhood analysis, both spatially-variable-feature methods (Moran's I and markvariogram), the `VisiumV2` tissue-image data layer and the `spatial_*` H&E plots delivered; **v0.7.0 is complete**
 6. ~~**`AggregateExpression` + DESeq2**~~ ✅ (`v0.6.0`) — `aggregate_expression`,
    `find_conserved_markers`, and pseudobulk DESeq2 (`test_use="deseq2"`) delivered;

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -23,6 +23,11 @@ from .multimodal import find_multi_modal_neighbors
 from .clustering import find_clusters
 from .umap import run_umap
 from .integration import run_harmony, integrate_layers
+from .anchors import (
+    find_integration_anchors,
+    integrate_data,
+    IntegrationAnchors,
+)
 from .markers import find_markers, find_all_markers, find_conserved_markers
 from .aggregate import aggregate_expression
 from .sctransform import sctransform
@@ -135,6 +140,9 @@ __all__ = [
     "run_umap",
     "run_harmony",
     "integrate_layers",
+    "find_integration_anchors",
+    "integrate_data",
+    "IntegrationAnchors",
     "find_markers",
     "find_all_markers",
     "find_conserved_markers",

--- a/shanuz/anchors.py
+++ b/shanuz/anchors.py
@@ -1,0 +1,535 @@
+"""Anchor-based dataset integration (Seurat's CCA / RPCA ``IntegrateData``).
+
+Harmony (``integration.py``) corrects an *existing* joint embedding. The
+anchor approach of Stuart et al. (2019) works the other way round: it never
+assumes the datasets share a coordinate system to begin with. Instead it
+
+  1. builds a *shared* low-dimensional space for a pair of datasets — either by
+     **canonical correlation analysis** (``reduction="cca"``: the SVD of the
+     cross-covariance ``AᵀB``, whose singular vectors are the directions along
+     which the two datasets co-vary most strongly) or by **reciprocal PCA**
+     (``reduction="rpca"``: project each dataset into the *other's* PCA space);
+  2. finds **mutual nearest neighbours** in that space — cell *i* of dataset A
+     and cell *j* of dataset B are an *anchor* only if each is among the other's
+     k nearest neighbours. A mutual pair is evidence the two cells are the same
+     biological state seen in two batches;
+  3. **scores** every anchor by how much of its neighbourhood the two members
+     share (a consistent anchor sits in a coherent local structure) and
+     **filters** ones that are not even near each other in the original
+     expression space;
+  4. **corrects** each query dataset onto the reference by adding, to every
+     query cell, a distance-weighted average of the anchor *correction vectors*
+     ``expr_ref − expr_query`` — pulling matched populations on top of each
+     other while leaving genuinely reference-only structure alone.
+
+The output of :func:`integrate_data` is a merged object carrying an
+``"integrated"`` assay whose ``data`` is the batch-corrected expression of the
+anchor features — exactly what you then ``scale_data`` + ``run_pca`` on to get
+an embedding that clusters by cell type rather than by batch.
+
+Only the anchor pairs and the reference-facing bookkeeping are Seurat-specific;
+the same :class:`IntegrationAnchors` object is what v0.3.0's reference mapping
+(``FindTransferAnchors`` / ``TransferData``) is built to reuse.
+
+This is a *reference-based* implementation: anchors are found between the
+reference (``reference=0`` by default) and each other dataset, and every other
+dataset is corrected onto the reference. That is one of Seurat's supported
+integration modes and keeps the guide-tree bookkeeping out of the first cut.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+REDUCTIONS = ("cca", "rpca")
+
+
+# ----------------------------------------------------------------------
+# Result container
+# ----------------------------------------------------------------------
+
+
+class IntegrationAnchors:
+    """Anchors linking a reference dataset to one or more query datasets.
+
+    Slots
+    -----
+    anchors         : DataFrame with columns ``dataset1, cell1, dataset2,
+                      cell2, score``. ``dataset1`` is always the reference; the
+                      cell columns hold *within-dataset* 0-based row indices.
+    objects         : the list of Shanuz objects passed to
+                      :func:`find_integration_anchors` (order preserved).
+    reference       : index into ``objects`` of the reference dataset.
+    reduction       : ``"cca"`` or ``"rpca"`` — how the shared space was built.
+    anchor_features : the features the anchors (and correction) run on.
+    dims            : number of shared dimensions used.
+    weight_embeddings : ``{query_index: (n_query_cells × dims) array}`` — each
+                      query dataset's cells in the shared space, used by
+                      :func:`integrate_data` to weight the correction.
+    """
+
+    __slots__ = (
+        "anchors",
+        "objects",
+        "reference",
+        "reduction",
+        "anchor_features",
+        "dims",
+        "weight_embeddings",
+    )
+
+    def __init__(
+        self,
+        anchors: pd.DataFrame,
+        objects: list,
+        reference: int,
+        reduction: str,
+        anchor_features: list[str],
+        dims: int,
+        weight_embeddings: dict[int, np.ndarray],
+    ) -> None:
+        self.anchors = anchors
+        self.objects = objects
+        self.reference = reference
+        self.reduction = reduction
+        self.anchor_features = list(anchor_features)
+        self.dims = dims
+        self.weight_embeddings = weight_embeddings
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return (
+            f"IntegrationAnchors: {len(self.anchors)} anchors across "
+            f"{len(self.objects)} datasets\n"
+            f"  reduction={self.reduction!r}  reference={self.reference}  "
+            f"dims={self.dims}  features={len(self.anchor_features)}"
+        )
+
+
+# ----------------------------------------------------------------------
+# Linear algebra helpers
+# ----------------------------------------------------------------------
+
+
+def _l2_normalize_rows(mat: np.ndarray) -> np.ndarray:
+    """L2-normalize each row of ``mat`` (a per-cell embedding)."""
+    norms = np.linalg.norm(mat, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return mat / norms
+
+
+def _l2_normalize_cols(mat: np.ndarray) -> np.ndarray:
+    """L2-normalize each column of ``mat`` (features × cells → per-cell unit)."""
+    norms = np.linalg.norm(mat, axis=0, keepdims=True)
+    norms[norms == 0] = 1.0
+    return mat / norms
+
+
+def _cca(A: np.ndarray, B: np.ndarray, dims: int) -> tuple[np.ndarray, np.ndarray]:
+    """Shared CCA embedding of two datasets.
+
+    ``A`` (features × cells_a) and ``B`` (features × cells_b) are L2-normalized
+    per cell. The SVD of the cross-covariance ``AᵀB`` (cells_a × cells_b) yields
+    left/right singular vectors that place the two datasets' cells in one space;
+    each cell's coordinates are then L2-normalized (Seurat's ``L2Dim``).
+    """
+    cross = A.T @ B
+    U, _s, Vt = np.linalg.svd(cross, full_matrices=False)
+    d = min(dims, U.shape[1])
+    emb_a = _l2_normalize_rows(U[:, :d])
+    emb_b = _l2_normalize_rows(Vt[:d, :].T)
+    return emb_a, emb_b
+
+
+def _pca_loadings(mat: np.ndarray, dims: int, seed: int = 42) -> np.ndarray:
+    """Top-``dims`` PCA loadings (features × dims) of a features × cells matrix."""
+    from sklearn.decomposition import PCA
+
+    d = min(dims, min(mat.shape) - 1)
+    pca = PCA(n_components=max(d, 1), random_state=seed)
+    pca.fit(mat.T)  # samples (cells) × features
+    return pca.components_.T  # features × dims
+
+
+# ----------------------------------------------------------------------
+# Neighbours / MNN
+# ----------------------------------------------------------------------
+
+
+def _nearest(query: np.ndarray, reference: np.ndarray, k: int) -> np.ndarray:
+    """For each row of ``query``, the indices of its ``k`` nearest ``reference`` rows."""
+    from sklearn.neighbors import NearestNeighbors
+
+    k = min(k, reference.shape[0])
+    nn = NearestNeighbors(n_neighbors=k).fit(reference)
+    return nn.kneighbors(query, return_distance=False)
+
+
+def _mutual_nn(
+    emb_a_for_b: np.ndarray,
+    emb_b_for_b: np.ndarray,
+    emb_b_for_a: np.ndarray,
+    emb_a_for_a: np.ndarray,
+    k: int,
+) -> list[tuple[int, int]]:
+    """Mutual nearest neighbours between datasets A and B.
+
+    ``emb_*_for_b`` are the coordinates used to find *B*-cells around each
+    *A*-cell (i.e. both datasets expressed in the space where B lives), and
+    ``emb_*_for_a`` the reverse. For CCA the two spaces coincide; for RPCA they
+    are the two reciprocal PCA projections.
+    """
+    a_to_b = _nearest(emb_a_for_b, emb_b_for_b, k)  # A-cell → nearby B-cells
+    b_to_a = _nearest(emb_b_for_a, emb_a_for_a, k)  # B-cell → nearby A-cells
+    b_sets = [set(row) for row in b_to_a]
+    pairs = []
+    for i, neigh in enumerate(a_to_b):
+        for j in neigh:
+            if i in b_sets[j]:
+                pairs.append((int(i), int(j)))
+    return pairs
+
+
+# ----------------------------------------------------------------------
+# Scoring & filtering
+# ----------------------------------------------------------------------
+
+
+def _score_anchors(
+    pairs: list[tuple[int, int]],
+    combined: np.ndarray,
+    n_a: int,
+    k_score: int,
+) -> np.ndarray:
+    """Shared-neighbourhood score in [0, 1] for each anchor.
+
+    ``combined`` stacks the two datasets ([A; B]) in a common space. An anchor
+    ``(i, j)`` scores high when the reference cell ``i`` and query cell
+    ``j = n_a + j`` share many of their ``k_score`` nearest neighbours — i.e.
+    the anchor sits in locally consistent structure. Scores are rescaled to
+    [0, 1] with Seurat's 1st/90th-percentile clamp.
+    """
+    if not pairs:
+        return np.array([])
+    knn = _nearest(combined, combined, min(k_score, combined.shape[0]))
+    neigh_sets = [set(row) for row in knn]
+    raw = np.empty(len(pairs))
+    for m, (i, j) in enumerate(pairs):
+        raw[m] = len(neigh_sets[i] & neigh_sets[n_a + j])
+    lo, hi = np.quantile(raw, 0.01), np.quantile(raw, 0.90)
+    if hi <= lo:
+        return np.ones_like(raw)
+    return np.clip((raw - lo) / (hi - lo), 0.0, 1.0)
+
+
+def _filter_anchors(
+    pairs: list[tuple[int, int]],
+    scores: np.ndarray,
+    A_feat: np.ndarray,
+    B_feat: np.ndarray,
+    k_filter: int,
+) -> tuple[list[tuple[int, int]], np.ndarray]:
+    """Drop anchors whose cells are not neighbours in the original feature space.
+
+    ``A_feat`` / ``B_feat`` are the L2-normalized (features × cells) anchor
+    matrices. An anchor ``(i, j)`` survives only if query cell ``j`` is among
+    reference cell ``i``'s ``k_filter`` nearest neighbours in expression space.
+    """
+    if not pairs:
+        return pairs, scores
+    keep_neigh = _nearest(A_feat.T, B_feat.T, min(k_filter, B_feat.shape[1]))
+    allowed = [set(row) for row in keep_neigh]
+    kept, kept_scores = [], []
+    for m, (i, j) in enumerate(pairs):
+        if j in allowed[i]:
+            kept.append((i, j))
+            kept_scores.append(scores[m])
+    return kept, np.asarray(kept_scores)
+
+
+# ----------------------------------------------------------------------
+# Data extraction
+# ----------------------------------------------------------------------
+
+
+def _anchor_feature_matrix(obj, features: list[str], layer: str) -> np.ndarray:
+    """Scaled (features × cells) matrix for the shared anchor features."""
+    from .reduction import _get_scaled_data
+
+    assay = obj.get_assay()
+    return _get_scaled_data(assay, features, layer)
+
+
+def _data_matrix(obj, features: list[str]) -> np.ndarray:
+    """Log-normalized ``data`` (features × cells) for the given features.
+
+    Uses ``layer_data`` so the rows come back in ``features`` order regardless
+    of how the assay stores its layer (a v5 layer may hold its own subset).
+    """
+    import scipy.sparse as sp
+
+    mat = obj.get_assay().layer_data("data", features=list(features))
+    if sp.issparse(mat):
+        return mat.toarray().astype(float)
+    return np.asarray(mat).astype(float)
+
+
+def _integration_features(objects, anchor_features: Optional[list[str]]) -> list[str]:
+    """The features anchors run on: the caller's, else shared variable features."""
+    from .reduction import _default_features
+
+    if anchor_features is not None:
+        common = anchor_features
+    else:
+        per_object = [set(_default_features(obj.get_assay(), None)) for obj in objects]
+        shared = set.intersection(*per_object) if per_object else set()
+        # Preserve the first object's ordering for determinism.
+        first = _default_features(objects[0].get_assay(), None)
+        common = [f for f in first if f in shared]
+        if not common:  # fall back to the shared raw feature set
+            feat_sets = [set(obj.get_assay().features()) for obj in objects]
+            shared_all = set.intersection(*feat_sets)
+            common = [f for f in objects[0].get_assay().features() if f in shared_all]
+    # Keep only features present (with scale/data) in every object.
+    for obj in objects:
+        present = set(obj.get_assay().features())
+        common = [f for f in common if f in present]
+    if not common:
+        raise ValueError("No shared anchor features across the objects.")
+    return list(common)
+
+
+# ----------------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------------
+
+
+def find_integration_anchors(
+    objects: list,
+    anchor_features: Optional[list[str]] = None,
+    reduction: str = "cca",
+    dims: int = 30,
+    k_anchor: int = 5,
+    k_filter: int = 200,
+    k_score: int = 30,
+    reference: int = 0,
+    layer: str = "scale.data",
+    seed: int = 42,
+) -> IntegrationAnchors:
+    """Find anchors linking each dataset to the reference (Seurat's ``FindIntegrationAnchors``).
+
+    Mirrors ``FindIntegrationAnchors(object.list, reduction = "cca")``. Anchors
+    are mutual nearest neighbours in a shared CCA (or reciprocal-PCA) space,
+    scored by neighbourhood consistency and filtered against the original
+    expression space.
+
+    Parameters
+    ----------
+    objects         : list of Shanuz objects (each normalized + with variable
+                      features / scaled data). ``objects[reference]`` is treated
+                      as the reference every other dataset is anchored to.
+    anchor_features : features to integrate on (default: variable features
+                      shared across all objects).
+    reduction       : ``"cca"`` or ``"rpca"``.
+    dims            : number of shared dimensions to use.
+    k_anchor        : neighbours for the mutual-nearest-neighbour search.
+    k_filter        : neighbourhood size for the feature-space anchor filter
+                      (set to 0 or None to skip filtering).
+    k_score         : neighbourhood size for anchor scoring.
+    reference       : index of the reference dataset in ``objects``.
+    layer           : layer to draw the shared-space expression from.
+    seed            : random seed for the PCA/neighbour steps.
+
+    Returns
+    -------
+    IntegrationAnchors
+    """
+    reduction = reduction.lower()
+    if reduction not in REDUCTIONS:
+        raise ValueError(
+            f"Unknown reduction {reduction!r}. Supported: {REDUCTIONS}."
+        )
+    if len(objects) < 2:
+        raise ValueError("find_integration_anchors needs at least two objects.")
+    if not 0 <= reference < len(objects):
+        raise IndexError(f"reference index {reference} out of range.")
+
+    features = _integration_features(objects, anchor_features)
+
+    ref_scaled = _l2_normalize_cols(
+        _anchor_feature_matrix(objects[reference], features, layer)
+    )
+
+    rows = []
+    weight_embeddings: dict[int, np.ndarray] = {}
+    used_dims = min(dims, ref_scaled.shape[1] - 1, ref_scaled.shape[0])
+
+    for d in range(len(objects)):
+        if d == reference:
+            continue
+        query_scaled = _l2_normalize_cols(
+            _anchor_feature_matrix(objects[d], features, layer)
+        )
+        used = min(used_dims, query_scaled.shape[1] - 1)
+
+        if reduction == "cca":
+            emb_ref, emb_query = _cca(ref_scaled, query_scaled, used)
+            pairs = _mutual_nn(
+                emb_ref, emb_query, emb_query, emb_ref, k_anchor
+            )
+            combined = np.vstack([emb_ref, emb_query])
+            weight_emb = emb_query
+        else:  # rpca — reciprocal PCA projections
+            load_ref = _pca_loadings(ref_scaled, used, seed=seed)
+            load_query = _pca_loadings(query_scaled, used, seed=seed)
+            ref_in_ref = ref_scaled.T @ load_ref
+            query_in_ref = query_scaled.T @ load_ref
+            ref_in_query = ref_scaled.T @ load_query
+            query_in_query = query_scaled.T @ load_query
+            pairs = _mutual_nn(
+                ref_in_ref, query_in_ref, ref_in_query, query_in_query, k_anchor
+            )
+            combined = np.vstack([ref_in_ref, query_in_ref])
+            weight_emb = query_in_ref
+
+        n_ref = ref_scaled.shape[1]
+        scores = _score_anchors(pairs, combined, n_ref, k_score)
+        if k_filter:
+            pairs, scores = _filter_anchors(
+                pairs, scores, ref_scaled, query_scaled, k_filter
+            )
+
+        weight_embeddings[d] = weight_emb
+        for (i, j), s in zip(pairs, scores):
+            rows.append((reference, int(i), d, int(j), float(s)))
+
+    anchors = pd.DataFrame(
+        rows, columns=["dataset1", "cell1", "dataset2", "cell2", "score"]
+    )
+    return IntegrationAnchors(
+        anchors=anchors,
+        objects=objects,
+        reference=reference,
+        reduction=reduction,
+        anchor_features=features,
+        dims=used_dims,
+        weight_embeddings=weight_embeddings,
+    )
+
+
+def integrate_data(
+    anchors: IntegrationAnchors,
+    new_assay: str = "integrated",
+    k_weight: int = 100,
+    sd_weight: float = 1.0,
+    add_cell_ids: Optional[list[str]] = None,
+) -> "object":
+    """Batch-correct query datasets onto the reference (Seurat's ``IntegrateData``).
+
+    Mirrors ``IntegrateData(anchors)``. For every query dataset, each cell is
+    corrected by a distance-weighted sum of anchor correction vectors
+    (``expr_ref − expr_query``); the reference is left unchanged. The corrected
+    expression of the anchor features is stored as the ``data`` layer of a new
+    ``"integrated"`` assay on a merged object, which becomes the active assay.
+
+    Downstream: ``scale_data`` + ``run_pca`` on the integrated assay yields an
+    embedding that clusters by cell type rather than by batch.
+
+    Parameters
+    ----------
+    anchors      : an :class:`IntegrationAnchors` from
+                   :func:`find_integration_anchors`.
+    new_assay    : name for the corrected assay (default ``"integrated"``).
+    k_weight     : anchors used to weight each query cell's correction.
+    sd_weight    : bandwidth multiplier for the Gaussian anchor kernel.
+    add_cell_ids : optional per-object prefixes for the merged cell names.
+
+    Returns
+    -------
+    Shanuz
+        A merged object carrying the ``new_assay`` assay (active) alongside the
+        original assay.
+    """
+    from .assay import Assay
+
+    objects = anchors.objects
+    ref = anchors.reference
+    features = anchors.anchor_features
+
+    # Merge order: reference first, then the remaining datasets in list order.
+    order = [ref] + [d for d in range(len(objects)) if d != ref]
+    ref_obj = objects[ref]
+    others = [objects[d] for d in order[1:]]
+
+    if add_cell_ids is not None:
+        ordered_ids = [add_cell_ids[d] for d in order]
+    else:
+        ordered_ids = None
+
+    merged = ref_obj.merge(others, add_cell_ids=ordered_ids)
+
+    ref_data = _data_matrix(ref_obj, features)  # features × cells_ref (unchanged)
+    corrected_blocks = [ref_data]
+
+    for d in order[1:]:
+        query_data = _data_matrix(objects[d], features)  # features × cells_q
+        pair = anchors.anchors[anchors.anchors["dataset2"] == d]
+        weight_emb = anchors.weight_embeddings[d]
+
+        if len(pair) == 0:
+            # No anchors to this dataset — leave it uncorrected.
+            corrected_blocks.append(query_data)
+            continue
+
+        i_idx = pair["cell1"].to_numpy()
+        j_idx = pair["cell2"].to_numpy()
+        anchor_scores = pair["score"].to_numpy()
+
+        # Correction vectors in feature space: reference minus query at anchors.
+        bv = ref_data[:, i_idx] - query_data[:, j_idx]  # features × n_anchor
+
+        anchor_pos = weight_emb[j_idx]  # n_anchor × dims (query anchor cells)
+        k = min(k_weight, anchor_pos.shape[0])
+        dist = _pairwise_to_anchors(weight_emb, anchor_pos, k)
+        nn_idx = dist[1]        # cells_q × k  → indices into the anchor list
+        nn_dist = dist[0]       # cells_q × k
+
+        # Gaussian kernel over the k nearest anchors, scaled by anchor score.
+        bandwidth = nn_dist[:, -1:].copy()
+        bandwidth[bandwidth == 0] = 1.0
+        weights = np.exp(-((nn_dist / (bandwidth / sd_weight)) ** 2))
+        weights = weights * anchor_scores[nn_idx]
+        wsum = weights.sum(axis=1, keepdims=True)
+        wsum[wsum == 0] = 1.0
+        weights = weights / wsum
+
+        # correction[:, c] = Σ_k bv[:, nn_idx[c, k]] * weights[c, k]
+        contrib = bv[:, nn_idx]  # features × cells_q × k
+        correction = np.einsum("fck,ck->fc", contrib, weights)
+        corrected_blocks.append(query_data + correction)
+
+    integrated = np.hstack(corrected_blocks)  # features × total_cells
+    cell_names = merged.cell_names()
+
+    integrated_assay = Assay(
+        data=integrated,
+        feature_names=list(features),
+        cell_names=list(cell_names),
+        var_features=list(features),
+        key=f"{new_assay.lower()}_",
+    )
+    merged.assays[new_assay] = integrated_assay
+    merged.active_assay = new_assay
+    return merged
+
+
+def _pairwise_to_anchors(
+    query_emb: np.ndarray, anchor_pos: np.ndarray, k: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Distances and indices from each query cell to its ``k`` nearest anchors."""
+    from sklearn.neighbors import NearestNeighbors
+
+    nn = NearestNeighbors(n_neighbors=k).fit(anchor_pos)
+    dist, idx = nn.kneighbors(query_emb)
+    return dist, idx

--- a/shanuz/assay5.py
+++ b/shanuz/assay5.py
@@ -437,25 +437,45 @@ class StdAssay(KeyMixin, ABC):
             shared_layers &= set(a.layers)
 
         new_layers: dict = {}
+        new_layer_features: dict = {}
         for layer_name in shared_layers:
+            # A layer may span only a subset of the assay's features (e.g.
+            # scale.data holds the variable features), so index against each
+            # assay's *layer* feature names, not the assay-wide list.
+            per_assay_feats = [
+                a._layer_features.get(layer_name, a._all_feature_names)
+                for a in all_assays
+            ]
+            common = set(per_assay_feats[0])
+            for lf in per_assay_feats[1:]:
+                common &= set(lf)
+            layer_features = [f for f in per_assay_feats[0] if f in common]
+
             mats = []
-            for a in all_assays:
-                feat_idx = [a._all_feature_names.index(f) for f in shared_features]
-                mat = a.layers[layer_name][feat_idx, :]
-                mats.append(mat)
+            for a, lf in zip(all_assays, per_assay_feats):
+                pos = {f: i for i, f in enumerate(lf)}
+                feat_idx = [pos[f] for f in layer_features]
+                mats.append(a.layers[layer_name][feat_idx, :])
             if sp.issparse(mats[0]):
                 new_layers[layer_name] = sp.hstack(mats, format="csc")
             else:
                 new_layers[layer_name] = np.hstack(mats)
+            new_layer_features[layer_name] = layer_features
 
-        return self.__class__(
+        merged = self.__class__(
             layers=new_layers,
             feature_names=shared_features,
             cell_names=new_cell_names,
             assay_orig=self.assay_orig,
             misc=dict(self.misc),
             key=self._key,
+            layer_features=new_layer_features,
         )
+        # Preserve the scaled-feature bookkeeping when every input agrees.
+        scaled = new_layer_features.get("scale.data")
+        if scaled is not None:
+            merged._scaled_features = list(scaled)
+        return merged
 
     # ------------------------------------------------------------------
     # Calc nCount / nFeature

--- a/shanuz/integration.py
+++ b/shanuz/integration.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Optional, Union
 
 import numpy as np
+import pandas as pd
 
 from .dimreduc import DimReduc
 
@@ -126,13 +127,13 @@ def integrate_layers(
 
     Parameters
     ----------
-    method         : 'harmony' (only method currently implemented).
-                     'cca' / 'rpca' are planned (v0.2.0) and raise
-                     NotImplementedError for now.
-    orig_reduction : reduction to integrate (default 'pca')
+    method         : 'harmony', 'cca', or 'rpca'.
+    orig_reduction : reduction to integrate (only used by 'harmony';
+                     default 'pca')
     new_reduction  : storage key for the integrated reduction
                      (defaults to '{method}')
-    group_by       : batch column(s); required for 'harmony'
+    group_by       : batch column identifying the layers/batches to integrate
+                     (required for every method)
     """
     method = method.lower()
     new_reduction = new_reduction or method
@@ -149,12 +150,88 @@ def integrate_layers(
             **kwargs,
         )
     elif method in ("cca", "rpca", "ccaintegration", "rpcaintegration"):
-        raise NotImplementedError(
-            f"method={method!r} (CCA/RPCA anchor integration) is on the "
-            "v0.2.0 roadmap and not yet implemented. Use method='harmony'."
+        if group_by is None:
+            raise ValueError(
+                f"method={method!r} requires group_by (batch column)."
+            )
+        reduction = "rpca" if method.startswith("rpca") else "cca"
+        _integrate_anchor_reduction(
+            seurat,
+            group_by=group_by,
+            reduction=reduction,
+            new_reduction=new_reduction,
+            assay=assay,
+            **kwargs,
         )
     else:
         raise ValueError(
             f"Unknown integration method {method!r}. "
-            "Supported: 'harmony' (also planned: 'cca', 'rpca')."
+            "Supported: 'harmony', 'cca', 'rpca'."
         )
+
+
+def _integrate_anchor_reduction(
+    seurat,
+    group_by: str,
+    reduction: str,
+    new_reduction: str,
+    assay: Optional[str] = None,
+    n_pcs: int = 30,
+    seed: int = 42,
+    **kwargs,
+) -> None:
+    """CCA/RPCA layer integration → a corrected reduction (Seurat v5 path).
+
+    Splits the object by ``group_by`` into per-batch datasets, finds anchors
+    between them (:func:`shanuz.anchors.find_integration_anchors`), builds the
+    batch-corrected ``"integrated"`` assay (:func:`shanuz.anchors.integrate_data`),
+    then runs ``scale_data`` + ``run_pca`` on it and stores the resulting
+    embedding under ``new_reduction`` (reindexed to the object's cell order).
+    """
+    from .anchors import find_integration_anchors, integrate_data
+    from .preprocessing import scale_data
+    from .reduction import run_pca
+
+    if isinstance(group_by, (list, tuple)):
+        if len(group_by) != 1:
+            raise ValueError(
+                "CCA/RPCA integration supports a single group_by column."
+            )
+        group_by = group_by[0]
+    if group_by not in seurat.meta_data.columns:
+        raise KeyError(f"group_by column {group_by!r} not found in meta_data.")
+
+    k_weight = kwargs.pop("k_weight", 100)
+    sd_weight = kwargs.pop("sd_weight", 1.0)
+
+    groups = list(pd.unique(seurat.meta_data[group_by]))
+    if len(groups) < 2:
+        raise ValueError(
+            f"group_by={group_by!r} has < 2 levels; nothing to integrate."
+        )
+
+    all_cells = seurat.cell_names()
+    labels = seurat.meta_data[group_by]
+    objects = [
+        seurat.subset(cells=[c for c in all_cells if labels.loc[c] == g])
+        for g in groups
+    ]
+
+    anchors = find_integration_anchors(
+        objects, reduction=reduction, seed=seed, **kwargs
+    )
+    merged = integrate_data(anchors, k_weight=k_weight, sd_weight=sd_weight)
+
+    scale_data(merged, assay="integrated")
+    run_pca(
+        merged,
+        n_pcs=n_pcs,
+        assay="integrated",
+        reduction_name=new_reduction,
+        seed=seed,
+    )
+
+    # Reindex the integrated embedding back to the original cell order.
+    seurat.reductions[new_reduction] = merged.reductions[new_reduction].subset(
+        cells=all_cells
+    )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -97,13 +97,164 @@ def test_integrate_layers_harmony_matches_run_harmony():
         obj.reductions["pca"].cell_embeddings.shape
 
 
-def test_integrate_layers_cca_not_implemented():
-    obj = _batched_object()
-    with pytest.raises(NotImplementedError):
-        integrate_layers(obj, method="cca", group_by="batch")
-
-
 def test_run_harmony_unknown_group_by_raises():
     obj = _batched_object()
     with pytest.raises(KeyError):
         run_harmony(obj, group_by="nonexistent_column")
+
+
+# ----------------------------------------------------------------------
+# CCA / RPCA anchor integration
+# ----------------------------------------------------------------------
+
+from shanuz.anchors import (  # noqa: E402
+    find_integration_anchors,
+    integrate_data,
+    IntegrationAnchors,
+)
+
+
+def _one_batch_object(batch, seed=0, n_per=50, G=200):
+    """A single dataset: two cell types; batch '2' carries a batch-effect block."""
+    rng = np.random.default_rng(seed)
+    mat = np.zeros((G, 2 * n_per))
+    celltype, cells = [], []
+    c = 0
+    for t in ("A", "B"):
+        for _ in range(n_per):
+            base = rng.gamma(0.3, size=G) + 0.05
+            if t == "A":
+                base[0:50] += 5.0
+            else:
+                base[50:100] += 5.0
+            if batch == "2":
+                base[100:150] += 4.0          # batch-specific gene block
+            mat[:, c] = rng.poisson(base * 3000.0 / base.sum())
+            celltype.append(t)
+            cells.append(f"b{batch}_c{c}")
+            c += 1
+
+    meta = pd.DataFrame({"celltype": celltype, "batch": batch}, index=cells)
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(mat), assay="RNA",
+        feature_names=[f"g{i}" for i in range(G)], cell_names=cells,
+        meta_data=meta,
+    )
+    normalize_data(obj)
+    find_variable_features(obj, selection_method="vst", nfeatures=150)
+    scale_data(obj)
+    return obj, np.array(celltype)
+
+
+def _object_pair(seed=0):
+    ref, ct_ref = _one_batch_object("1", seed=seed)
+    query, ct_query = _one_batch_object("2", seed=seed + 1)
+    celltype = np.concatenate([ct_ref, ct_query])
+    return [ref, query], celltype
+
+
+def test_find_integration_anchors_returns_scored_anchors():
+    objs, _ = _object_pair()
+    anchors = find_integration_anchors(objs, reduction="cca", k_filter=0)
+    assert isinstance(anchors, IntegrationAnchors)
+    df = anchors.anchors
+    assert list(df.columns) == ["dataset1", "cell1", "dataset2", "cell2", "score"]
+    assert len(df) > 0
+    assert (df["dataset1"] == 0).all()
+    assert (df["dataset2"] == 1).all()
+    assert df["score"].between(0.0, 1.0).all()
+
+
+def test_find_integration_anchors_rejects_unknown_reduction():
+    objs, _ = _object_pair()
+    with pytest.raises(ValueError):
+        find_integration_anchors(objs, reduction="mnn")
+
+
+def test_find_integration_anchors_needs_two_objects():
+    objs, _ = _object_pair()
+    with pytest.raises(ValueError):
+        find_integration_anchors(objs[:1])
+
+
+def test_find_integration_anchors_is_deterministic():
+    objs, _ = _object_pair()
+    a1 = find_integration_anchors(objs, reduction="cca")
+    a2 = find_integration_anchors(objs, reduction="cca")
+    pd.testing.assert_frame_equal(a1.anchors, a2.anchors)
+
+
+def _integrated_pca(merged, seed=0):
+    scale_data(merged, assay="integrated")
+    run_pca(merged, n_pcs=15, assay="integrated", seed=seed)
+    return merged.reductions["pca"].cell_embeddings
+
+
+def test_integrate_data_clusters_by_celltype_not_batch():
+    objs, celltype = _object_pair()
+    batch = np.array(["1"] * len(objs[0]) + ["2"] * len(objs[1]))
+
+    anchors = find_integration_anchors(objs, reduction="cca")
+    merged = integrate_data(anchors)
+
+    assert "integrated" in merged.assays
+    assert merged.active_assay == "integrated"
+
+    emb = _integrated_pca(merged)
+    # After anchor correction, cell type should dominate over batch.
+    assert silhouette_score(emb, celltype) > silhouette_score(emb, batch)
+
+
+def test_integrate_data_rpca_clusters_by_celltype():
+    objs, celltype = _object_pair()
+    batch = np.array(["1"] * len(objs[0]) + ["2"] * len(objs[1]))
+
+    anchors = find_integration_anchors(objs, reduction="rpca")
+    merged = integrate_data(anchors)
+    emb = _integrated_pca(merged)
+    assert silhouette_score(emb, celltype) > silhouette_score(emb, batch)
+
+
+def test_integrate_data_leaves_the_reference_untouched():
+    objs, _ = _object_pair()
+    anchors = find_integration_anchors(objs, reduction="cca")
+    features = anchors.anchor_features
+    merged = integrate_data(anchors)
+
+    ref = objs[0]
+    ref_cells = ref.cell_names()
+    got = merged.get_assay("integrated").layer_data(
+        "data", features=features, cells=ref_cells
+    )
+    orig = ref.get_assay().layer_data("data", features=features, cells=ref_cells)
+    orig = orig.toarray() if sp.issparse(orig) else np.asarray(orig)
+    got = got.toarray() if sp.issparse(got) else np.asarray(got)
+    assert np.allclose(got, orig)
+
+
+def test_integrate_layers_cca_mixes_batches():
+    obj = _batched_object()
+    batch = obj.meta_data["batch"].to_numpy()
+    celltype = obj.meta_data["celltype"].to_numpy()
+
+    integrate_layers(obj, method="cca", group_by="batch", new_reduction="int_cca")
+
+    assert "int_cca" in obj.reductions
+    emb = obj.reductions["int_cca"].cell_embeddings
+    assert emb.shape[0] == len(obj)
+    assert np.isfinite(emb).all()
+    # Integrated embedding should separate cell types more than batches.
+    assert silhouette_score(emb, celltype) > silhouette_score(emb, batch)
+
+
+def test_integrate_layers_rpca_produces_a_reduction():
+    obj = _batched_object()
+    integrate_layers(obj, method="rpca", group_by="batch", new_reduction="int_rpca")
+    assert "int_rpca" in obj.reductions
+    assert obj.reductions["int_rpca"].cell_embeddings.shape[0] == len(obj)
+
+
+def test_integrate_layers_cca_requires_group_by():
+    obj = _batched_object()
+    with pytest.raises(ValueError):
+        integrate_layers(obj, method="cca")

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -252,6 +252,9 @@ same caveat as the other tutorials.
 | Neighbors | `FindNeighbors(pbmc, dims)` | `find_neighbors(pbmc, dims, k_param)` |
 | Cluster | `FindClusters(pbmc, resolution)` | `find_clusters(pbmc, resolution, algorithm)` |
 | UMAP | `RunUMAP(pbmc, dims)` | `run_umap(pbmc, dims)` |
+| Harmony integration | `RunHarmony(pbmc, "batch")` | `run_harmony(pbmc, "batch")` / `integrate_layers(pbmc, method="harmony", group_by="batch")` |
+| CCA/RPCA anchors | `FindIntegrationAnchors(list, reduction="cca")` → `IntegrateData(anchors)` | `find_integration_anchors(objs, reduction="cca")` → `integrate_data(anchors)` |
+| CCA/RPCA layers | `IntegrateLayers(obj, method=CCAIntegration)` | `integrate_layers(obj, method="cca", group_by="batch")` (or `"rpca"`) |
 | Markers | `FindMarkers(pbmc, ident.1)` | `find_markers(pbmc, ident_1)` |
 | All markers | `FindAllMarkers(pbmc, only.pos, logfc.threshold)` | `find_all_markers(pbmc, only_pos, logfc_threshold)` |
 | Conserved markers | `FindConservedMarkers(pbmc, ident.1, grouping.var)` | `find_conserved_markers(pbmc, ident_1, grouping_var)` |
@@ -323,6 +326,59 @@ more forgivingly. The fitted `θ` lands in `misc["theta"]`.
 > steeply at the end, raise `max_iter`. (With `family="nb"` and `θ` being
 > estimated, the deviance is re-scaled as `θ` moves, so it is only strictly
 > monotone when you pin `θ` with `optimize_theta=False`.)
+
+### Integrating datasets — Harmony, CCA, RPCA
+
+Two batches of the same tissue rarely line up: a shared cell type sits in a
+different place in each dataset's PCA, so cells cluster by batch before they
+cluster by biology. Shanuz offers two remedies.
+
+**Harmony** (`run_harmony`) corrects an embedding you already have — it takes the
+joint PCA and iteratively pulls the batches together while keeping cell types
+apart. It is fast and needs only a `group_by` column.
+
+**Anchor integration** (Seurat's CCA/RPCA) works from scratch, without assuming
+the datasets even share a coordinate system. It builds a *shared* space for a
+pair of datasets — by canonical correlation (`reduction="cca"`, the SVD of the
+cross-covariance) or reciprocal PCA (`reduction="rpca"`) — then keeps only the
+*mutual* nearest neighbours across datasets as **anchors**: cell *i* here and
+cell *j* there, each among the other's closest matches, are almost certainly the
+same state seen twice. Anchors are scored for neighbourhood consistency, filtered
+against the raw expression, and then used to pull every query dataset onto the
+reference.
+
+```python
+from shanuz import (
+    find_integration_anchors, integrate_data, integrate_layers,
+    run_harmony, scale_data, run_pca, find_clusters, run_umap,
+)
+
+# --- Harmony: correct an existing joint PCA in place -------------------------
+run_harmony(pbmc, group_by="batch")             # stores reductions["harmony"]
+run_umap(pbmc, reduction="harmony", dims=range(30))
+
+# --- CCA/RPCA anchors: a list of per-batch objects → a corrected assay -------
+anchors = find_integration_anchors([ref, query], reduction="cca")   # or "rpca"
+merged = integrate_data(anchors)                # active assay is now "integrated"
+scale_data(merged)
+run_pca(merged)                                 # clusters by cell type, not batch
+find_clusters(merged, resolution=0.5)
+
+# --- One-call Seurat v5 path: split one object by batch, integrate, embed ----
+integrate_layers(pbmc, method="cca", group_by="batch", new_reduction="integrated")
+run_umap(pbmc, reduction="integrated", dims=range(30))
+```
+
+**`find_integration_anchors`** is *reference-based*: `objects[reference]` (index
+0 by default) is the anchor every other dataset is corrected onto. **CCA** shines
+when the datasets share structure but differ globally (cross-species, cross-
+technology); **RPCA** is stricter and faster, a better fit when the batches are
+already similar or very large. Both return the same `IntegrationAnchors`, which
+is also what v0.3.0's reference mapping is built to consume.
+
+> The correction is applied to the log-normalised `data` of the shared anchor
+> features and stored as an `"integrated"` assay — so `scale_data` + `run_pca`
+> on it is the natural next step. The reference dataset is left untouched.
 
 ### Pseudobulk & conserved markers
 


### PR DESCRIPTION
Implements the last open item in the **v0.2.0** milestone: Seurat's anchor-based dataset integration (CCA / RPCA). With this, v0.2.0 (Batch Correction & Integration) is complete, and v0.3.0 reference mapping (`FindTransferAnchors` / `TransferData`) is unblocked.

## What's new

**`shanuz/anchors.py`** — a self-contained anchor-integration engine (its own module per the house idiom; reused by v0.3.0):

- **`find_integration_anchors(objects, reduction="cca"|"rpca", dims, k_anchor, k_filter, k_score, reference=0)`** → `IntegrationAnchors`. Builds a shared space per dataset pair — **CCA** (SVD of the cross-covariance `AᵀB`) or **reciprocal PCA** — finds **mutual nearest neighbours** as anchors, **scores** them by shared-neighbourhood consistency, and **filters** against the raw expression space.
- **`integrate_data(anchors, new_assay="integrated", k_weight, sd_weight)`** → merged `Shanuz` with an active `"integrated"` assay. Corrects each query cell by a Gaussian-weighted sum of anchor correction vectors (`expr_ref − expr_query`); the reference is left untouched.
- **`IntegrationAnchors`** — result container (anchor table + reference/reduction bookkeeping + per-query shared-space embeddings). This is what v0.3.0's reference mapping is built to consume.

**`integrate_layers(method="cca"|"rpca", group_by=...)`** now dispatches (was `NotImplementedError`): splits the object by batch, runs the anchor pipeline, and stores the batch-corrected embedding as a reduction.

## Design notes

- **Reference-based**: anchors link each dataset to `reference=0`, and every other dataset is corrected onto it — one of Seurat's supported modes. A full guide-tree over all pairwise anchors is a later refinement.
- Correction is applied to the log-normalised `data` of the shared anchor features, so `scale_data` + `run_pca` on the `"integrated"` assay is the natural next step.

## Latent bug fixed

`Assay5.merge` indexed the `scale.data` layer (which holds only the variable features) using assay-wide feature positions, raising `IndexError` whenever two **scaled** v5 objects were merged. This feature is the first to hit that path. `merge` is now layer-feature-aware and preserves `_scaled_features`.

## Tests

10 new in `tests/test_integration.py`: anchor-table structure, unknown-reduction / two-object / group_by guards, determinism, CCA & RPCA "clusters by cell type not batch" (silhouette), reference-untouched, and both `integrate_layers` paths. The obsolete `not_implemented` test is replaced.

**Full suite: 282 passed** (was 273; net +9). ruff clean on all changed files.

## Docs

- `ROADMAP.md`: v0.2.0 marked complete; CCA/RPCA + `IntegrateLayers` sections updated to delivered; priority #4 (`FindTransferAnchors`) noted as unblocked.
- `README.md`: integration feature line + v0.2.0 milestone row.
- `tutorials/README.md`: three API-reference rows + an "Integrating datasets — Harmony, CCA, RPCA" section with a runnable snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)