### PR TITLE
Add leverage-score sketching (SketchData / ProjectData)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Dimensionality reduction** — `run_pca`, `run_spca` (supervised, off a cell graph), `run_ica`, `run_tsne`, `glm_pca` (Poisson or negative binomial, straight on counts)
 - **Batch correction / integration** — `run_harmony` (via harmonypy), CCA/RPCA anchors (`find_integration_anchors` + `integrate_data`), and the `integrate_layers` dispatcher (`method="harmony"|"cca"|"rpca"`)
 - **Reference mapping** — `find_transfer_anchors` (project a query into a reference; `pcaproject` or `cca`) + `transfer_data` (annotate the query with reference labels, or impute reference expression onto it); `project_umap` / `map_query` place the query in the reference's own UMAP in one call
+- **Scale (sketching)** — `sketch_data` draws a leverage-weighted subset of a huge dataset (rare states kept, not lost), `leverage_score` computes the per-cell scores via a CountSketch (no full SVD), and `project_data` extends the sketch's PCA/UMAP/labels back to every cell
 - **Nearest-neighbour graph** — `find_neighbors` (KNN + SNN)
 - **Multimodal WNN** — `find_multi_modal_neighbors` (per-cell RNA/protein weights, joint `wknn`/`wsnn` graphs)
 - **Clustering** — `find_clusters` (Louvain via python-igraph, Leiden via leidenalg)
