### PR TITLE
Add reference-UMAP projection (MapQuery / ProjectUMAP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Signature scoring** — `add_module_score`, `cell_cycle_scoring` (S/G2M + Phase)
 - **Dimensionality reduction** — `run_pca`, `run_spca` (supervised, off a cell graph), `run_ica`, `run_tsne`, `glm_pca` (Poisson or negative binomial, straight on counts)
 - **Batch correction / integration** — `run_harmony` (via harmonypy), CCA/RPCA anchors (`find_integration_anchors` + `integrate_data`), and the `integrate_layers` dispatcher (`method="harmony"|"cca"|"rpca"`)
-- **Reference mapping** — `find_transfer_anchors` (project a query into a reference; `pcaproject` or `cca`) + `transfer_data` (annotate the query with reference labels, or impute reference expression onto it)
+- **Reference mapping** — `find_transfer_anchors` (project a query into a reference; `pcaproject` or `cca`) + `transfer_data` (annotate the query with reference labels, or impute reference expression onto it); `project_umap` / `map_query` place the query in the reference's own UMAP in one call
 - **Nearest-neighbour graph** — `find_neighbors` (KNN + SNN)
 - **Multimodal WNN** — `find_multi_modal_neighbors` (per-cell RNA/protein weights, joint `wknn`/`wsnn` graphs)
 - **Clustering** — `find_clusters` (Louvain via python-igraph, Leiden via leidenalg)
@@ -290,7 +290,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | Milestone | Focus |
 |-----------|-------|
 | v0.2.0 | Batch correction — Harmony, CCA/RPCA anchors, `IntegrateLayers` dispatcher ✅ *(complete)* |
-| v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData` ✅, `MapQuery` 🚧 |
+| v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData`, `MapQuery`/`ProjectUMAP` ✅ *(complete)* |
 | v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(delivered — see Tutorial 3)* |
 | v0.5.0 | Additional reductions — t-SNE, ICA, `run_spca`, `glm_pca` (Poisson + negative binomial) ✅ *(complete)* |
 | v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`), bimod (`test_use="bimod"`) ✅ *(complete)* |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,16 +70,16 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 
 ---
 
-## v0.3.0 — Reference Mapping & Label Transfer — 🚧 in progress
+## v0.3.0 — Reference Mapping & Label Transfer — ✅ complete
 
 > **Why:** label transfer from a curated atlas to a query dataset is a standard
 > first-annotation step; all machinery (KNN, PCA, anchors) already exists.
 >
-> **Status:** the anchor + transfer core is delivered — `find_transfer_anchors`
+> **Status:** all three pieces delivered — `find_transfer_anchors`
 > (pcaproject / cca) and `transfer_data` (classification + imputation) in
-> `shanuz/transfer.py`, reusing the `anchors.py` machinery end-to-end.
-> `MapQuery` / `ProjectUMAP` (placing the query in the reference UMAP) is the
-> remaining item.
+> `shanuz/transfer.py`, plus `project_umap` / `map_query` in `shanuz/mapping.py`
+> (placing the query in the reference UMAP). Reuses the `anchors.py` machinery
+> end-to-end and adds no dependency.
 
 ### `FindTransferAnchors` — ✅ delivered
 - Implemented as `find_transfer_anchors(reference, query, reduction="pcaproject")`
@@ -105,12 +105,25 @@ Spatial data structures (FOV/Centroids/Segmentation/Molecules)
 - **Tests:** query cells get the correct transferred label at >85% accuracy;
   per-class scores form a distribution; imputation recovers the marker split.
 
-### `MapQuery` + `ProjectUMAP` — ⏳ next
-- **R:** `MapQuery(query, reference, refmodel)` then `ProjectUMAP(...)`
-- **Plan:** compose `FindTransferAnchors` + `TransferData` + UMAP projection
-  (transform-only mode of `umap-learn`, using reference's fitted UMAP model)
-- **Note:** `umap-learn` exposes `UMAP.transform(query_embeddings)` — store the
-  fitted model in `obj.reductions["umap"].misc["umap_model"]` after `run_umap`
+### `MapQuery` + `ProjectUMAP` — ✅ delivered
+- Implemented in `shanuz/mapping.py` as `project_umap(query, reference)` and the
+  `map_query(anchors, refdata="celltype")` convenience. `project_umap` is a
+  two-step map: project the query through the reference's PCA loadings into the
+  reference's PC space, then run the reference's *fitted* UMAP model in
+  transform-only mode (`umap-learn`'s `UMAP.transform`), so the query lands in the
+  reference's existing embedding. It aligns the loadings to only the reference-PCA
+  features the query actually carries scaled, so a query missing a few variable
+  features still projects. Result stored as `query.reductions["ref.umap"]`.
+- `map_query` composes the whole workflow from a `TransferAnchors`: `transfer_data`
+  the labels onto `query.meta_data` (`predicted.id` / `prediction.score.*`), then
+  `project_umap` the query into the reference UMAP — one call from anchors to an
+  annotated, atlas-placed query. Verified (`tests/test_mapping.py`) that projected
+  query cells land nearest the matching reference type's UMAP centroid (>85%)
+  despite an injected batch block, and that `map_query` annotates + places in one
+  call.
+- **R:** `MapQuery(anchorset, query, reference, refdata = ...)` then `ProjectUMAP(...)`
+- **Note:** the fitted model lives in `reference.reductions["umap"].misc["umap_model"]`,
+  stored by `run_umap` when embedding from a reduction (not a graph).
 
 ---
 
@@ -531,11 +544,12 @@ If milestones are too large, these are the highest-value individual items:
 1. ~~**Harmony** (`v0.2.0`)~~ — ✅ delivered (`run_harmony` / `integrate_layers`)
 2. ~~**WNN** (`v0.4.0`)~~ — ✅ delivered (`find_multi_modal_neighbors` + `run_umap(graph=)`); CBMC tutorial section still open
 3. ~~**GitHub Actions CI** (`v0.10.0`)~~ — ✅ delivered
-4. **`FindTransferAnchors` / `TransferData`** (`v0.3.0`) — ✅ delivered
-   (`shanuz/transfer.py`: `find_transfer_anchors` pcaproject/cca + `transfer_data`
-   classification/imputation), enabling atlas-based annotation. Built on the
-   v0.2.0 anchor machinery. **`MapQuery` / `ProjectUMAP`** (query into the
-   reference UMAP) is the remaining v0.3.0 item.
+4. ~~**`FindTransferAnchors` / `TransferData` / `MapQuery` / `ProjectUMAP`**~~ ✅
+   (`v0.3.0`) — `shanuz/transfer.py` (`find_transfer_anchors` pcaproject/cca +
+   `transfer_data` classification/imputation) and `shanuz/mapping.py`
+   (`project_umap` + `map_query`) deliver atlas-based annotation and place the
+   query in the reference UMAP. Built on the v0.2.0 anchor machinery — **v0.3.0 is
+   complete**.
 5. ~~**`FindSpatiallyVariableFeatures`** + **`SpatialFeaturePlot`**~~ ✅ (`v0.7.0`) — all four loaders, niche/neighbourhood analysis, both spatially-variable-feature methods (Moran's I and markvariogram), the `VisiumV2` tissue-image data layer and the `spatial_*` H&E plots delivered; **v0.7.0 is complete**
 6. ~~**`AggregateExpression` + DESeq2**~~ ✅ (`v0.6.0`) — `aggregate_expression`,
    `find_conserved_markers`, and pseudobulk DESeq2 (`test_use="deseq2"`) delivered;

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -33,6 +33,7 @@ from .transfer import (
     transfer_data,
     TransferAnchors,
 )
+from .mapping import map_query, project_umap
 from .markers import find_markers, find_all_markers, find_conserved_markers
 from .aggregate import aggregate_expression
 from .sctransform import sctransform
@@ -151,6 +152,8 @@ __all__ = [
     "find_transfer_anchors",
     "transfer_data",
     "TransferAnchors",
+    "map_query",
+    "project_umap",
     "find_markers",
     "find_all_markers",
     "find_conserved_markers",

--- a/shanuz/mapping.py
+++ b/shanuz/mapping.py
@@ -1,0 +1,284 @@
+"""Reference mapping, part two — Seurat's ``ProjectUMAP`` / ``MapQuery``.
+
+``transfer.py`` gets you *anchors* between a fixed reference and a query and
+carries labels or expression across them. This module does the last thing you
+usually want from a reference: **place the query in the reference's own UMAP**,
+so the new cells land on the atlas you already know how to read.
+
+The trick is that a UMAP is not an equation you can apply to a new point — it is
+a stochastic optimisation. ``umap-learn`` solves this by keeping the fitted
+model around: :func:`shanuz.run_umap` stashes it in
+``reduction.misc["umap_model"]``, and its ``.transform`` places new points into
+the *existing* embedding by pinning them near the training points they resemble
+and running a short, held-fixed optimisation. So projection is a two-step map:
+
+  1. **query → reference PCA.** The reference's PCA is a plain linear map from
+     genes to components (``embeddings = scaledᵀ @ loadings``). Push the query's
+     scaled expression through the *reference's* loadings and the query lands in
+     the same principal-component space the reference UMAP was trained on — the
+     same "project into a space the query never helped define" logic that makes
+     :func:`shanuz.find_transfer_anchors`'s ``pcaproject`` robust.
+  2. **reference PCA → reference UMAP.** Run the reference's fitted UMAP model in
+     transform-only mode on those projected coordinates.
+
+:func:`project_umap` is that two-step map on its own. :func:`map_query` is the
+Seurat ``MapQuery`` convenience that composes the whole reference-mapping
+workflow: take the anchors, :func:`~shanuz.transfer_data` the labels onto the
+query's metadata, and :func:`project_umap` the query into the reference UMAP —
+one call from anchors to an annotated, atlas-placed query.
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+
+from .dimreduc import DimReduc
+from .transfer import TransferAnchors, transfer_data
+
+
+# ----------------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------------
+
+
+def project_umap(
+    query,
+    reference,
+    reduction: str = "pca",
+    umap_reduction: str = "umap",
+    dims: Optional[Union[list[int], range]] = None,
+    reduction_name: str = "ref.umap",
+    reduction_key: str = "refUMAP_",
+    layer: str = "scale.data",
+) -> DimReduc:
+    """Project a query into a reference's UMAP (Seurat's ``ProjectUMAP``).
+
+    Mirrors ``ProjectUMAP(query, reference, reduction.model = "umap")``. The
+    query is first projected into the reference's PCA (through the reference's
+    loadings), then run through the reference's *fitted* UMAP model in
+    transform-only mode — so the query cells land in the reference's existing
+    embedding rather than in a fresh, unrelated one. Stores the result as
+    ``query.reductions[reduction_name]`` and returns it.
+
+    The reference must already carry both a PCA reduction (``reduction``, for the
+    loadings) and a UMAP reduction (``umap_reduction``) fitted with a returnable
+    model — i.e. ``run_umap(reference)``, which stashes the ``umap-learn`` model
+    in ``reduction.misc["umap_model"]``.
+
+    Parameters
+    ----------
+    query          : query Shanuz object (normalized + scaled on the reference's
+                     PCA features).
+    reference      : reference Shanuz object carrying the fitted PCA + UMAP.
+    reduction      : reference reduction whose loadings project the query
+                     (default ``"pca"``).
+    umap_reduction : reference reduction holding the fitted UMAP model (default
+                     ``"umap"``).
+    dims           : which PCA dimensions to feed the UMAP model (0-indexed).
+                     Defaults to the dimensions the model was trained on.
+    reduction_name : storage key for the projection in ``query.reductions``.
+    reduction_key  : prefix for the projected dimension names.
+    layer          : layer to draw the query's expression from.
+
+    Returns
+    -------
+    DimReduc
+        The query's cells in the reference UMAP; also stored on ``query``.
+    """
+    if reduction not in reference.reductions:
+        raise KeyError(
+            f"Reference reduction {reduction!r} not found; run run_pca(reference) "
+            "first."
+        )
+    if umap_reduction not in reference.reductions:
+        raise KeyError(
+            f"Reference reduction {umap_reduction!r} not found; run "
+            "run_umap(reference) first."
+        )
+
+    umap_dr = reference.reductions[umap_reduction]
+    model = umap_dr.misc.get("umap_model")
+    if model is None:
+        raise ValueError(
+            f"Reference reduction {umap_reduction!r} has no fitted UMAP model in "
+            "misc['umap_model']; run_umap(reference) must be run from a reduction "
+            "(not a graph) so the model is stored for transform-only projection."
+        )
+
+    query_pca = _project_into_reference_pca(query, reference, reduction, layer)
+    query_pca = _select_model_dims(query_pca, model, dims)
+
+    umap_coords = np.asarray(model.transform(query_pca))
+
+    dim_names = [f"{reduction_key}{i + 1}" for i in range(umap_coords.shape[1])]
+    projected = DimReduc(
+        cell_embeddings=umap_coords,
+        cell_names=query.cell_names(),
+        feature_names=dim_names,
+        assay_used=query.active_assay,
+        key=reduction_key,
+        misc={
+            "projected_from": umap_reduction,
+            "reference_reduction": reduction,
+            "query_pca": query_pca,
+        },
+    )
+    query.reductions[reduction_name] = projected
+    return projected
+
+
+def map_query(
+    anchors: TransferAnchors,
+    refdata: Optional[Union[str, np.ndarray, list, pd.Series]] = None,
+    reference_reduction: str = "pca",
+    reduction_model: str = "umap",
+    reduction_name: str = "ref.umap",
+    reduction_key: str = "refUMAP_",
+    k_weight: int = 50,
+    sd_weight: float = 1.0,
+    refdata_features: Optional[list[str]] = None,
+    layer: str = "scale.data",
+) -> Optional[pd.DataFrame]:
+    """Annotate and place a query in a reference (Seurat's ``MapQuery``).
+
+    Mirrors ``MapQuery(anchorset, query, reference, refdata = "celltype")``. The
+    single call that turns transfer anchors into a mapped query:
+
+    1. :func:`~shanuz.transfer_data` carries ``refdata`` across the anchors, and
+       — for a categorical label — writes ``predicted.id`` /
+       ``prediction.score.*`` straight onto ``query.meta_data``.
+    2. :func:`project_umap` projects the query into the reference's UMAP, stored
+       as ``query.reductions[reduction_name]``.
+
+    Both steps mutate the query object (the anchors' ``query``) in place.
+
+    Parameters
+    ----------
+    anchors             : a :class:`~shanuz.TransferAnchors` from
+                          :func:`~shanuz.find_transfer_anchors`.
+    refdata             : reference labels to transfer (metadata column name or a
+                          per-reference-cell array) or a 2-D
+                          ``features × reference-cells`` matrix to impute. Pass
+                          ``None`` to skip transfer and only project the UMAP.
+    reference_reduction : reference reduction whose loadings project the query
+                          into the UMAP's input space (default ``"pca"``).
+    reduction_model     : reference reduction holding the fitted UMAP model.
+    reduction_name      : storage key for the projection in ``query.reductions``.
+    reduction_key       : prefix for the projected dimension names.
+    k_weight, sd_weight : anchor-weighting knobs passed to
+                          :func:`~shanuz.transfer_data`.
+    refdata_features    : row names for imputation output (2-D ``refdata``).
+    layer               : layer to draw the query's expression from.
+
+    Returns
+    -------
+    pandas.DataFrame or None
+        The transferred predictions (classification) or imputed expression
+        (imputation); ``None`` when ``refdata`` is not given.
+    """
+    query = anchors.query
+
+    predictions: Optional[pd.DataFrame] = None
+    if refdata is not None:
+        predictions = transfer_data(
+            anchors,
+            refdata,
+            k_weight=k_weight,
+            sd_weight=sd_weight,
+            refdata_features=refdata_features,
+        )
+        classification = isinstance(refdata, str) or np.ndim(refdata) == 1
+        if classification:
+            # Write predicted.id / prediction.score.* onto the query metadata,
+            # as Seurat's MapQuery does. Imputation output is returned, not stored.
+            for col in predictions.columns:
+                query.meta_data[col] = (
+                    predictions[col].reindex(query.meta_data.index).to_numpy()
+                )
+
+    project_umap(
+        query,
+        anchors.reference,
+        reduction=reference_reduction,
+        umap_reduction=reduction_model,
+        reduction_name=reduction_name,
+        reduction_key=reduction_key,
+        layer=layer,
+    )
+    return predictions
+
+
+# ----------------------------------------------------------------------
+# Internals
+# ----------------------------------------------------------------------
+
+
+def _project_into_reference_pca(query, reference, reduction: str, layer: str) -> np.ndarray:
+    """Project the query into the reference's PCA (``n_query × n_pcs``).
+
+    The reference PCA is a linear map ``scaledᵀ @ loadings``; pushing the query's
+    scaled expression through the *reference's* loadings lands it in the same
+    principal-component space. Only the reference PCA features the query actually
+    carries (scaled) are used, and the loadings are subset to match, so a query
+    missing a few of the reference's variable features still projects cleanly.
+    """
+    ref_pca = reference.reductions[reduction]
+    ref_feats = ref_pca.features()
+    loadings = np.asarray(ref_pca.feature_loadings)  # (n_ref_feats × n_pcs)
+    if loadings.shape[0] != len(ref_feats):
+        raise ValueError(
+            f"Reference reduction {reduction!r} carries no feature loadings; it "
+            "cannot project a query. Use run_pca(reference)."
+        )
+
+    assay = query.get_assay()
+    scaled_here = set(_scaled_feature_names(assay, layer))
+    feat_pos = {f: i for i, f in enumerate(ref_feats)}
+    keep = [f for f in ref_feats if f in scaled_here]
+    if not keep:
+        raise ValueError(
+            "The query shares none of the reference PCA's features (scaled); "
+            "ensure both were scaled on a common feature set."
+        )
+
+    loadings_kept = loadings[[feat_pos[f] for f in keep], :]  # (n_keep × n_pcs)
+    query_scaled = assay.layer_data(layer, features=keep)     # (n_keep × n_query)
+    if sp.issparse(query_scaled):
+        query_scaled = query_scaled.toarray()
+    query_scaled = np.asarray(query_scaled, dtype=float)
+
+    return query_scaled.T @ loadings_kept                     # (n_query × n_pcs)
+
+
+def _select_model_dims(
+    query_pca: np.ndarray, model, dims: Optional[Union[list[int], range]]
+) -> np.ndarray:
+    """Take the PCA dimensions the fitted UMAP model expects as input.
+
+    With ``dims`` given, use exactly those columns. Otherwise default to the
+    dimensions the model was trained on (``run_umap``'s default is every PCA
+    dimension, so this is usually a no-op), inferred from the fitted model when
+    ``umap-learn`` exposes the training data.
+    """
+    if dims is not None:
+        return query_pca[:, list(dims)]
+
+    trained = getattr(model, "_raw_data", None)
+    if trained is not None and getattr(trained, "ndim", 0) == 2:
+        n_in = trained.shape[1]
+        if n_in <= query_pca.shape[1]:
+            return query_pca[:, :n_in]
+    return query_pca
+
+
+def _scaled_feature_names(assay, layer: str) -> list[str]:
+    """Which features the assay actually carries in its scaled layer."""
+    from .assay5 import Assay5
+
+    if isinstance(assay, Assay5):
+        return list(assay._layer_features.get(layer, assay._all_feature_names))
+    # Classic Assay v3 stores scale_data over the assay's feature list.
+    return list(assay._feature_names)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,194 @@
+"""Tests for reference mapping, part two (v0.3.0).
+
+  * project_umap  (mapping.py)
+  * map_query     (mapping.py)
+
+Builds an annotated reference with a fitted PCA + UMAP and an unlabelled query
+(same two cell types, the query carrying a batch-effect gene block the reference
+never sees), then checks that projecting the query lands each cell in the right
+neighbourhood of the *reference's* UMAP and that ``map_query`` both annotates and
+places the query in one call. Network-free.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from shanuz.shanuz import create_shanuz_object  # noqa: E402
+from shanuz.preprocessing import (  # noqa: E402
+    normalize_data,
+    find_variable_features,
+    scale_data,
+)
+from shanuz.reduction import run_pca  # noqa: E402
+from shanuz.umap import run_umap  # noqa: E402
+from shanuz.dimreduc import DimReduc  # noqa: E402
+from shanuz.transfer import find_transfer_anchors  # noqa: E402
+from shanuz.mapping import map_query, project_umap  # noqa: E402
+
+
+def _labelled_object(batch, seed=0, n_per=40, G=200):
+    """Two cell types (A/B); batch '2' carries a batch-effect gene block."""
+    rng = np.random.default_rng(seed)
+    mat = np.zeros((G, 2 * n_per))
+    celltype, cells = [], []
+    c = 0
+    for t in ("A", "B"):
+        for _ in range(n_per):
+            base = rng.gamma(0.3, size=G) + 0.05
+            if t == "A":
+                base[0:50] += 5.0
+            else:
+                base[50:100] += 5.0
+            if batch == "2":
+                base[100:150] += 4.0          # batch-specific gene block
+            mat[:, c] = rng.poisson(base * 3000.0 / base.sum())
+            celltype.append(t)
+            cells.append(f"b{batch}_c{c}")
+            c += 1
+
+    meta = pd.DataFrame({"celltype": celltype, "batch": batch}, index=cells)
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(mat), assay="RNA",
+        feature_names=[f"g{i}" for i in range(G)], cell_names=cells,
+        meta_data=meta,
+    )
+    normalize_data(obj)
+    find_variable_features(obj, selection_method="vst", nfeatures=150)
+    scale_data(obj)
+    return obj, np.array(celltype)
+
+
+def _ref_query(seed=0):
+    """Reference (with a fitted PCA + UMAP) and an unlabelled query.
+
+    Both are scaled on a shared feature set so the query carries every feature
+    the reference's PCA is built on.
+    """
+    reference, ct_ref = _labelled_object("1", seed=seed)
+    query, ct_query = _labelled_object("2", seed=seed + 1)
+
+    common = [
+        f for f in reference.get_assay().variable_features
+        if f in set(query.get_assay().variable_features)
+    ]
+    scale_data(reference, features=common)
+    scale_data(query, features=common)
+    run_pca(reference, n_pcs=20, features=common)
+    run_umap(reference, n_neighbors=15, min_dist=0.3, seed=42)
+    return reference, query, ct_ref, ct_query
+
+
+def _umap_centroid_accuracy(query_coords, ref_coords, ct_ref, ct_query):
+    """Classify each query cell by the nearest reference-type UMAP centroid."""
+    classes = sorted(set(ct_ref))
+    centroids = {c: ref_coords[ct_ref == c].mean(axis=0) for c in classes}
+    preds = []
+    for row in query_coords:
+        d = {c: np.linalg.norm(row - centroids[c]) for c in classes}
+        preds.append(min(d, key=d.get))
+    return float(np.mean(np.asarray(preds) == np.asarray(ct_query)))
+
+
+# ----------------------------------------------------------------------
+# project_umap
+# ----------------------------------------------------------------------
+
+
+def test_project_umap_stores_reference_embedding():
+    reference, query, _, _ = _ref_query()
+
+    dr = project_umap(query, reference)
+
+    assert isinstance(dr, DimReduc)
+    assert "ref.umap" in query.reductions
+    assert dr.cell_embeddings.shape == (len(query), 2)
+    assert dr.cells() == query.cell_names()
+    # The intermediate reference-PCA projection is kept for introspection.
+    assert dr.misc["query_pca"].shape[0] == len(query)
+
+
+def test_project_umap_places_query_near_matching_reference_type():
+    reference, query, ct_ref, ct_query = _ref_query()
+    dr = project_umap(query, reference)
+
+    ref_umap = reference.reductions["umap"].cell_embeddings
+    acc = _umap_centroid_accuracy(dr.cell_embeddings, ref_umap, ct_ref, ct_query)
+    # Despite the query's batch block, projection lands cells with the right type.
+    assert acc > 0.85
+
+
+def test_project_umap_missing_pca_raises():
+    reference, query, _, _ = _ref_query()
+    del reference.reductions["pca"]
+    with pytest.raises(KeyError):
+        project_umap(query, reference)
+
+
+def test_project_umap_requires_fitted_model():
+    reference, query, _, _ = _ref_query()
+    # A UMAP reduction with no stored model (e.g. embedded from a graph).
+    reference.reductions["umap"] = DimReduc(
+        cell_embeddings=reference.reductions["umap"].cell_embeddings,
+        cell_names=reference.cell_names(),
+        key="UMAP_",
+        misc={"umap_graph": "wsnn"},
+    )
+    with pytest.raises(ValueError):
+        project_umap(query, reference)
+
+
+# ----------------------------------------------------------------------
+# map_query
+# ----------------------------------------------------------------------
+
+
+def test_map_query_annotates_and_projects():
+    reference, query, _, ct_query = _ref_query()
+    anchors = find_transfer_anchors(reference, query, reduction="pcaproject")
+
+    pred = map_query(anchors, refdata="celltype")
+
+    # Labels transferred and written onto the query metadata.
+    assert "predicted.id" in query.meta_data.columns
+    assert "prediction.score.max" in query.meta_data.columns
+    assert np.mean(query.meta_data["predicted.id"].to_numpy() == ct_query) > 0.85
+    # Predictions are also returned.
+    assert list(pred.index) == query.cell_names()
+    # And the query is placed in the reference UMAP.
+    assert "ref.umap" in query.reductions
+    assert query.reductions["ref.umap"].cell_embeddings.shape == (len(query), 2)
+
+
+def test_map_query_without_refdata_only_projects():
+    reference, query, _, _ = _ref_query()
+    anchors = find_transfer_anchors(reference, query)
+
+    pred = map_query(anchors, refdata=None)
+
+    assert pred is None
+    assert "predicted.id" not in query.meta_data.columns
+    assert "ref.umap" in query.reductions
+
+
+def test_map_query_imputes_without_writing_metadata():
+    reference, query, _, _ = _ref_query()
+    anchors = find_transfer_anchors(reference, query)
+
+    feats = ["g10", "g60"]
+    ref_expr = reference.get_assay().layer_data("data", features=feats)
+    ref_expr = ref_expr.toarray() if sp.issparse(ref_expr) else np.asarray(ref_expr)
+
+    imputed = map_query(anchors, refdata=ref_expr, refdata_features=feats)
+
+    # Imputation output is returned as a matrix, not written to metadata.
+    assert list(imputed.index) == feats
+    assert list(imputed.columns) == query.cell_names()
+    assert "predicted.id" not in query.meta_data.columns
+    # The UMAP projection still happens.
+    assert "ref.umap" in query.reductions

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -257,6 +257,8 @@ same caveat as the other tutorials.
 | CCA/RPCA layers | `IntegrateLayers(obj, method=CCAIntegration)` | `integrate_layers(obj, method="cca", group_by="batch")` (or `"rpca"`) |
 | Transfer anchors | `FindTransferAnchors(reference, query, reduction="pcaproject")` | `find_transfer_anchors(reference, query, reduction="pcaproject")` (or `"cca"`) |
 | Transfer labels | `TransferData(anchors, refdata=reference$celltype)` | `transfer_data(anchors, refdata="celltype")` |
+| Project into reference UMAP | `ProjectUMAP(query, reference, reduction.model="umap")` | `project_umap(query, reference)` |
+| Map query (annotate + place) | `MapQuery(anchors, query, reference, refdata=list(id="celltype"))` | `map_query(anchors, refdata="celltype")` |
 | Markers | `FindMarkers(pbmc, ident.1)` | `find_markers(pbmc, ident_1)` |
 | All markers | `FindAllMarkers(pbmc, only.pos, logfc.threshold)` | `find_all_markers(pbmc, only_pos, logfc_threshold)` |
 | Conserved markers | `FindConservedMarkers(pbmc, ident.1, grouping.var)` | `find_conserved_markers(pbmc, ident_1, grouping_var)` |
@@ -419,8 +421,41 @@ joint space instead, for the harder cross-modality / cross-species cases.
 > distance-weighted, score-scaled Gaussian kernel `integrate_data` uses, so a
 > query cell surrounded by confident, consistent anchors of one type gets a
 > high `prediction.score.max`; an ambiguous one gets a low score you can filter
-> on. Placing the query in the reference *UMAP* (`MapQuery` / `ProjectUMAP`)
-> builds on these same anchors and lands next.
+> on.
+
+#### Placing the query in the reference UMAP
+
+Annotating the query is half the job; the other half is *seeing* it on the atlas
+you already know how to read. `project_umap` runs the reference's **fitted** UMAP
+model in transform-only mode, so the query cells land in the reference's existing
+embedding rather than in a fresh, unrelated one. `map_query` composes the whole
+workflow — transfer the labels *and* project the UMAP — in a single call.
+
+```python
+from shanuz import run_pca, run_umap, find_transfer_anchors, map_query, project_umap
+
+# The reference needs a fitted PCA + UMAP; run_umap stashes the umap-learn model
+# in reference.reductions["umap"].misc["umap_model"] for transform-only projection.
+run_pca(reference)
+run_umap(reference)                       # embeds from "pca", keeps the model
+
+anchors = find_transfer_anchors(reference, query, reduction="pcaproject")
+
+# One call: transfer_data writes predicted.id / prediction.score.* onto the
+# query's metadata, and project_umap places it in the reference UMAP.
+pred = map_query(anchors, refdata="celltype")
+query.reductions["ref.umap"]              # the query, on the reference's UMAP
+
+# Or just the projection, without label transfer:
+project_umap(query, reference)            # -> query.reductions["ref.umap"]
+```
+
+`project_umap` is itself a two-step map: it projects the query through the
+*reference's* PCA loadings into the reference's PC space (the same "project into a
+space the query never helped define" logic as `pcaproject` above), then runs the
+reference's UMAP model's `.transform`. A query cell that resembles reference
+T cells is pinned near the reference's T-cell island and optimised to sit there —
+so the query overlays the atlas, batch block and all.
 
 ### Pseudobulk & conserved markers
 


### PR DESCRIPTION
Completes the **v0.3.0 Reference Mapping** milestone — the last item after `find_transfer_anchors` / `transfer_data` (#22). New module `shanuz/mapping.py` places a query in the reference's own UMAP.

## What's new

- **`project_umap(query, reference)`** — Seurat's `ProjectUMAP`. A two-step map:
  1. project the query through the *reference's* PCA loadings into the reference's PC space (the same "project into a space the query never helped define" logic that makes `find_transfer_anchors`'s `pcaproject` robust), then
  2. run the reference's **fitted** `umap-learn` model in transform-only mode (`UMAP.transform`), so the query lands in the reference's existing embedding rather than a fresh one.

  Aligns the loadings to only the reference-PCA features the query actually carries scaled, so a query missing a few variable features still projects cleanly. Result stored as `query.reductions["ref.umap"]`.

- **`map_query(anchors, refdata="celltype")`** — Seurat's `MapQuery`. Composes the whole workflow from a `TransferAnchors`: `transfer_data` the labels onto `query.meta_data` (`predicted.id` / `prediction.score.*`), then `project_umap` the query into the reference UMAP — one call from anchors to an annotated, atlas-placed query. Returns the predictions (or imputed matrix; `None` when `refdata` is omitted).

Reuses `transfer.py` + `umap.py` end-to-end. The fitted model comes from `run_umap`, which already stashes it in `reference.reductions["umap"].misc["umap_model"]`. **No new dependency.**

## Tests

`tests/test_mapping.py` — 7 tests:
- projection stores the reference embedding (shape / cell names / intermediate PCA kept in `misc`)
- **projected query cells land nearest the matching reference type's UMAP centroid (>85%)** despite an injected batch block
- missing-PCA (`KeyError`) and no-fitted-model (`ValueError`) guards
- `map_query` annotate + project, project-only (`refdata=None`), and imputation-without-metadata paths

**Full suite: 300 passing (+7 from this PR). `ruff check` clean.**

## Docs
- `ROADMAP.md`: v0.3.0 marked ✅ complete; `MapQuery`/`ProjectUMAP` entry filled in; priority #4 struck through.
- `README.md`: reference-mapping feature bullet + milestone table row.
- `tutorials/README.md`: two API-reference rows + a "Placing the query in the reference UMAP" walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)