### PR TITLE
Reference mapping: FindTransferAnchors / TransferData (v0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Signature scoring** — `add_module_score`, `cell_cycle_scoring` (S/G2M + Phase)
 - **Dimensionality reduction** — `run_pca`, `run_spca` (supervised, off a cell graph), `run_ica`, `run_tsne`, `glm_pca` (Poisson or negative binomial, straight on counts)
 - **Batch correction / integration** — `run_harmony` (via harmonypy), CCA/RPCA anchors (`find_integration_anchors` + `integrate_data`), and the `integrate_layers` dispatcher (`method="harmony"|"cca"|"rpca"`)
+- **Reference mapping** — `find_transfer_anchors` (project a query into a reference; `pcaproject` or `cca`) + `transfer_data` (annotate the query with reference labels, or impute reference expression onto it)
 - **Nearest-neighbour graph** — `find_neighbors` (KNN + SNN)
 - **Multimodal WNN** — `find_multi_modal_neighbors` (per-cell RNA/protein weights, joint `wknn`/`wsnn` graphs)
 - **Clustering** — `find_clusters` (Louvain via python-igraph, Leiden via leidenalg)
@@ -289,7 +290,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | Milestone | Focus |
 |-----------|-------|
 | v0.2.0 | Batch correction — Harmony, CCA/RPCA anchors, `IntegrateLayers` dispatcher ✅ *(complete)* |
-| v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData`, `MapQuery` |
+| v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData` ✅, `MapQuery` 🚧 |
 | v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(delivered — see Tutorial 3)* |
 | v0.5.0 | Additional reductions — t-SNE, ICA, `run_spca`, `glm_pca` (Poisson + negative binomial) ✅ *(complete)* |
 | v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`), bimod (`test_use="bimod"`) ✅ *(complete)* |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,30 +70,42 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 
 ---
 
-## v0.3.0 — Reference Mapping & Label Transfer
+## v0.3.0 — Reference Mapping & Label Transfer — 🚧 in progress
 
 > **Why:** label transfer from a curated atlas to a query dataset is a standard
 > first-annotation step; all machinery (KNN, PCA, anchors) already exists.
+>
+> **Status:** the anchor + transfer core is delivered — `find_transfer_anchors`
+> (pcaproject / cca) and `transfer_data` (classification + imputation) in
+> `shanuz/transfer.py`, reusing the `anchors.py` machinery end-to-end.
+> `MapQuery` / `ProjectUMAP` (placing the query in the reference UMAP) is the
+> remaining item.
 
-### `FindTransferAnchors`
+### `FindTransferAnchors` — ✅ delivered
+- Implemented as `find_transfer_anchors(reference, query, reduction="pcaproject")`
+  in `shanuz/transfer.py`, returning a `TransferAnchors` container (anchor pairs
+  `cell1/cell2/score` + the query embedding used for weighting). Default
+  **pcaproject** projects the query through the reference's PCA loadings (computed
+  on the shared anchor features, so the reference need not already carry a `pca`
+  reduction); **cca** builds a jointly-learned space. MNN → score → filter reuse
+  the same helpers as `find_integration_anchors` (`tests/test_transfer.py`).
 - **R:** `FindTransferAnchors(reference, query, dims = 1:30)`
-- **Plan:**
-  1. Project query into reference PCA space (`reference.reductions["pca"].loadings`)
-  2. Find MNN between reference and projected query cells (sklearn `NearestNeighbors`)
-  3. Score and filter anchors by consistency (same logic as CCA anchors above)
-  4. Returns `TransferAnchors` object (stores anchor pairs + weights)
-- **Dep:** CCA/RPCA from v0.2.0
+- **Dep:** CCA/RPCA anchors from v0.2.0 (`shanuz/anchors.py`)
 
-### `TransferData`
+### `TransferData` — ✅ delivered
+- Implemented as `transfer_data(anchors, refdata)` in `shanuz/transfer.py`. Builds
+  a per-query-cell weight over the anchors (the same distance-weighted,
+  score-scaled Gaussian kernel `integrate_data` uses), then either **classifies**
+  (a metadata column or 1-D label array → `predicted.id` +
+  `prediction.score.<class>` per class, rows summing to 1, + `prediction.score.max`)
+  or **imputes** (a 2-D `features × reference-cells` matrix → predicted query
+  expression). Verified to recover a query's true cell types across an injected
+  batch block (`tests/test_transfer.py`).
 - **R:** `TransferData(anchors, refdata = reference$celltype)`
-- **Plan:**
-  1. For each query cell, take a weighted average of reference labels/embeddings
-     across its anchors
-  2. Categorical labels → predicted label + prediction score per class
-  3. Continuous (e.g. gene expression imputation) → weighted mean
-- **Tests:** majority of cells get correct label when query == reference (self-transfer)
+- **Tests:** query cells get the correct transferred label at >85% accuracy;
+  per-class scores form a distribution; imputation recovers the marker split.
 
-### `MapQuery` + `ProjectUMAP`
+### `MapQuery` + `ProjectUMAP` — ⏳ next
 - **R:** `MapQuery(query, reference, refmodel)` then `ProjectUMAP(...)`
 - **Plan:** compose `FindTransferAnchors` + `TransferData` + UMAP projection
   (transform-only mode of `umap-learn`, using reference's fitted UMAP model)
@@ -519,7 +531,11 @@ If milestones are too large, these are the highest-value individual items:
 1. ~~**Harmony** (`v0.2.0`)~~ — ✅ delivered (`run_harmony` / `integrate_layers`)
 2. ~~**WNN** (`v0.4.0`)~~ — ✅ delivered (`find_multi_modal_neighbors` + `run_umap(graph=)`); CBMC tutorial section still open
 3. ~~**GitHub Actions CI** (`v0.10.0`)~~ — ✅ delivered
-4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — enables atlas-based annotation (next-cycle candidate). CCA/RPCA anchors are now in place (`shanuz/anchors.py`, with a reusable `IntegrationAnchors`), as is `run_spca` — the reduction Azimuth maps onto. This is now unblocked.
+4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — ✅ delivered
+   (`shanuz/transfer.py`: `find_transfer_anchors` pcaproject/cca + `transfer_data`
+   classification/imputation), enabling atlas-based annotation. Built on the
+   v0.2.0 anchor machinery. **`MapQuery` / `ProjectUMAP`** (query into the
+   reference UMAP) is the remaining v0.3.0 item.
 5. ~~**`FindSpatiallyVariableFeatures`** + **`SpatialFeaturePlot`**~~ ✅ (`v0.7.0`) — all four loaders, niche/neighbourhood analysis, both spatially-variable-feature methods (Moran's I and markvariogram), the `VisiumV2` tissue-image data layer and the `spatial_*` H&E plots delivered; **v0.7.0 is complete**
 6. ~~**`AggregateExpression` + DESeq2**~~ ✅ (`v0.6.0`) — `aggregate_expression`,
    `find_conserved_markers`, and pseudobulk DESeq2 (`test_use="deseq2"`) delivered;

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -28,6 +28,11 @@ from .anchors import (
     integrate_data,
     IntegrationAnchors,
 )
+from .transfer import (
+    find_transfer_anchors,
+    transfer_data,
+    TransferAnchors,
+)
 from .markers import find_markers, find_all_markers, find_conserved_markers
 from .aggregate import aggregate_expression
 from .sctransform import sctransform
@@ -143,6 +148,9 @@ __all__ = [
     "find_integration_anchors",
     "integrate_data",
     "IntegrationAnchors",
+    "find_transfer_anchors",
+    "transfer_data",
+    "TransferAnchors",
     "find_markers",
     "find_all_markers",
     "find_conserved_markers",

--- a/shanuz/transfer.py
+++ b/shanuz/transfer.py
@@ -1,0 +1,405 @@
+"""Reference mapping — Seurat's ``FindTransferAnchors`` / ``TransferData``.
+
+Integration (``anchors.py``) *corrects* several datasets onto each other so they
+share a coordinate system. Reference mapping is the asymmetric cousin: the
+reference is an annotated atlas you trust and never touch, and the query is a
+new, unlabelled dataset you want to *annotate* by borrowing from the reference.
+
+The anchor machinery is the same as integration — build a shared space, find
+mutual nearest neighbours, score and filter them — but two things differ:
+
+  1. **The space is directional.** By default (``reduction="pcaproject"``) the
+     query is *projected into the reference's PCA* rather than a jointly-learned
+     CCA space: the reference's principal axes are computed once on the shared
+     anchor features and the query is pushed through the same loadings. Because
+     those axes were learned without ever seeing the query, batch-specific
+     structure the reference doesn't have simply lands nowhere — which is what
+     makes projection robust for annotation. ``reduction="cca"`` is also
+     supported for the harder cross-modality / cross-species cases.
+  2. **The reference is fixed.** Anchors run *reference → query* and are used by
+     :func:`transfer_data` to carry labels (or expression) across, not to move
+     any cells.
+
+:func:`transfer_data` turns the anchors into a per-query-cell weight over the
+anchors (the same distance-weighted, score-scaled Gaussian kernel that
+``IntegrateData`` uses) and then either
+
+  * **classifies** — a categorical reference label becomes a one-hot matrix over
+    the anchor reference cells; ``weights @ onehot`` gives each query cell a
+    probability per class (``predicted.id`` = argmax, ``prediction.score.*`` =
+    the probabilities), or
+  * **imputes** — a continuous ``features × reference-cells`` matrix is carried
+    across the same weights to predict query expression.
+
+This reuses :class:`shanuz.anchors` end to end; only the projection and the
+label/expression transfer are new. ``MapQuery`` / ``ProjectUMAP`` (placing the
+query in the reference UMAP) build on top of this and land separately.
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from .anchors import (
+    _anchor_feature_matrix,
+    _cca,
+    _filter_anchors,
+    _integration_features,
+    _l2_normalize_cols,
+    _l2_normalize_rows,
+    _mutual_nn,
+    _pairwise_to_anchors,
+    _pca_loadings,
+    _score_anchors,
+)
+
+REDUCTIONS = ("pcaproject", "cca")
+
+
+# ----------------------------------------------------------------------
+# Result container
+# ----------------------------------------------------------------------
+
+
+class TransferAnchors:
+    """Anchors linking a fixed reference to a query, for label/data transfer.
+
+    Slots
+    -----
+    anchors          : DataFrame with columns ``cell1, cell2, score``.
+                       ``cell1`` is a *within-reference* 0-based cell index,
+                       ``cell2`` a *within-query* one; the reference is never
+                       moved.
+    reference        : the reference Shanuz object (annotated atlas).
+    query            : the query Shanuz object (to be annotated).
+    reduction        : ``"pcaproject"`` or ``"cca"`` — how the shared space was
+                       built.
+    anchor_features  : the features the anchors run on.
+    dims             : number of shared dimensions used.
+    query_embedding  : ``(n_query_cells × dims)`` — the query cells in the shared
+                       space, used by :func:`transfer_data` to weight anchors.
+    """
+
+    __slots__ = (
+        "anchors",
+        "reference",
+        "query",
+        "reduction",
+        "anchor_features",
+        "dims",
+        "query_embedding",
+    )
+
+    def __init__(
+        self,
+        anchors: pd.DataFrame,
+        reference,
+        query,
+        reduction: str,
+        anchor_features: list[str],
+        dims: int,
+        query_embedding: np.ndarray,
+    ) -> None:
+        self.anchors = anchors
+        self.reference = reference
+        self.query = query
+        self.reduction = reduction
+        self.anchor_features = list(anchor_features)
+        self.dims = dims
+        self.query_embedding = query_embedding
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return (
+            f"TransferAnchors: {len(self.anchors)} anchors "
+            f"(reference {len(self.reference)} cells → query "
+            f"{len(self.query)} cells)\n"
+            f"  reduction={self.reduction!r}  dims={self.dims}  "
+            f"features={len(self.anchor_features)}"
+        )
+
+
+# ----------------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------------
+
+
+def find_transfer_anchors(
+    reference,
+    query,
+    anchor_features: Optional[list[str]] = None,
+    reduction: str = "pcaproject",
+    dims: int = 30,
+    k_anchor: int = 5,
+    k_filter: int = 200,
+    k_score: int = 30,
+    layer: str = "scale.data",
+    seed: int = 42,
+) -> TransferAnchors:
+    """Find transfer anchors from a reference to a query (Seurat's ``FindTransferAnchors``).
+
+    Mirrors ``FindTransferAnchors(reference, query, reduction = "pcaproject")``.
+    Anchors are mutual nearest neighbours between the reference and the query in
+    a shared space — by default the reference's own PCA, into which the query is
+    projected — scored by neighbourhood consistency and filtered against the
+    original expression space.
+
+    Parameters
+    ----------
+    reference       : annotated reference Shanuz object (normalized + with
+                      variable features / scaled data).
+    query           : query Shanuz object to annotate (same preprocessing).
+    anchor_features : features to anchor on (default: variable features shared
+                      by reference and query).
+    reduction       : ``"pcaproject"`` (project the query into the reference's
+                      PCA; the default and most robust for annotation) or
+                      ``"cca"`` (a jointly-learned space, for harder
+                      cross-modality/species cases). The reference PCA is
+                      computed on the shared anchor features, so the reference
+                      need not already carry a ``pca`` reduction.
+    dims            : number of shared dimensions to use.
+    k_anchor        : neighbours for the mutual-nearest-neighbour search.
+    k_filter        : neighbourhood size for the feature-space anchor filter
+                      (set to 0 or None to skip filtering).
+    k_score         : neighbourhood size for anchor scoring.
+    layer           : layer to draw the shared-space expression from.
+    seed            : random seed for the PCA/neighbour steps.
+
+    Returns
+    -------
+    TransferAnchors
+    """
+    reduction = reduction.lower()
+    if reduction not in REDUCTIONS:
+        raise ValueError(
+            f"Unknown reduction {reduction!r}. Supported: {REDUCTIONS}."
+        )
+
+    features = _integration_features([reference, query], anchor_features)
+
+    ref_scaled = _l2_normalize_cols(
+        _anchor_feature_matrix(reference, features, layer)
+    )
+    query_scaled = _l2_normalize_cols(
+        _anchor_feature_matrix(query, features, layer)
+    )
+    if ref_scaled.shape[0] != query_scaled.shape[0]:
+        raise ValueError(
+            "Reference and query disagree on the number of anchor features "
+            f"({ref_scaled.shape[0]} vs {query_scaled.shape[0]}); ensure the "
+            "anchor features are scaled in both objects."
+        )
+
+    used = min(
+        dims,
+        ref_scaled.shape[1] - 1,
+        query_scaled.shape[1] - 1,
+        ref_scaled.shape[0],
+    )
+
+    if reduction == "pcaproject":
+        # Project the query through the reference's PCA loadings — both datasets
+        # end up in the reference's principal-component space.
+        load_ref = _pca_loadings(ref_scaled, used, seed=seed)
+        ref_emb = _l2_normalize_rows(ref_scaled.T @ load_ref)
+        query_emb = _l2_normalize_rows(query_scaled.T @ load_ref)
+    else:  # cca — a jointly-learned shared space
+        ref_emb, query_emb = _cca(ref_scaled, query_scaled, used)
+
+    pairs = _mutual_nn(ref_emb, query_emb, query_emb, ref_emb, k_anchor)
+    combined = np.vstack([ref_emb, query_emb])
+    n_ref = ref_emb.shape[0]
+    scores = _score_anchors(pairs, combined, n_ref, k_score)
+    if k_filter:
+        pairs, scores = _filter_anchors(
+            pairs, scores, ref_scaled, query_scaled, k_filter
+        )
+
+    rows = [(int(i), int(j), float(s)) for (i, j), s in zip(pairs, scores)]
+    anchors = pd.DataFrame(rows, columns=["cell1", "cell2", "score"])
+
+    return TransferAnchors(
+        anchors=anchors,
+        reference=reference,
+        query=query,
+        reduction=reduction,
+        anchor_features=features,
+        dims=used,
+        query_embedding=query_emb,
+    )
+
+
+def transfer_data(
+    anchors: TransferAnchors,
+    refdata: Union[str, np.ndarray, list, pd.Series],
+    k_weight: int = 50,
+    sd_weight: float = 1.0,
+    refdata_features: Optional[list[str]] = None,
+) -> pd.DataFrame:
+    """Transfer labels or expression from reference to query (Seurat's ``TransferData``).
+
+    Mirrors ``TransferData(anchorset, refdata = "celltype")``. Each query cell
+    gets a weight over the anchors — a distance-weighted, anchor-score-scaled
+    Gaussian kernel in the shared space (the same weighting ``IntegrateData``
+    uses) — and the reference information is carried across those weights.
+
+    ``refdata`` selects the mode:
+
+    * **classification** — a metadata column name (``str``) or a 1-D array of
+      per-reference-cell labels. Returns a DataFrame indexed by query cell with
+      ``predicted.id``, one ``prediction.score.<class>`` column per reference
+      class (each query cell's rows sum to 1), and ``prediction.score.max``.
+    * **imputation** — a 2-D ``features × reference-cells`` matrix. Returns a
+      DataFrame of predicted query expression (features × query cells); name the
+      rows with ``refdata_features``.
+
+    Parameters
+    ----------
+    anchors          : a :class:`TransferAnchors` from
+                       :func:`find_transfer_anchors`.
+    refdata          : reference labels (str column / 1-D array) or a 2-D
+                       ``features × reference-cells`` matrix to impute.
+    k_weight         : anchors used to weight each query cell.
+    sd_weight        : bandwidth multiplier for the Gaussian anchor kernel.
+    refdata_features : row names for the imputation output (2-D ``refdata``).
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    anchor_df = anchors.anchors
+    if len(anchor_df) == 0:
+        raise ValueError(
+            "No anchors between reference and query; cannot transfer. Try a "
+            "larger k_anchor or k_filter=0 in find_transfer_anchors."
+        )
+
+    query_cells = anchors.query.cell_names()
+    ref_cell1 = anchor_df["cell1"].to_numpy()
+    query_cell2 = anchor_df["cell2"].to_numpy()
+    anchor_scores = anchor_df["score"].to_numpy()
+
+    weights = _anchor_weight_matrix(
+        anchors.query_embedding, query_cell2, anchor_scores, k_weight, sd_weight
+    )  # (n_query × n_anchor)
+
+    classification = isinstance(refdata, str) or np.ndim(refdata) == 1
+    if classification:
+        return _transfer_labels(
+            anchors.reference, refdata, ref_cell1, weights, query_cells
+        )
+    return _transfer_expression(
+        refdata, refdata_features, ref_cell1, weights, query_cells
+    )
+
+
+# ----------------------------------------------------------------------
+# Internals
+# ----------------------------------------------------------------------
+
+
+def _anchor_weight_matrix(
+    query_emb: np.ndarray,
+    anchor_query_idx: np.ndarray,
+    anchor_scores: np.ndarray,
+    k_weight: int,
+    sd_weight: float,
+) -> np.ndarray:
+    """Per-query-cell weight over the anchors (``n_query × n_anchor``).
+
+    Each query cell weights its ``k_weight`` nearest anchors (located at their
+    query positions in the shared space) with a Gaussian kernel scaled by the
+    anchor score, normalized to sum to 1 — matching ``IntegrateData``.
+    """
+    n_query = query_emb.shape[0]
+    n_anchor = len(anchor_query_idx)
+    anchor_pos = query_emb[anchor_query_idx]  # n_anchor × dims
+    k = min(k_weight, n_anchor)
+
+    nn_dist, nn_idx = _pairwise_to_anchors(query_emb, anchor_pos, k)  # n_query × k
+    bandwidth = nn_dist[:, -1:].copy()
+    bandwidth[bandwidth == 0] = 1.0
+    w = np.exp(-((nn_dist / (bandwidth / sd_weight)) ** 2))
+    w = w * anchor_scores[nn_idx]
+    wsum = w.sum(axis=1, keepdims=True)
+    wsum[wsum == 0] = 1.0
+    w = w / wsum
+
+    weights = np.zeros((n_query, n_anchor))
+    rows = np.repeat(np.arange(n_query), k)
+    weights[rows, nn_idx.ravel()] = w.ravel()
+    return weights
+
+
+def _transfer_labels(
+    reference,
+    refdata: Union[str, np.ndarray, list, pd.Series],
+    ref_cell1: np.ndarray,
+    weights: np.ndarray,
+    query_cells: list[str],
+) -> pd.DataFrame:
+    """Categorical label transfer → per-class prediction scores + argmax id."""
+    if isinstance(refdata, str):
+        if refdata not in reference.meta_data.columns:
+            raise KeyError(
+                f"refdata column {refdata!r} not found in reference meta_data."
+            )
+        labels = reference.meta_data.loc[reference.cell_names(), refdata].to_numpy()
+    else:
+        labels = np.asarray(refdata)
+        if labels.shape[0] != len(reference):
+            raise ValueError(
+                f"refdata has {labels.shape[0]} labels but the reference has "
+                f"{len(reference)} cells."
+            )
+
+    labels = labels.astype(object)
+    classes = sorted({str(x) for x in labels})
+    class_index = {c: i for i, c in enumerate(classes)}
+
+    # One-hot the anchor reference cells' labels: (n_anchor × n_classes).
+    anchor_labels = labels[ref_cell1]
+    onehot = np.zeros((len(anchor_labels), len(classes)))
+    onehot[np.arange(len(anchor_labels)), [class_index[str(x)] for x in anchor_labels]] = 1.0
+
+    scores = weights @ onehot  # (n_query × n_classes), rows sum to 1
+    predicted = [classes[i] for i in scores.argmax(axis=1)]
+    score_max = scores.max(axis=1)
+
+    out = pd.DataFrame(
+        {"predicted.id": predicted}, index=list(query_cells)
+    )
+    for c in classes:
+        out[f"prediction.score.{c}"] = scores[:, class_index[c]]
+    out["prediction.score.max"] = score_max
+    return out
+
+
+def _transfer_expression(
+    refdata,
+    refdata_features: Optional[list[str]],
+    ref_cell1: np.ndarray,
+    weights: np.ndarray,
+    query_cells: list[str],
+) -> pd.DataFrame:
+    """Continuous imputation → predicted query expression (features × cells)."""
+    refmat = np.asarray(refdata, dtype=float)
+    if refmat.ndim != 2:
+        raise ValueError("Continuous refdata must be a 2-D features × cells matrix.")
+
+    n_features = refmat.shape[0]
+    anchor_ref = refmat[:, ref_cell1]          # features × n_anchor
+    imputed = anchor_ref @ weights.T           # features × n_query
+
+    if refdata_features is None:
+        refdata_features = [f"feature_{i}" for i in range(n_features)]
+    elif len(refdata_features) != n_features:
+        raise ValueError(
+            f"refdata_features has {len(refdata_features)} names but refdata has "
+            f"{n_features} rows."
+        )
+
+    return pd.DataFrame(
+        imputed, index=list(refdata_features), columns=list(query_cells)
+    )

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,0 +1,204 @@
+"""Tests for reference mapping (v0.3.0).
+
+  * find_transfer_anchors  (transfer.py)
+  * transfer_data          (transfer.py)
+
+Builds an annotated reference and an unlabelled query (same two cell types, the
+query carrying a batch-effect gene block the reference never sees), then checks
+that projecting the query into the reference and transferring the ``celltype``
+label recovers the query's true cell types. Network-free.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from shanuz.shanuz import create_shanuz_object  # noqa: E402
+from shanuz.preprocessing import (  # noqa: E402
+    normalize_data,
+    find_variable_features,
+    scale_data,
+)
+from shanuz.transfer import (  # noqa: E402
+    find_transfer_anchors,
+    transfer_data,
+    TransferAnchors,
+)
+
+
+def _labelled_object(batch, seed=0, n_per=60, G=200):
+    """Two cell types (A/B); batch '2' carries a batch-effect gene block."""
+    rng = np.random.default_rng(seed)
+    mat = np.zeros((G, 2 * n_per))
+    celltype, cells = [], []
+    c = 0
+    for t in ("A", "B"):
+        for _ in range(n_per):
+            base = rng.gamma(0.3, size=G) + 0.05
+            if t == "A":
+                base[0:50] += 5.0
+            else:
+                base[50:100] += 5.0
+            if batch == "2":
+                base[100:150] += 4.0          # batch-specific gene block
+            mat[:, c] = rng.poisson(base * 3000.0 / base.sum())
+            celltype.append(t)
+            cells.append(f"b{batch}_c{c}")
+            c += 1
+
+    meta = pd.DataFrame({"celltype": celltype, "batch": batch}, index=cells)
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(mat), assay="RNA",
+        feature_names=[f"g{i}" for i in range(G)], cell_names=cells,
+        meta_data=meta,
+    )
+    normalize_data(obj)
+    find_variable_features(obj, selection_method="vst", nfeatures=150)
+    scale_data(obj)
+    return obj, np.array(celltype)
+
+
+def _ref_query(seed=0):
+    reference, ct_ref = _labelled_object("1", seed=seed)
+    query, ct_query = _labelled_object("2", seed=seed + 1)
+    return reference, query, ct_ref, ct_query
+
+
+# ----------------------------------------------------------------------
+# find_transfer_anchors
+# ----------------------------------------------------------------------
+
+
+def test_find_transfer_anchors_returns_scored_anchors():
+    reference, query, _, _ = _ref_query()
+    anchors = find_transfer_anchors(reference, query, k_filter=0)
+
+    assert isinstance(anchors, TransferAnchors)
+    df = anchors.anchors
+    assert list(df.columns) == ["cell1", "cell2", "score"]
+    assert len(df) > 0
+    assert df["cell1"].between(0, len(reference) - 1).all()
+    assert df["cell2"].between(0, len(query) - 1).all()
+    assert df["score"].between(0.0, 1.0).all()
+    assert anchors.query_embedding.shape[0] == len(query)
+
+
+def test_find_transfer_anchors_rejects_unknown_reduction():
+    reference, query, _, _ = _ref_query()
+    with pytest.raises(ValueError):
+        find_transfer_anchors(reference, query, reduction="mnn")
+
+
+def test_find_transfer_anchors_is_deterministic():
+    reference, query, _, _ = _ref_query()
+    a1 = find_transfer_anchors(reference, query)
+    a2 = find_transfer_anchors(reference, query)
+    pd.testing.assert_frame_equal(a1.anchors, a2.anchors)
+
+
+def test_find_transfer_anchors_cca_reduction():
+    reference, query, _, _ = _ref_query()
+    anchors = find_transfer_anchors(reference, query, reduction="cca")
+    assert anchors.reduction == "cca"
+    assert len(anchors.anchors) > 0
+
+
+# ----------------------------------------------------------------------
+# transfer_data — classification
+# ----------------------------------------------------------------------
+
+
+def _accuracy(predicted, truth):
+    return float(np.mean(np.asarray(predicted) == np.asarray(truth)))
+
+
+def test_transfer_data_predicts_query_celltypes():
+    reference, query, _, ct_query = _ref_query()
+    anchors = find_transfer_anchors(reference, query, reduction="pcaproject")
+
+    pred = transfer_data(anchors, refdata="celltype")
+
+    assert list(pred.index) == query.cell_names()
+    assert "predicted.id" in pred.columns
+    assert "prediction.score.max" in pred.columns
+    # Projection should annotate the query despite its batch block.
+    assert _accuracy(pred["predicted.id"], ct_query) > 0.85
+
+
+def test_transfer_data_scores_form_a_distribution():
+    reference, query, _, _ = _ref_query()
+    anchors = find_transfer_anchors(reference, query)
+    pred = transfer_data(anchors, refdata="celltype")
+
+    score_cols = [c for c in pred.columns if c.startswith("prediction.score.")
+                  and c != "prediction.score.max"]
+    assert set(score_cols) == {"prediction.score.A", "prediction.score.B"}
+    # Per-class scores are a probability distribution over the classes.
+    row_sums = pred[score_cols].sum(axis=1).to_numpy()
+    assert np.allclose(row_sums, 1.0)
+    assert (pred["prediction.score.max"] >= 0.5).all()
+    assert pred[score_cols].to_numpy().min() >= 0.0
+
+
+def test_transfer_data_accepts_label_array():
+    reference, query, ct_ref, ct_query = _ref_query()
+    anchors = find_transfer_anchors(reference, query)
+
+    # Same labels, passed as a raw per-reference-cell array instead of a column.
+    pred = transfer_data(anchors, refdata=ct_ref)
+    assert _accuracy(pred["predicted.id"], ct_query) > 0.85
+
+
+def test_transfer_data_unknown_column_raises():
+    reference, query, _, _ = _ref_query()
+    anchors = find_transfer_anchors(reference, query)
+    with pytest.raises(KeyError):
+        transfer_data(anchors, refdata="no_such_column")
+
+
+def test_transfer_data_wrong_length_array_raises():
+    reference, query, _, _ = _ref_query()
+    anchors = find_transfer_anchors(reference, query)
+    with pytest.raises(ValueError):
+        transfer_data(anchors, refdata=np.array(["A", "B", "A"]))
+
+
+# ----------------------------------------------------------------------
+# transfer_data — continuous imputation
+# ----------------------------------------------------------------------
+
+
+def test_transfer_data_imputes_expression():
+    reference, query, _, ct_query = _ref_query()
+    anchors = find_transfer_anchors(reference, query)
+
+    # Impute the two cell-type marker blocks from the reference onto the query.
+    feats = ["g10", "g60"]     # g10 ↑ in type A, g60 ↑ in type B
+    ref_expr = reference.get_assay().layer_data("data", features=feats)
+    ref_expr = ref_expr.toarray() if sp.issparse(ref_expr) else np.asarray(ref_expr)
+
+    imputed = transfer_data(anchors, refdata=ref_expr, refdata_features=feats)
+
+    assert list(imputed.index) == feats
+    assert list(imputed.columns) == query.cell_names()
+    assert imputed.shape == (2, len(query))
+
+    # g10 should read higher in the query cells the reference calls type A.
+    a_mask = ct_query == "A"
+    assert imputed.loc["g10"].to_numpy()[a_mask].mean() > \
+        imputed.loc["g10"].to_numpy()[~a_mask].mean()
+    assert imputed.loc["g60"].to_numpy()[~a_mask].mean() > \
+        imputed.loc["g60"].to_numpy()[a_mask].mean()
+
+
+def test_transfer_data_no_anchors_raises():
+    reference, query, _, _ = _ref_query()
+    anchors = find_transfer_anchors(reference, query)
+    anchors.anchors = anchors.anchors.iloc[0:0]  # drop every anchor
+    with pytest.raises(ValueError):
+        transfer_data(anchors, refdata="celltype")

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -255,6 +255,8 @@ same caveat as the other tutorials.
 | Harmony integration | `RunHarmony(pbmc, "batch")` | `run_harmony(pbmc, "batch")` / `integrate_layers(pbmc, method="harmony", group_by="batch")` |
 | CCA/RPCA anchors | `FindIntegrationAnchors(list, reduction="cca")` → `IntegrateData(anchors)` | `find_integration_anchors(objs, reduction="cca")` → `integrate_data(anchors)` |
 | CCA/RPCA layers | `IntegrateLayers(obj, method=CCAIntegration)` | `integrate_layers(obj, method="cca", group_by="batch")` (or `"rpca"`) |
+| Transfer anchors | `FindTransferAnchors(reference, query, reduction="pcaproject")` | `find_transfer_anchors(reference, query, reduction="pcaproject")` (or `"cca"`) |
+| Transfer labels | `TransferData(anchors, refdata=reference$celltype)` | `transfer_data(anchors, refdata="celltype")` |
 | Markers | `FindMarkers(pbmc, ident.1)` | `find_markers(pbmc, ident_1)` |
 | All markers | `FindAllMarkers(pbmc, only.pos, logfc.threshold)` | `find_all_markers(pbmc, only_pos, logfc_threshold)` |
 | Conserved markers | `FindConservedMarkers(pbmc, ident.1, grouping.var)` | `find_conserved_markers(pbmc, ident_1, grouping_var)` |
@@ -379,6 +381,46 @@ is also what v0.3.0's reference mapping is built to consume.
 > The correction is applied to the log-normalised `data` of the shared anchor
 > features and stored as an `"integrated"` assay — so `scale_data` + `run_pca`
 > on it is the natural next step. The reference dataset is left untouched.
+
+### Reference mapping — annotating a query from an atlas
+
+Integration mixes several datasets into one shared space. Reference mapping is
+the asymmetric cousin: you keep an annotated atlas fixed and *borrow* its labels
+for a new, unlabelled dataset. The anchor machinery is the same — build a shared
+space, find mutual nearest neighbours, score and filter them — but the reference
+is never moved and the anchors carry information *reference → query*.
+
+```python
+from shanuz import find_transfer_anchors, transfer_data
+
+# reference: annotated atlas (has a "celltype" column). query: new, unlabelled.
+# Both normalized + find_variable_features + scale_data, as usual.
+anchors = find_transfer_anchors(reference, query, reduction="pcaproject")
+
+# Classification: predict the query's cell types from the reference labels.
+pred = transfer_data(anchors, refdata="celltype")
+query.add_meta_data(pred["predicted.id"], col_name="predicted.celltype")
+query.add_meta_data(pred["prediction.score.max"], col_name="prediction.score")
+# pred also has one prediction.score.<class> column per reference class.
+
+# Imputation: carry reference expression (features × ref-cells) onto the query.
+ref_expr = reference.get_assay().layer_data("data", features=["CD3D", "MS4A1"])
+imputed = transfer_data(anchors, refdata=ref_expr, refdata_features=["CD3D", "MS4A1"])
+```
+
+**`reduction="pcaproject"`** (the default) projects the query through the
+*reference's* PCA loadings — the principal axes are learned once on the reference
+and the query is pushed through the same map. Because those axes never saw the
+query, batch-specific structure the reference lacks simply lands nowhere, which
+is what makes projection robust for annotation. **`reduction="cca"`** learns a
+joint space instead, for the harder cross-modality / cross-species cases.
+
+> `transfer_data` weights each query cell's anchors with the same
+> distance-weighted, score-scaled Gaussian kernel `integrate_data` uses, so a
+> query cell surrounded by confident, consistent anchors of one type gets a
+> high `prediction.score.max`; an ambiguous one gets a low score you can filter
+> on. Placing the query in the reference *UMAP* (`MapQuery` / `ProjectUMAP`)
+> builds on these same anchors and lands next.
 
 ### Pseudobulk & conserved markers
 


### PR DESCRIPTION
Implements Seurat's reference-mapping workflow — annotate an unlabelled query from an annotated atlas — in a new `shanuz/transfer.py`, reusing the anchor machinery from `anchors.py` end to end. This is the anchor + transfer core of v0.3.0; `MapQuery` / `ProjectUMAP` remains the open item.

## What's here

**`find_transfer_anchors(reference, query, reduction="pcaproject", …) -> TransferAnchors`**
- Default **`pcaproject`**: project the query through the *reference's* PCA loadings (computed on the shared anchor features, so the reference needn't already carry a `pca` reduction). Because the axes never saw the query, batch structure the reference lacks lands nowhere — robust for annotation.
- **`cca`**: a jointly-learned space, for the harder cross-modality/species cases.
- MNN → score → filter reuse the exact helpers behind `find_integration_anchors` (`_mutual_nn`, `_score_anchors`, `_filter_anchors`, `_cca`, `_pca_loadings`). The reference is never moved; anchors are directional (reference → query).
- `TransferAnchors` container: anchor pairs (`cell1`/`cell2`/`score`) + the query embedding used for weighting.

**`transfer_data(anchors, refdata, …) -> pandas.DataFrame`**
- Builds a per-query-cell weight over the anchors — the same distance-weighted, anchor-score-scaled Gaussian kernel `integrate_data` uses.
- **Classification** (metadata column name or 1-D label array): `predicted.id`, one `prediction.score.<class>` per reference class (each query cell's rows sum to 1), and `prediction.score.max`.
- **Imputation** (2-D `features × reference-cells` matrix): predicted query expression.

**Exports:** `find_transfer_anchors`, `transfer_data`, `TransferAnchors` in `shanuz/__init__.py`.

## Design notes
- `pcaproject` computes the reference PCA on the anchor features internally (parallel to how `rpca` works in `find_integration_anchors`) rather than requiring a pre-existing reference reduction — keeps it self-contained and testable.
- `integrate_data` / `anchors.py` left untouched; transfer only *imports* the shared internals.

## Tests — `tests/test_transfer.py` (+11)
Anchor shape/scores/determinism, the `cca` path, label-transfer accuracy **>85%** across an injected batch block, per-class scores forming a distribution (rows sum to 1), the raw-label-array form, error paths (unknown column, wrong-length array, no anchors), and continuous imputation recovering the A/B marker split.

- Full suite: **293 passed** (was 282; +11)
- `ruff check` on the new files: clean

## Docs
- **README:** reference-mapping feature line; v0.3.0 milestone row (`TransferData` ✅, `MapQuery` 🚧).
- **ROADMAP:** v0.3.0 section — `FindTransferAnchors` / `TransferData` marked ✅ delivered, `MapQuery`/`ProjectUMAP` as next; priority #4 updated.
- **tutorials/README:** two quick-ref rows + a "Reference mapping" section with a runnable snippet (classification + imputation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)