@@ -295,7 +296,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | v0.5.0 | Additional reductions — t-SNE, ICA, `run_spca`, `glm_pca` (Poisson + negative binomial) ✅ *(complete)* |
 | v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`), bimod (`test_use="bimod"`) ✅ *(complete)* |
 | v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I + markvariogram), `image_*` plots, `VisiumV2` tissue images, `spatial_*` H&E plots ✅ *(delivered — see Tutorial 5)* |
-| v0.8.0 | Scale — BPCells-style lazy matrices, `SketchData`, `ProjectData` |
+| v0.8.0 | Scale — `SketchData`/`ProjectData` (leverage-score sketching) ✅; BPCells-style lazy matrices *(open)* |
 | v0.9.0 | Specialized — `HTODemux`, Mixscape (CRISPR screens) |
 | v0.10.0 | Infrastructure — PyPI, GitHub Actions CI, type annotations, MkDocs site |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -425,6 +425,12 @@ brute-force loop over every cell pair (`tests/test_markvariogram.py`).
 
 ## v0.8.0 — Scale & Performance
 
+> **Status:** leverage-score sketching is delivered — `sketch_data` /
+> `project_data` (+ the standalone `leverage_score`) in `shanuz/sketch.py` draw an
+> information-dense subset of a huge dataset and extend the sketch's analysis back
+> to every cell, reusing the `mapping.py` projection and `transfer.py` anchors and
+> adding no dependency. BPCells-style lazy/on-disk matrices remain open.
+
 ### BPCells-style lazy/on-disk matrices
 - **R:** `BPCells` package enables out-of-core analysis on millions of cells
 - **Python dep:** `bpcells-python` (if available) or `zarr` / `h5py` lazy arrays
@@ -433,20 +439,46 @@ brute-force loop over every cell pair (`tests/test_markvariogram.py`).
   (they support numpy-style slicing). The key change is avoiding `.toarray()` /
   `.todense()` calls in hot paths — audit and gate these behind shape checks.
 
-### `SketchData` (leverage-score sub-sampling)
+### `SketchData` (leverage-score sub-sampling) — ✅ delivered
+- Implemented as `sketch_data(obj, ncells=5000, method="LeverageScore")` in
+  `shanuz/sketch.py`, with the leverage computation exposed on its own as
+  `leverage_score(obj)`. Each cell is sampled **without replacement** with
+  probability proportional to its statistical leverage, so the rare states a
+  uniform sample would drop are kept (indeed over-represented, which the tests
+  check directly). Returns a standalone subset `Shanuz` object whose active assay
+  is renamed to `"sketch"`; the scores are written back onto the source object's
+  `leverage.score` metadata (`tests/test_sketch.py`).
+- **The leverage computation is the point, not a detail.** The exact leverage of
+  cell *i* is `ℓ_i = ‖U_i‖²` (the row norm of the left singular vectors), an
+  *O(n·d²)* SVD — the very cost sketching exists to avoid. So (as Seurat's
+  `LeverageScore` does) a sparse **CountSketch** `S` embeds the *n* rows into a
+  small `nsketch × d` matrix `B` with `BᵀB ≈ AᵀA` in a single pass over the
+  non-zeros; whitening `A` with `B`'s right singular vectors gives an approximately
+  orthonormal `Z` and `ℓ_i ≈ ‖Z_i‖²`. When `nsketch ≥ n` no sketch is taken and
+  the scores are exact — validated against the textbook `‖U_i‖²` to `1e-6`.
+- **One caveat, documented in the docstring and a test:** a single-hash CountSketch
+  is a faithful subspace embedding only once it has ~`d²` rows, so `nsketch` should
+  comfortably exceed the feature count (the default 5000 does, for the few-thousand
+  variable features a real sketch runs on).
 - **R:** `SketchData(obj, ncells = 5000, method = "LeverageScore")`
-- **Plan:**
-  1. Compute per-cell leverage scores from PCA: `lev[i] = ||U[i,:]||² / k` where
-     `U` is the left singular matrix of the scaled data
-  2. Sample `ncells` cells with probability proportional to leverage scores
-  3. Return subset `Shanuz` object; use `ProjectData` to extend results back to
-     the full dataset
-- **Tests:** sketched subset preserves cluster structure of the full dataset
+- **Divergence from R:** Seurat stores the sketch as an extra assay on the same
+  object; here it is a separate object (as the plan called for), which fits
+  shanuz's `subset` model and keeps the full/sketch data cleanly apart.
 
-### `ProjectData`
+### `ProjectData` — ✅ delivered
+- Implemented as `project_data(full, sketch, ...)` in `shanuz/sketch.py`, the
+  inverse of `sketch_data`. Projects every full-dataset cell through the *sketch's*
+  PCA loadings (stored as `full.reductions["pca.full"]`) — the same transform-only
+  linear map `project_umap` uses — and, when the sketch carries a fitted UMAP,
+  through that model too (`full.reductions["ref.umap"]`, via `project_umap`).
+  Optional `refdata` (`{new_col: sketch_col}` or a column name) carries the
+  sketch's labels to the full data via `find_transfer_anchors` + `transfer_data`.
+  Verified that projected sketch cells reproduce their sketch-PCA coordinates and
+  that transferred labels recover the full data's cell types at >85%
+  (`tests/test_sketch.py`).
 - **R:** `ProjectData(obj, reference = sketch, reduction = "pca")`
-- **Plan:** project the full dataset into sketch's PCA/UMAP space using
-  `sklearn.neighbors` or `umap-learn`'s `transform` method
+- **Reuse:** no new machinery — the PCA/UMAP projection is `mapping.py`'s and the
+  label transfer is `transfer.py`'s; `project_data` is the composition.
 
 ---
 
@@ -554,7 +586,10 @@ If milestones are too large, these are the highest-value individual items:
 6. ~~**`AggregateExpression` + DESeq2**~~ ✅ (`v0.6.0`) — `aggregate_expression`,
    `find_conserved_markers`, and pseudobulk DESeq2 (`test_use="deseq2"`) delivered;
    MAST (`test_use="mast"`) and bimod (`test_use="bimod"`) too — **v0.6.0 complete**
-7. **`SketchData`** (`v0.8.0`) — enables million-cell datasets
+7. ~~**`SketchData`** (`v0.8.0`)~~ — ✅ delivered (`sketch_data` / `project_data` +
+   `leverage_score` in `shanuz/sketch.py`): leverage-weighted subsampling for
+   million-cell datasets, and projection of the sketch's PCA/UMAP/labels back to
+   the full data. BPCells-style lazy matrices are the remaining v0.8.0 item.
 8. ~~**`run_spca` + `glm_pca`** (Poisson + negative binomial)~~ ✅ (`v0.5.0`) —
    **v0.5.0 is complete**; GLM-PCA now fits both `family="poisson"` and
    `family="nb"` (dispersion estimated by ML), closing the last gap in it

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -34,6 +34,7 @@ from .transfer import (
     TransferAnchors,
 )
 from .mapping import map_query, project_umap
+from .sketch import sketch_data, project_data, leverage_score
 from .markers import find_markers, find_all_markers, find_conserved_markers
 from .aggregate import aggregate_expression
 from .sctransform import sctransform
@@ -154,6 +155,9 @@ __all__ = [
     "TransferAnchors",
     "map_query",
     "project_umap",
+    "sketch_data",
+    "project_data",
+    "leverage_score",
     "find_markers",
     "find_all_markers",
     "find_conserved_markers",

--- a/shanuz/sketch.py
+++ b/shanuz/sketch.py
@@ -1,0 +1,358 @@
+"""Leverage-score sketching — Seurat's ``SketchData`` / ``ProjectData``.
+
+A million-cell atlas is mostly redundant: thousands of near-identical cells sit
+on top of each other in the common states, while the rare states — the ones you
+usually care about — are a handful of points each. Clustering, UMAP and marker
+tests on the whole thing are slow *and* dominated by the redundant majority.
+Sketching fixes both: pick a small, information-dense subset ("the sketch"),
+do the expensive analysis on that, then :func:`project_data` the answers back
+onto every cell.
+
+The subset is not a uniform random sample — that would just reproduce the
+majority. Cells are drawn with probability proportional to their **statistical
+leverage**. Leverage measures how much a cell influences the geometry of the
+data: a cell in a dense, redundant cloud has low leverage (drop it and the
+subspace is unchanged), while a cell in a sparse, distinctive corner has high
+leverage (it is the only evidence that corner exists). Sampling by leverage
+therefore keeps the rare states that uniform sampling throws away.
+
+**Computing leverage without an SVD of the whole matrix.** The exact leverage of
+row *i* of an *n × d* matrix ``A`` is ``ℓ_i = ‖U_i‖²``, where ``U`` are the left
+singular vectors — an *O(n d²)* SVD, the very cost we are trying to avoid. The
+classical fix (Drineas et al. 2012, and what Seurat's ``LeverageScore`` does) is
+a **subspace embedding**: hit the *n* rows with a sparse random ``CountSketch``
+``S`` (one signed entry per column, so ``SA`` costs a single pass over the
+non-zeros) to get a small ``nsketch × d`` matrix ``B`` with ``BᵀB ≈ AᵀA``.
+Whitening ``A`` with ``B``'s right singular vectors, ``Z = A · V Σ⁻¹``, makes
+``Z`` approximately orthonormal, and ``ℓ_i ≈ ‖Z_i‖²`` — leverage for every cell
+from one small factorisation. When ``nsketch ≥ n`` (small data) no sketch is
+taken and the scores are exact.
+
+:func:`leverage_score` is that computation on its own; :func:`sketch_data` draws
+the weighted subset and returns it as a standalone object; :func:`project_data`
+is the inverse map — it pushes every full-dataset cell through the *sketch's*
+PCA loadings (and, if present, its fitted UMAP model, reusing
+:func:`shanuz.project_umap`), and optionally carries cluster labels from the
+sketch to the full data via the :mod:`shanuz.transfer` anchors.
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+import scipy.sparse as sp
+
+from .dimreduc import DimReduc
+from .reduction import _default_features, _get_scaled_data
+
+
+# ----------------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------------
+
+
+def leverage_score(
+    obj,
+    nsketch: int = 5000,
+    features: Optional[list[str]] = None,
+    assay: Optional[str] = None,
+    layer: str = "scale.data",
+    var_name: Optional[str] = "leverage.score",
+    eps: float = 1e-8,
+    seed: int = 123,
+) -> np.ndarray:
+    """Per-cell statistical leverage (Seurat's ``LeverageScore``).
+
+    A cell's leverage is how much it influences the column space of the data — low
+    in a dense, redundant cloud, high in a sparse, distinctive corner. Leverage is
+    approximated with a ``CountSketch`` subspace embedding so no full SVD of the
+    data is needed; when ``nsketch`` is at least the number of cells the scores are
+    computed exactly. The scores are non-negative, each is at most 1, and they sum
+    to the dimension of the subspace (the rank).
+
+    Parameters
+    ----------
+    obj      : a :class:`~shanuz.Shanuz` object (normalized + scaled).
+    nsketch  : rows of the random sketch. Larger is more accurate and slower; the
+               approximation kicks in only when ``nsketch`` is below the cell count.
+    features : features to score on (default: the assay's variable features).
+    assay    : assay to use (default: active assay).
+    layer    : layer to draw the data from (default ``"scale.data"``).
+    var_name : if given, the scores are also written to ``obj.meta_data[var_name]``.
+    eps      : relative tolerance for dropping near-zero singular directions.
+    seed     : random seed for the sketch.
+
+    Returns
+    -------
+    numpy.ndarray
+        One leverage score per cell, in ``obj.cell_names()`` order.
+    """
+    assay_name = assay or obj.active_assay
+    assay_obj = obj.assays[assay_name]
+    feats = _default_features(assay_obj, features)
+
+    mat = _get_scaled_data(assay_obj, feats, layer)   # (n_features × n_cells)
+    A = np.asarray(mat, dtype=float).T                # (n_cells × n_features)
+
+    rng = np.random.default_rng(seed)
+    scores = _leverage_from_matrix(A, nsketch, rng, eps)
+
+    if var_name is not None:
+        obj.meta_data[var_name] = scores
+    return scores
+
+
+def sketch_data(
+    obj,
+    ncells: int = 5000,
+    method: str = "LeverageScore",
+    features: Optional[list[str]] = None,
+    assay: Optional[str] = None,
+    layer: str = "scale.data",
+    nsketch: int = 5000,
+    sketched_assay: str = "sketch",
+    var_name: Optional[str] = "leverage.score",
+    seed: int = 123,
+):
+    """Draw a leverage-weighted subset of cells (Seurat's ``SketchData``).
+
+    Mirrors ``SketchData(object, ncells = 5000, method = "LeverageScore")``. Each
+    cell is sampled without replacement with probability proportional to its
+    :func:`leverage_score`, so the rare states a uniform sample would drop are kept
+    (indeed over-represented). The leverage scores are written back onto ``obj``'s
+    metadata, and the drawn subset is returned as a **standalone**
+    :class:`~shanuz.Shanuz` object — run the expensive analysis (PCA, clustering,
+    UMAP) on it and use :func:`project_data` to extend the results to every cell.
+
+    This departs from Seurat, which stores the sketch as an extra assay on the same
+    object; here it is a separate object, matching the roadmap and shanuz's
+    ``subset`` model. Its active assay is renamed to ``sketched_assay`` so the
+    provenance is visible, and ``obj.misc["sketch"]`` records how it was drawn.
+
+    Parameters
+    ----------
+    obj            : a :class:`~shanuz.Shanuz` object (normalized + scaled).
+    ncells         : cells to keep (capped at the number available).
+    method         : only ``"LeverageScore"`` is implemented.
+    features       : features to score on (default: variable features).
+    assay          : assay to use (default: active assay).
+    layer          : layer to draw the data from.
+    nsketch        : sketch size passed to :func:`leverage_score`.
+    sketched_assay : name the returned object's active assay is renamed to.
+    var_name       : metadata column the scores are written to on ``obj``.
+    seed           : random seed for scoring and sampling.
+
+    Returns
+    -------
+    Shanuz
+        The sketched subset (a new object).
+    """
+    if method != "LeverageScore":
+        raise ValueError(
+            f"Unknown sketch method {method!r}; only 'LeverageScore' is implemented."
+        )
+
+    scores = leverage_score(
+        obj, nsketch=nsketch, features=features, assay=assay, layer=layer,
+        var_name=var_name, seed=seed,
+    )
+
+    n = len(obj)
+    k = min(ncells, n)
+    total = float(scores.sum())
+    probs = scores / total if total > 0 else np.full(n, 1.0 / n)
+
+    rng = np.random.default_rng(seed + 1)
+    idx = np.sort(rng.choice(n, size=k, replace=False, p=probs))
+    cell_names = obj.cell_names()
+    cells = [cell_names[i] for i in idx]
+
+    sketched = obj.subset(cells=cells)
+    if sketched_assay and sketched_assay != sketched.active_assay:
+        src = sketched.active_assay
+        sketched.assays[sketched_assay] = sketched.assays.pop(src)
+        sketched.active_assay = sketched_assay
+    sketched.misc["sketch"] = {
+        "method": method,
+        "ncells": k,
+        "from_cells": n,
+        "source_assay": obj.active_assay,
+        "leverage_var": var_name,
+    }
+    return sketched
+
+
+def project_data(
+    full,
+    sketch,
+    reduction: str = "pca",
+    full_reduction: str = "pca.full",
+    umap_reduction: str = "umap",
+    full_umap_reduction: str = "ref.umap",
+    refdata: Optional[Union[str, dict, np.ndarray, list]] = None,
+    project_umap: bool = True,
+    dims: Optional[Union[list[int], range]] = None,
+    k_weight: int = 50,
+    sd_weight: float = 1.0,
+    layer: str = "scale.data",
+    seed: int = 42,
+):
+    """Extend a sketch's analysis to the full dataset (Seurat's ``ProjectData``).
+
+    The inverse of :func:`sketch_data`: once the sketch has been reduced and
+    (optionally) clustered, every full-dataset cell is placed into the sketch's
+    coordinate system and, if asked, given the sketch's labels.
+
+    1. **PCA.** Each full cell is pushed through the sketch's PCA loadings — the
+       same "project into a space this cell never helped define" linear map that
+       :func:`shanuz.project_umap` uses — and stored as
+       ``full.reductions[full_reduction]``.
+    2. **UMAP** (when ``project_umap`` and the sketch carries a fitted UMAP model):
+       the projected cells are run through the sketch's UMAP via
+       :func:`shanuz.project_umap`, stored as ``full.reductions[full_umap_reduction]``.
+    3. **Labels** (when ``refdata`` is given): :func:`shanuz.find_transfer_anchors`
+       links the sketch (reference) to the full data (query) and
+       :func:`shanuz.transfer_data` carries the labels across, written onto
+       ``full.meta_data``.
+
+    ``full`` is mutated in place and returned.
+
+    Parameters
+    ----------
+    full                : the full :class:`~shanuz.Shanuz` object (normalized +
+                          scaled on the sketch's PCA features).
+    sketch              : the sketched object from :func:`sketch_data`, already
+                          carrying a PCA (and optionally a fitted UMAP).
+    reduction           : sketch reduction whose loadings project the full data.
+    full_reduction      : storage key for the projected PCA on ``full``.
+    umap_reduction      : sketch reduction holding the fitted UMAP model.
+    full_umap_reduction : storage key for the projected UMAP on ``full``.
+    refdata             : labels to transfer. A ``dict`` ``{new_col: sketch_col}``
+                          writes each transferred label under ``new_col`` (plus
+                          ``new_col.score``); a ``str`` column / 1-D array writes
+                          the full ``predicted.id`` / ``prediction.score.*`` frame.
+                          ``None`` skips transfer.
+    project_umap        : also project the sketch's UMAP when a fitted model exists.
+    dims                : PCA dimensions to feed the UMAP model (default: all).
+    k_weight, sd_weight : anchor-weighting knobs for :func:`shanuz.transfer_data`.
+    layer               : layer to draw the full data's expression from.
+    seed                : random seed for the anchor step.
+
+    Returns
+    -------
+    Shanuz
+        ``full``, now carrying the projected reduction(s) and any transferred labels.
+    """
+    from .mapping import _project_into_reference_pca, project_umap as _project_umap
+
+    if reduction not in sketch.reductions:
+        raise KeyError(
+            f"Sketch reduction {reduction!r} not found; run run_pca(sketch) first."
+        )
+
+    sketch_pca = sketch.reductions[reduction]
+    full_pca = _project_into_reference_pca(full, sketch, reduction, layer)
+
+    key = getattr(sketch_pca, "_key", "PC_") or "PC_"
+    dim_names = [f"{key}{i + 1}" for i in range(full_pca.shape[1])]
+    full.reductions[full_reduction] = DimReduc(
+        cell_embeddings=full_pca,
+        cell_names=full.cell_names(),
+        feature_loadings=np.asarray(sketch_pca.feature_loadings),
+        feature_names=dim_names if not sketch_pca.features() else list(sketch_pca.features()),
+        assay_used=full.active_assay,
+        key=key,
+        misc={"projected_from": reduction, "sketch_reduction": reduction},
+    )
+
+    if (
+        project_umap
+        and umap_reduction in sketch.reductions
+        and sketch.reductions[umap_reduction].misc.get("umap_model") is not None
+    ):
+        _project_umap(
+            full,
+            sketch,
+            reduction=reduction,
+            umap_reduction=umap_reduction,
+            dims=dims,
+            reduction_name=full_umap_reduction,
+            layer=layer,
+        )
+
+    if refdata is not None:
+        from .transfer import find_transfer_anchors
+
+        anchors = find_transfer_anchors(
+            sketch, full, reduction="pcaproject", layer=layer, seed=seed
+        )
+        _write_refdata(anchors, full, refdata, k_weight, sd_weight)
+
+    return full
+
+
+# ----------------------------------------------------------------------
+# Internals
+# ----------------------------------------------------------------------
+
+
+def _count_sketch(n: int, nsketch: int, rng: np.random.Generator) -> sp.csr_matrix:
+    """A CountSketch subspace embedding — an ``nsketch × n`` sparse sign matrix.
+
+    Each of the ``n`` columns has exactly one non-zero, a random ``±1`` in a random
+    row, so ``S @ A`` hashes the cells into ``nsketch`` signed buckets in a single
+    pass over the data's non-zeros.
+    """
+    rows = rng.integers(0, nsketch, size=n)
+    signs = rng.choice(np.array([-1.0, 1.0]), size=n)
+    cols = np.arange(n)
+    return sp.csr_matrix((signs, (rows, cols)), shape=(nsketch, n))
+
+
+def _leverage_from_matrix(
+    A: np.ndarray, nsketch: int, rng: np.random.Generator, eps: float
+) -> np.ndarray:
+    """Leverage scores of the rows of ``A`` (``n × d``), via a sketched whitening.
+
+    ``B = S A`` is a small subspace embedding (or ``A`` itself when no sketch is
+    taken). Whitening ``A`` with ``B``'s right singular vectors, ``Z = A V Σ⁻¹``,
+    makes ``Z`` approximately orthonormal, so ``ℓ_i = ‖Z_i‖²`` approximates the
+    exact leverage ``a_iᵀ (AᵀA)⁻¹ a_i`` — and equals it when ``B = A``.
+    """
+    n, d = A.shape
+    if 0 < nsketch < n and nsketch >= d:
+        B = np.asarray(_count_sketch(n, nsketch, rng) @ A)
+    else:
+        B = A
+
+    _, s, vt = np.linalg.svd(B, full_matrices=False)
+    if s.size == 0 or s[0] == 0:
+        return np.zeros(n)
+
+    tol = s[0] * max(B.shape) * eps
+    keep = s > tol
+    whiten = vt[keep].T / s[keep]          # (d × r)
+    z = A @ whiten                          # (n × r)
+    return np.einsum("ij,ij->i", z, z)
+
+
+def _write_refdata(anchors, full, refdata, k_weight: int, sd_weight: float) -> None:
+    """Carry ``refdata`` from the sketch onto the full object's metadata."""
+    from .transfer import transfer_data
+
+    meta = full.meta_data
+    if isinstance(refdata, dict):
+        for out_col, src_col in refdata.items():
+            preds = transfer_data(
+                anchors, src_col, k_weight=k_weight, sd_weight=sd_weight
+            )
+            meta[out_col] = preds["predicted.id"].reindex(meta.index).to_numpy()
+            meta[f"{out_col}.score"] = (
+                preds["prediction.score.max"].reindex(meta.index).to_numpy()
+            )
+    else:
+        preds = transfer_data(
+            anchors, refdata, k_weight=k_weight, sd_weight=sd_weight
+        )
+        for col in preds.columns:
+            meta[col] = preds[col].reindex(meta.index).to_numpy()

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -1,0 +1,203 @@
+"""Tests for leverage-score sketching (v0.8.0 Scale).
+
+  * leverage_score  (sketch.py)
+  * sketch_data     (sketch.py)
+  * project_data    (sketch.py)
+
+Builds small clustered datasets (each cell type has its own elevated gene block)
+and checks that leverage scores match the textbook definition, that sketching
+draws a leverage-weighted subset that over-represents the rare states, and that
+``project_data`` places every full-dataset cell back into the sketch's PCA/UMAP
+and transfers the sketch's labels to the full data. Network-free.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from shanuz.shanuz import create_shanuz_object  # noqa: E402
+from shanuz.preprocessing import (  # noqa: E402
+    normalize_data,
+    find_variable_features,
+    scale_data,
+)
+from shanuz.reduction import run_pca, _default_features, _get_scaled_data  # noqa: E402
+from shanuz.umap import run_umap  # noqa: E402
+from shanuz.sketch import leverage_score, sketch_data, project_data  # noqa: E402
+
+
+def _clustered_object(sizes=(60, 60, 60), seed=0, G=150, nfeatures=100):
+    """Cells in K clusters; cluster k carries an elevated gene block."""
+    rng = np.random.default_rng(seed)
+    K = len(sizes)
+    block = G // (K + 1)
+    cols, celltype, cells = [], [], []
+    c = 0
+    for k, nk in enumerate(sizes):
+        for _ in range(nk):
+            base = rng.gamma(0.3, size=G) + 0.05
+            base[k * block:(k + 1) * block] += 5.0
+            cols.append(rng.poisson(base * 3000.0 / base.sum()))
+            celltype.append(f"T{k}")
+            cells.append(f"c{c}")
+            c += 1
+
+    mat = np.array(cols).T  # (G features × n cells)
+    meta = pd.DataFrame({"celltype": celltype}, index=cells)
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(mat), assay="RNA",
+        feature_names=[f"g{i}" for i in range(G)], cell_names=cells,
+        meta_data=meta,
+    )
+    normalize_data(obj)
+    find_variable_features(obj, selection_method="vst", nfeatures=nfeatures)
+    scale_data(obj)
+    return obj, np.array(celltype)
+
+
+# ----------------------------------------------------------------------
+# leverage_score
+# ----------------------------------------------------------------------
+
+
+def test_leverage_score_matches_textbook_definition():
+    obj, _ = _clustered_object()
+
+    # Build the exact matrix the function scores on, and its textbook leverage
+    # (row norms of the left singular vectors).
+    assay = obj.get_assay()
+    feats = _default_features(assay, None)
+    A = np.asarray(_get_scaled_data(assay, feats, "scale.data"), dtype=float).T
+    U, s, _ = np.linalg.svd(A, full_matrices=False)
+    tol = s[0] * max(A.shape) * 1e-8
+    r = int((s > tol).sum())
+    exact = (U[:, :r] ** 2).sum(axis=1)
+
+    scores = leverage_score(obj, nsketch=10 ** 9)  # nsketch >= n → exact
+
+    assert np.allclose(scores, exact, atol=1e-6)
+    # Leverage scores are non-negative, each at most 1, and sum to the rank.
+    assert scores.min() >= -1e-9
+    assert scores.max() <= 1 + 1e-8
+    assert scores.sum() == pytest.approx(r, abs=1e-6)
+    # Also written back to metadata.
+    assert "leverage.score" in obj.meta_data.columns
+
+
+def test_leverage_score_flags_rare_cells():
+    # 120 common cells, 6 rare cells in a distinct state.
+    obj, ct = _clustered_object(sizes=(120, 6), G=120, nfeatures=80)
+    scores = leverage_score(obj, nsketch=10 ** 9)
+
+    assert scores[ct == "T1"].mean() > scores[ct == "T0"].mean()
+
+
+def test_leverage_score_sketch_approximates_exact():
+    # n = 810 cells, d = 20 features: nsketch=500 sits between d and n, so the
+    # CountSketch path is exercised. A single-hash sketch is a subspace embedding
+    # only once it has ~d² rows, so this uses nsketch ≈ d² — the regime where the
+    # approximation tracks the exact scores (as it does at nsketch=5000 for the
+    # million-cell case this is a proxy for).
+    obj, _ = _clustered_object(sizes=(270, 270, 270), G=80, nfeatures=20)
+    exact = leverage_score(obj, nsketch=10 ** 9, seed=0)
+    approx = leverage_score(obj, nsketch=500, seed=0)
+
+    assert np.corrcoef(exact, approx)[0, 1] > 0.9
+
+
+# ----------------------------------------------------------------------
+# sketch_data
+# ----------------------------------------------------------------------
+
+
+def test_sketch_data_returns_subset():
+    obj, _ = _clustered_object()
+    sk = sketch_data(obj, ncells=40, seed=0)
+
+    assert len(sk) == 40
+    assert set(sk.cell_names()) <= set(obj.cell_names())
+    # Scores stashed on the source object; the sketch's assay is renamed.
+    assert "leverage.score" in obj.meta_data.columns
+    assert sk.active_assay == "sketch"
+    assert "sketch" in sk.assays
+    assert sk.misc["sketch"]["ncells"] == 40
+
+
+def test_sketch_data_oversamples_rare():
+    # 10% of cells are a distinct rare state; leverage sampling should enrich it.
+    obj, ct = _clustered_object(sizes=(180, 20), G=120, nfeatures=80)
+    sk = sketch_data(obj, ncells=60, seed=0)
+
+    sketch_types = obj.meta_data.loc[sk.cell_names(), "celltype"].to_numpy()
+    rare_full = float(np.mean(ct == "T1"))
+    rare_sketch = float(np.mean(sketch_types == "T1"))
+    assert rare_sketch > rare_full
+
+
+def test_sketch_data_caps_at_available_cells():
+    obj, _ = _clustered_object(sizes=(30, 30))
+    sk = sketch_data(obj, ncells=10_000, seed=0)
+
+    assert len(sk) == len(obj)
+
+
+# ----------------------------------------------------------------------
+# project_data
+# ----------------------------------------------------------------------
+
+
+def test_project_data_projects_full_into_sketch_pca():
+    obj, _ = _clustered_object(sizes=(80, 80, 80))
+    sk = sketch_data(obj, ncells=60, seed=0)
+    run_pca(sk, n_pcs=20)
+
+    project_data(obj, sk, project_umap=False)
+
+    assert "pca.full" in obj.reductions
+    full_emb = obj.reductions["pca.full"].cell_embeddings
+    assert full_emb.shape == (len(obj), 20)
+
+    # Projecting the sketch cells through the sketch's own loadings reproduces
+    # their sketch-PCA coordinates (up to a per-PC offset → correlation ≈ 1).
+    idx = [obj.cell_names().index(c) for c in sk.cell_names()]
+    sk_emb = sk.reductions["pca"].cell_embeddings
+    for d in range(3):
+        r = abs(np.corrcoef(full_emb[idx, d], sk_emb[:, d])[0, 1])
+        assert r > 0.99
+
+
+def test_project_data_transfers_labels():
+    obj, ct = _clustered_object(sizes=(80, 80, 80))
+    sk = sketch_data(obj, ncells=90, seed=0)
+    run_pca(sk, n_pcs=20)
+
+    project_data(obj, sk, refdata={"predicted": "celltype"}, project_umap=False)
+
+    assert "predicted" in obj.meta_data.columns
+    assert "predicted.score" in obj.meta_data.columns
+    acc = np.mean(obj.meta_data["predicted"].to_numpy() == ct)
+    assert acc > 0.85
+
+
+def test_project_data_projects_umap_when_model_present():
+    obj, _ = _clustered_object(sizes=(80, 80, 80))
+    sk = sketch_data(obj, ncells=90, seed=0)
+    run_pca(sk, n_pcs=20)
+    run_umap(sk, n_neighbors=15, min_dist=0.3, seed=42)
+
+    project_data(obj, sk)  # project_umap=True by default
+
+    assert "ref.umap" in obj.reductions
+    assert obj.reductions["ref.umap"].cell_embeddings.shape == (len(obj), 2)
+
+
+def test_project_data_missing_sketch_pca_raises():
+    obj, _ = _clustered_object(sizes=(40, 40))
+    sk = sketch_data(obj, ncells=40, seed=0)  # no run_pca on the sketch
+    with pytest.raises(KeyError):
+        project_data(obj, sk)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -259,6 +259,9 @@ same caveat as the other tutorials.
 | Transfer labels | `TransferData(anchors, refdata=reference$celltype)` | `transfer_data(anchors, refdata="celltype")` |
 | Project into reference UMAP | `ProjectUMAP(query, reference, reduction.model="umap")` | `project_umap(query, reference)` |
 | Map query (annotate + place) | `MapQuery(anchors, query, reference, refdata=list(id="celltype"))` | `map_query(anchors, refdata="celltype")` |
+| Leverage scores | `LeverageScore(obj)` | `leverage_score(obj)` |
+| Sketch a large dataset | `SketchData(obj, ncells=5000, method="LeverageScore")` | `sketch_data(obj, ncells=5000)` |
+| Project sketch → full data | `ProjectData(obj, sketched.assay="sketch", reduction="pca")` | `project_data(full, sketch, refdata={"cluster_full": "seurat_clusters"})` |
 | Markers | `FindMarkers(pbmc, ident.1)` | `find_markers(pbmc, ident_1)` |
 | All markers | `FindAllMarkers(pbmc, only.pos, logfc.threshold)` | `find_all_markers(pbmc, only_pos, logfc_threshold)` |
 | Conserved markers | `FindConservedMarkers(pbmc, ident.1, grouping.var)` | `find_conserved_markers(pbmc, ident_1, grouping_var)` |
@@ -456,6 +459,52 @@ space the query never helped define" logic as `pcaproject` above), then runs the
 reference's UMAP model's `.transform`. A query cell that resembles reference
 T cells is pinned near the reference's T-cell island and optimised to sit there —
 so the query overlays the atlas, batch block and all.
+
+### Sketching — analysing a million cells through a small subset
+
+A huge atlas is mostly redundant: the common states are thousands of near-identical
+cells stacked on top of each other, while the rare states — usually the interesting
+ones — are a handful of points each. Sketching picks a small, information-dense
+subset, does the expensive clustering / UMAP on *that*, and projects the answers
+back onto every cell. The subset is drawn by **leverage**, not uniformly: a cell in
+a dense redundant cloud has low leverage (drop it and nothing changes), a cell in a
+sparse distinctive corner has high leverage (it is the only evidence that corner
+exists) — so leverage sampling keeps the rare states a uniform sample would lose.
+
+```python
+from shanuz import sketch_data, project_data, run_pca, run_umap
+from shanuz.neighbors import find_neighbors
+from shanuz.clustering import find_clusters
+
+# full: a large, normalized + scaled object. Draw a leverage-weighted sketch.
+sketch = sketch_data(full, ncells=5000)   # a standalone object; assay -> "sketch"
+# full.meta_data["leverage.score"] now holds the per-cell scores.
+
+# Do the heavy analysis on the small sketch.
+run_pca(sketch, n_pcs=30)
+find_neighbors(sketch, dims=range(30))
+find_clusters(sketch, resolution=0.8)     # -> sketch.meta_data["seurat_clusters"]
+run_umap(sketch, dims=range(30))          # keeps the umap-learn model
+
+# Extend the sketch's PCA, UMAP and cluster labels back to *every* cell.
+project_data(full, sketch, refdata={"cluster_full": "seurat_clusters"})
+full.reductions["pca.full"]               # every cell in the sketch's PC space
+full.reductions["ref.umap"]               # every cell on the sketch's UMAP
+full.meta_data["cluster_full"]            # every cell's transferred cluster
+```
+
+`leverage_score` computes the scores with a sparse **CountSketch** rather than a
+full SVD of the data — the whole reason sketching scales — so it stays cheap on
+millions of cells. `project_data` is the mirror image of reference mapping: the
+sketch plays the role of the reference, and each full cell is pushed through the
+sketch's PCA loadings (and its fitted UMAP model) exactly as `project_umap` places
+a query on an atlas, with `find_transfer_anchors` + `transfer_data` carrying the
+cluster labels across.
+
+> `leverage_score` and `sketch_data` default to `nsketch=5000`; the CountSketch is
+> a faithful embedding once it has more rows than roughly the squared feature
+> count, which the default comfortably clears for the few-thousand variable
+> features a sketch runs on.
 
 ### Pseudobulk & conserved markers
 


### PR DESCRIPTION
## Summary

Opens the **v0.8.0 Scale** milestone with leverage-score sketching — analysing a million-cell dataset through a small, information-dense subset — in a new `shanuz/sketch.py`. Three functions, reusing the `mapping.py` projection and `transfer.py` anchors end to end; **no new dependency**.

- **`leverage_score(obj, nsketch=5000)`** — per-cell statistical leverage. A cell in a dense redundant cloud scores low; a cell in a sparse distinctive corner scores high. Exact when `nsketch ≥ n`; otherwise approximated with a sparse **CountSketch** subspace embedding (`SA` in one pass over the non-zeros → whiten `A` with `B`'s right singular vectors → `ℓ_i ≈ ‖Z_i‖²`), so no full SVD of the data is ever taken. Writes `leverage.score` to metadata.
- **`sketch_data(obj, ncells=5000, method="LeverageScore")`** — draws a leverage-weighted subset *without replacement*, so the rare states a uniform sample would drop are kept (over-represented). Returns a standalone `Shanuz` object with its active assay renamed to `"sketch"`.
- **`project_data(full, sketch)`** — the inverse map. Projects every full cell through the sketch's PCA loadings (`pca.full`), through the sketch's fitted UMAP when present (`ref.umap`, via `project_umap`), and optionally carries the sketch's labels to the full data (`find_transfer_anchors` + `transfer_data`).

## Design notes

- **Follows the roadmap's divergence from Seurat**: the sketch is a *separate object* (Seurat stores it as an extra assay on the same object), which fits shanuz's `subset` model and keeps full/sketch data cleanly apart.
- **The leverage math is the value proposition**: exact `‖U_i‖²` is an `O(n·d²)` SVD — the very cost sketching avoids — so a CountSketch embeds the rows into a small `nsketch × d` matrix with `BᵀB ≈ AᵀA` first. Validated against the textbook definition to `1e-6` in the no-sketch regime.
- **One documented caveat**: a single-hash CountSketch is a faithful subspace embedding only once it has ~`d²` rows, so `nsketch` should comfortably exceed the feature count (the default 5000 does, for the few-thousand variable features a real sketch runs on). The approximation test runs in the `nsketch ≈ d²` regime as a proxy for the real `nsketch=5000 ≫ d` case.

## Tests

`tests/test_sketch.py` — **10 network-free tests**:
- leverage matches `‖U_i‖²`, bounded in `[0,1]`, sums to the rank; flags rare cells; CountSketch tracks the exact scores at `nsketch ≈ d²`
- sketch returns a leverage-weighted subset, over-samples the rare state, caps at `n`
- `project_data` reproduces sketch-cell PCA coordinates (per-PC corr ≈ 1), transfers labels at >85% accuracy, projects the UMAP when a model exists, raises `KeyError` without a sketch PCA

**Full suite: 310 passed** (was 300, net +10). Ruff clean on the new files.

## Docs

- `README.md` — Scale (sketching) feature bullet; v0.8.0 roadmap row updated (sketching ✅, lazy matrices open)
- `ROADMAP.md` — `SketchData` / `ProjectData` entries and priority #7 marked delivered, with implementation notes; v0.8.0 left partial (BPCells-style lazy matrices remain)
- `tutorials/README.md` — three API Quick Reference rows + a "Sketching — analysing a million cells through a small subset" walkthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)