### PR TITLE
Add BPCells-style lazy on-disk matrices (LazyMatrix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Batch correction / integration** — `run_harmony` (via harmonypy), CCA/RPCA anchors (`find_integration_anchors` + `integrate_data`), and the `integrate_layers` dispatcher (`method="harmony"|"cca"|"rpca"`)
 - **Reference mapping** — `find_transfer_anchors` (project a query into a reference; `pcaproject` or `cca`) + `transfer_data` (annotate the query with reference labels, or impute reference expression onto it); `project_umap` / `map_query` place the query in the reference's own UMAP in one call
 - **Scale (sketching)** — `sketch_data` draws a leverage-weighted subset of a huge dataset (rare states kept, not lost), `leverage_score` computes the per-cell scores via a CountSketch (no full SVD), and `project_data` extends the sketch's PCA/UMAP/labels back to every cell
+- **Scale (lazy on-disk matrices)** — `LazyMatrix` keeps a matrix out-of-core as memory-mapped compressed-sparse-column arrays (BPCells-style); `write_lazy_matrix` / `open_lazy_matrix` persist and map it, a slice reads only the touched cells off disk, `col_blocks` streams a million cells at bounded RAM, and it drops straight into an `Assay5` layer — no new dependency
 - **Nearest-neighbour graph** — `find_neighbors` (KNN + SNN)
 - **Multimodal WNN** — `find_multi_modal_neighbors` (per-cell RNA/protein weights, joint `wknn`/`wsnn` graphs)
 - **Clustering** — `find_clusters` (Louvain via python-igraph, Leiden via leidenalg)
@@ -296,7 +297,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | v0.5.0 | Additional reductions — t-SNE, ICA, `run_spca`, `glm_pca` (Poisson + negative binomial) ✅ *(complete)* |
 | v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`), bimod (`test_use="bimod"`) ✅ *(complete)* |
 | v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I + markvariogram), `image_*` plots, `VisiumV2` tissue images, `spatial_*` H&E plots ✅ *(delivered — see Tutorial 5)* |
-| v0.8.0 | Scale — `SketchData`/`ProjectData` (leverage-score sketching) ✅; BPCells-style lazy matrices *(open)* |
+| v0.8.0 | Scale — `SketchData`/`ProjectData` (leverage-score sketching) ✅; BPCells-style lazy on-disk matrices (`LazyMatrix`) ✅ *(complete)* |
 | v0.9.0 | Specialized — `HTODemux`, Mixscape (CRISPR screens) |
 | v0.10.0 | Infrastructure — PyPI, GitHub Actions CI, type annotations, MkDocs site |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -425,19 +425,40 @@ brute-force loop over every cell pair (`tests/test_markvariogram.py`).
 
 ## v0.8.0 — Scale & Performance
 
-> **Status:** leverage-score sketching is delivered — `sketch_data` /
-> `project_data` (+ the standalone `leverage_score`) in `shanuz/sketch.py` draw an
-> information-dense subset of a huge dataset and extend the sketch's analysis back
-> to every cell, reusing the `mapping.py` projection and `transfer.py` anchors and
-> adding no dependency. BPCells-style lazy/on-disk matrices remain open.
+> **Status:** ✅ **complete.** Leverage-score sketching (`sketch_data` /
+> `project_data` + `leverage_score`, `shanuz/sketch.py`) draws an information-dense
+> subset of a huge dataset and extends the sketch's analysis back to every cell;
+> BPCells-style lazy on-disk matrices (`LazyMatrix`, `shanuz/lazy.py`) keep a matrix
+> out-of-core and stream over it. Both add **no new dependency** — sketching reuses
+> the `mapping.py` / `transfer.py` machinery, and `LazyMatrix` is built on NumPy's
+> memory-mapping alone.
 
-### BPCells-style lazy/on-disk matrices
-- **R:** `BPCells` package enables out-of-core analysis on millions of cells
-- **Python dep:** `bpcells-python` (if available) or `zarr` / `h5py` lazy arrays
-- **Plan:** `Assay5` layers can already hold any array-like object; extend
-  `_get_data_matrix` to handle `zarr.Array` and `h5py.Dataset` transparently
-  (they support numpy-style slicing). The key change is avoiding `.toarray()` /
-  `.todense()` calls in hot paths — audit and gate these behind shape checks.
+### BPCells-style lazy/on-disk matrices — ✅ delivered
+- Implemented as `LazyMatrix` in `shanuz/lazy.py`, with `write_lazy_matrix(matrix,
+  path)` to persist a matrix out-of-core and `open_lazy_matrix(path)` to map it
+  back (`is_lazy(x)` to test). A matrix is stored as a directory of three
+  **memory-mapped** `.npy` arrays — the `data` / `indices` / `indptr` triple of a
+  compressed-sparse-**column** matrix, exactly scipy's `csc_matrix` layout — plus a
+  JSON header. Opening maps the arrays without reading them; peak memory is the
+  slices you touch, not the whole matrix (`tests/test_lazy.py`).
+- **A faithful drop-in for a sparse layer.** Indexing (`m[:, cells]`,
+  `m[np.ix_(genes, cells)]`, slices, boolean masks) reads only the touched columns
+  off disk and returns an ordinary `scipy.sparse.csc_matrix`, so every hot path
+  that already accepts a sparse layer keeps working. `Assay5` layers hold any
+  array-like, so `assay.set_layer_data("counts", lazy)` just works, and the
+  full-densify helpers (`as_dense` / `np.asarray`) route through `__array__` — the
+  deliberate "materialise everything" escape hatch you avoid on the huge path.
+- **Streaming reductions.** `sum` / `mean` over axis 0 (per-cell) or 1 (per-feature)
+  run in a single pass over the on-disk arrays; `nnz_per_col()` (the `nFeature`
+  count) comes straight from `indptr`; `col_blocks(block_size)` walks the matrix in
+  cell-blocks — the primitive for processing a million cells at bounded RAM.
+- **R:** `BPCells` package enables out-of-core analysis on millions of cells.
+- **Design note (CSC, not CSR):** shanuz matrices are `features × cells` and the
+  scale-out ops (sketching, cell subsetting, per-cell normalisation) select
+  **columns**, which CSC makes cheap. Row-only (feature) subsetting still scans the
+  touched columns; keeping both orientations on disk (as BPCells does) to make that
+  cheap too, and a full `.toarray()` audit of the hot paths to gate densification
+  behind shape checks, are the natural follow-ons.
 
 ### `SketchData` (leverage-score sub-sampling) — ✅ delivered
 - Implemented as `sketch_data(obj, ncells=5000, method="LeverageScore")` in
@@ -560,7 +581,7 @@ Each milestone's new `pip` deps:
 | v0.5.0 | *(none — sPCA and GLM-PCA are pure NumPy/SciPy; `glmpca-py` proved unnecessary)* |
 | v0.6.0 | `pydeseq2` (optional) |
 | v0.7.0 | *(none — Moran's I is pure NumPy/SciPy; the Visium PNG uses matplotlib, already in `[analysis]`)* |
-| v0.8.0 | `zarr` (optional) |
+| v0.8.0 | *(none — sketching reuses existing machinery; `LazyMatrix` is built on NumPy memory-mapping alone)* |
 | v0.9.0 | *(none — sklearn already present)* |
 | v0.10.0 | `build`, `twine`, `mkdocs`, `mkdocstrings`, `ruff`, `mypy` (all dev-only) |
 
@@ -586,10 +607,13 @@ If milestones are too large, these are the highest-value individual items:
 6. ~~**`AggregateExpression` + DESeq2**~~ ✅ (`v0.6.0`) — `aggregate_expression`,
    `find_conserved_markers`, and pseudobulk DESeq2 (`test_use="deseq2"`) delivered;
    MAST (`test_use="mast"`) and bimod (`test_use="bimod"`) too — **v0.6.0 complete**
-7. ~~**`SketchData`** (`v0.8.0`)~~ — ✅ delivered (`sketch_data` / `project_data` +
-   `leverage_score` in `shanuz/sketch.py`): leverage-weighted subsampling for
-   million-cell datasets, and projection of the sketch's PCA/UMAP/labels back to
-   the full data. BPCells-style lazy matrices are the remaining v0.8.0 item.
+7. ~~**`SketchData`** + **BPCells-style lazy matrices** (`v0.8.0`)~~ — ✅ delivered.
+   `sketch_data` / `project_data` + `leverage_score` (`shanuz/sketch.py`):
+   leverage-weighted subsampling for million-cell datasets, and projection of the
+   sketch's PCA/UMAP/labels back to the full data. `LazyMatrix` (`shanuz/lazy.py`):
+   out-of-core, memory-mapped compressed-sparse-column storage with lazy column
+   reads, streaming block reductions, and a clean `Assay5`-layer drop-in — no new
+   dependency. **v0.8.0 is complete.**
 8. ~~**`run_spca` + `glm_pca`** (Poisson + negative binomial)~~ ✅ (`v0.5.0`) —
    **v0.5.0 is complete**; GLM-PCA now fits both `family="poisson"` and
    `family="nb"` (dispersion estimated by ML), closing the last gap in it

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -35,6 +35,7 @@ from .transfer import (
 )
 from .mapping import map_query, project_umap
 from .sketch import sketch_data, project_data, leverage_score
+from .lazy import LazyMatrix, write_lazy_matrix, open_lazy_matrix, is_lazy
 from .markers import find_markers, find_all_markers, find_conserved_markers
 from .aggregate import aggregate_expression
 from .sctransform import sctransform
@@ -158,6 +159,10 @@ __all__ = [
     "sketch_data",
     "project_data",
     "leverage_score",
+    "LazyMatrix",
+    "write_lazy_matrix",
+    "open_lazy_matrix",
+    "is_lazy",
     "find_markers",
     "find_all_markers",
     "find_conserved_markers",

--- a/shanuz/lazy.py
+++ b/shanuz/lazy.py
@@ -1,0 +1,369 @@
+"""BPCells-style lazy, on-disk matrices for out-of-core analysis (v0.8.0 Scale).
+
+The problem this solves
+=======================
+A single dense ``float64`` matrix of a million cells by twenty-thousand genes is
+160 GB — it never fits in memory, and even the sparse counts (a few GB) leave no
+headroom for the copies every analysis step makes. Seurat's answer is the
+``BPCells`` package: it keeps the matrix **on disk** in a compressed sparse
+format, memory-maps it, and streams operations over it a block of cells at a time
+so that peak RAM is a function of the *block* size, not the dataset size. Nothing
+is loaded until it is needed, and only the slice that is needed is loaded.
+
+``LazyMatrix`` is the Python analogue, built on the one dependency shanuz already
+has — NumPy. A matrix is written to a directory as three memory-mapped arrays
+(the ``data`` / ``indices`` / ``indptr`` triple of a compressed-sparse-**column**
+matrix, exactly scipy's ``csc_matrix`` layout) plus a small JSON header. Opening
+it maps those arrays without reading them; a slice reads only the touched
+columns' non-zeros off disk and returns an ordinary in-memory ``scipy.sparse``
+matrix, so every downstream call site that already accepts a sparse layer keeps
+working unchanged.
+
+Why compressed-sparse-*column*
+==============================
+shanuz matrices are ``features × cells``, and the operations that dominate at
+scale — sketching, cell subsetting, per-cell normalisation — select or stream
+over **cells**, i.e. columns. CSC stores each column contiguously, so reading an
+arbitrary set of columns costs only their own non-zeros; ``col_blocks`` walks the
+whole matrix in cell-blocks for a streaming reduction. Selecting a subset of
+*features* (rows) from a CSC store still requires scanning the touched columns,
+which is why a subset-of-both index (``m[np.ix_(genes, cells)]``) first narrows to
+the cell columns and only then to the gene rows — the feature filter then runs
+over a small in-memory block. (BPCells keeps both orientations on disk to make
+row-only slicing cheap too; that is a natural future extension here.)
+
+How it slots into an assay
+==========================
+An :class:`~shanuz.assay5.Assay5` layer may hold *any* array-like object, so a
+``LazyMatrix`` can be dropped in wherever a ``counts`` / ``data`` layer would sit::
+
+    lazy = write_lazy_matrix(assay.layers["counts"], "counts.mat")
+    assay.set_layer_data("counts", lazy)
+
+``Assay5.layer_data`` indexes the layer with ``m[np.ix_(rows, cols)]`` and gets a
+concrete sparse block back; the hot paths that then call ``.toarray()`` on that
+block are untouched. Code that densifies the whole layer — ``as_dense`` /
+``np.asarray`` — routes through :meth:`LazyMatrix.__array__`, the deliberate
+"materialise everything" escape hatch you avoid on the million-cell path but keep
+for the small ones.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Iterator, Optional, Tuple, Union
+
+import numpy as np
+import scipy.sparse as sp
+
+from ._sparse import as_sparse
+
+_FORMAT = "shanuz-lazy-csc-v1"
+_META = "meta.json"
+_DATA = "data.npy"
+_INDICES = "indices.npy"
+_INDPTR = "indptr.npy"
+
+
+class LazyMatrix:
+    """A memory-mapped, on-disk compressed-sparse-column matrix.
+
+    Instances are created by :func:`write_lazy_matrix` (persist an in-memory
+    matrix) or :func:`open_lazy_matrix` (map an existing store); they are not
+    constructed directly. The three CSC arrays are memory-mapped read-only, so
+    the object is cheap to hold and its footprint is the slices you touch — not
+    the whole matrix.
+
+    Supports the slicing idioms the assay layer accessors use — ``m[rows, cols]``,
+    ``m[np.ix_(rows, cols)]``, ``m[idx, :]``, ``m[:, idx]``, contiguous slices —
+    returning a ``scipy.sparse.csc_matrix`` block. Tuple indexing is always an
+    **outer** (cross-product) selection, matching ``np.ix_`` and how layers are
+    block-subset throughout shanuz; element-wise pair indexing is not supported.
+    """
+
+    __slots__ = ("_path", "_shape", "_dtype", "_data", "_indices", "_indptr")
+
+    def __init__(
+        self,
+        path: Union[str, Path],
+        shape: Tuple[int, int],
+        data: np.ndarray,
+        indices: np.ndarray,
+        indptr: np.ndarray,
+    ) -> None:
+        self._path = Path(path)
+        self._shape = (int(shape[0]), int(shape[1]))
+        self._data = data
+        self._indices = indices
+        self._indptr = indptr
+
+    # ------------------------------------------------------------------
+    # Array-like metadata
+    # ------------------------------------------------------------------
+
+    @property
+    def shape(self) -> Tuple[int, int]:
+        return self._shape
+
+    @property
+    def nrow(self) -> int:
+        return self._shape[0]
+
+    @property
+    def ncol(self) -> int:
+        return self._shape[1]
+
+    @property
+    def ndim(self) -> int:
+        return 2
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._data.dtype
+
+    @property
+    def nnz(self) -> int:
+        return int(self._data.shape[0])
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def __len__(self) -> int:
+        return self._shape[0]
+
+    def __repr__(self) -> str:
+        return (
+            f"LazyMatrix(shape={self._shape}, nnz={self.nnz}, "
+            f"dtype={self.dtype}, path='{self._path}')"
+        )
+
+    # ------------------------------------------------------------------
+    # Lazy column reads — the heart of the out-of-core story
+    # ------------------------------------------------------------------
+
+    def _read_columns(self, cols: Union[slice, np.ndarray]) -> sp.csc_matrix:
+        """Materialise the requested columns as an in-memory CSC block.
+
+        Only the touched columns' ``data`` / ``indices`` ranges are read off the
+        memory-mapped arrays; the rest of the matrix is never faulted in.
+        """
+        nrow = self.nrow
+        indptr = self._indptr
+
+        # Fast path: a contiguous column slice is one contiguous disk read.
+        if isinstance(cols, slice):
+            start, stop, step = cols.indices(self.ncol)
+            if step == 1:
+                s, e = int(indptr[start]), int(indptr[stop])
+                data = np.array(self._data[s:e])
+                indices = np.array(self._indices[s:e])
+                new_indptr = np.array(indptr[start:stop + 1]) - int(indptr[start])
+                return sp.csc_matrix(
+                    (data, indices, new_indptr), shape=(nrow, stop - start)
+                )
+            cols = np.arange(start, stop, step, dtype=np.intp)
+
+        cols = np.asarray(cols, dtype=np.intp)
+        starts = np.asarray(indptr[cols])
+        ends = np.asarray(indptr[cols + 1])
+        sizes = ends - starts
+
+        new_indptr = np.empty(cols.shape[0] + 1, dtype=np.int64)
+        new_indptr[0] = 0
+        np.cumsum(sizes, out=new_indptr[1:])
+        total = int(new_indptr[-1])
+
+        new_data = np.empty(total, dtype=self.dtype)
+        new_indices = np.empty(total, dtype=self._indices.dtype)
+        for k in range(cols.shape[0]):
+            s, e = int(starts[k]), int(ends[k])
+            a, b = int(new_indptr[k]), int(new_indptr[k + 1])
+            new_data[a:b] = self._data[s:e]
+            new_indices[a:b] = self._indices[s:e]
+        return sp.csc_matrix(
+            (new_data, new_indices, new_indptr), shape=(nrow, cols.shape[0])
+        )
+
+    @staticmethod
+    def _resolve(sel, n: int) -> Union[slice, np.ndarray]:
+        """Normalise one axis selector to a plain slice or an integer index array."""
+        if isinstance(sel, slice):
+            return sel
+        arr = np.asarray(sel)
+        if arr.dtype == bool:
+            return np.flatnonzero(arr)
+        return arr.ravel().astype(np.intp)
+
+    def __getitem__(self, key) -> sp.csc_matrix:
+        if isinstance(key, tuple):
+            if len(key) != 2:
+                raise IndexError("LazyMatrix supports 2-D indexing only.")
+            row_sel, col_sel = key
+        else:
+            row_sel, col_sel = key, slice(None)
+
+        rows = self._resolve(row_sel, self.nrow)
+        cols = self._resolve(col_sel, self.ncol)
+
+        sub = self._read_columns(cols)
+        if not (isinstance(rows, slice) and rows == slice(None, None, None)):
+            sub = sub[rows, :]
+        return sp.csc_matrix(sub)
+
+    def col_blocks(
+        self, block_size: int = 10_000
+    ) -> Iterator[Tuple[int, int, sp.csc_matrix]]:
+        """Stream the matrix in blocks of ``block_size`` columns (cells).
+
+        Yields ``(start, stop, block)`` where ``block`` is an in-memory
+        ``csc_matrix`` of columns ``[start:stop)``. This is the primitive for an
+        out-of-core reduction: process a million cells at bounded peak memory.
+        """
+        if block_size <= 0:
+            raise ValueError("block_size must be positive.")
+        for start in range(0, self.ncol, block_size):
+            stop = min(start + block_size, self.ncol)
+            yield start, stop, self._read_columns(slice(start, stop))
+
+    # ------------------------------------------------------------------
+    # Streaming reductions (single pass over the on-disk arrays)
+    # ------------------------------------------------------------------
+
+    def sum(self, axis: Optional[int] = None):
+        """Sum over ``axis`` (0 → per-cell, 1 → per-feature, None → scalar)."""
+        data = np.asarray(self._data)
+        if axis is None:
+            return float(data.sum())
+        if data.size == 0:
+            return np.zeros(self.ncol if axis == 0 else self.nrow, dtype=float)
+        if axis == 0:
+            counts = np.diff(np.asarray(self._indptr))
+            col_ids = np.repeat(np.arange(self.ncol), counts)
+            return np.bincount(col_ids, weights=data, minlength=self.ncol).astype(float)
+        if axis == 1:
+            return np.bincount(
+                np.asarray(self._indices), weights=data, minlength=self.nrow
+            ).astype(float)
+        raise ValueError("axis must be 0, 1, or None.")
+
+    def mean(self, axis: Optional[int] = None):
+        """Mean over ``axis``, dividing the streamed sums by the matrix extent."""
+        total = self.sum(axis)
+        if axis is None:
+            return total / (self.nrow * self.ncol)
+        denom = self.nrow if axis == 0 else self.ncol
+        return total / denom
+
+    def nnz_per_col(self) -> np.ndarray:
+        """Non-zeros per column (cell) — the ``nFeature`` count, read from indptr."""
+        return np.diff(np.asarray(self._indptr)).astype(np.int64)
+
+    # ------------------------------------------------------------------
+    # Materialisation (the escape hatches — avoid on the huge path)
+    # ------------------------------------------------------------------
+
+    def to_scipy(self) -> sp.csc_matrix:
+        """Read the whole matrix into an in-memory ``csc_matrix``."""
+        return sp.csc_matrix(
+            (np.array(self._data), np.array(self._indices), np.array(self._indptr)),
+            shape=self._shape,
+        )
+
+    def toarray(self) -> np.ndarray:
+        """Read the whole matrix into a dense ``ndarray``."""
+        return self.to_scipy().toarray()
+
+    def __array__(self, dtype=None) -> np.ndarray:
+        arr = self.toarray()
+        return arr.astype(dtype) if dtype is not None else arr
+
+    # ------------------------------------------------------------------
+    # Resource management
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the memory-mapped arrays."""
+        for name in ("_data", "_indices", "_indptr"):
+            arr = getattr(self, name, None)
+            mm = getattr(arr, "_mmap", None) if arr is not None else None
+            if mm is not None:
+                mm.close()
+            setattr(self, name, None)
+
+    def __enter__(self) -> "LazyMatrix":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+
+# ----------------------------------------------------------------------
+# Persist / open
+# ----------------------------------------------------------------------
+
+
+def write_lazy_matrix(
+    matrix, path: Union[str, Path], *, overwrite: bool = False
+) -> LazyMatrix:
+    """Write ``matrix`` to ``path`` as an on-disk CSC store and open it lazily.
+
+    ``matrix`` may be a scipy sparse matrix, a dense array-like, or another
+    :class:`LazyMatrix`; it is canonicalised to sorted, duplicate-summed CSC
+    before being saved as three ``.npy`` arrays plus a JSON header. Returns a
+    :class:`LazyMatrix` mapping the freshly written store.
+    """
+    path = Path(path)
+    if isinstance(matrix, LazyMatrix):
+        matrix = matrix.to_scipy()
+    m = as_sparse(matrix, "csc")
+    m.sum_duplicates()
+    m.sort_indices()
+
+    if path.exists():
+        looks_like_store = (path / _META).exists()
+        is_empty_dir = path.is_dir() and not any(path.iterdir())
+        if not overwrite:
+            raise FileExistsError(
+                f"'{path}' already exists; pass overwrite=True to replace it."
+            )
+        if not (looks_like_store or is_empty_dir):
+            raise ValueError(
+                f"Refusing to overwrite '{path}': it is not a lazy-matrix store."
+            )
+        shutil.rmtree(path)
+    path.mkdir(parents=True)
+
+    np.save(path / _DATA, m.data)
+    np.save(path / _INDICES, m.indices)
+    np.save(path / _INDPTR, m.indptr)
+    meta = {
+        "format": _FORMAT,
+        "shape": [int(m.shape[0]), int(m.shape[1])],
+        "dtype": str(m.data.dtype),
+        "nnz": int(m.nnz),
+    }
+    (path / _META).write_text(json.dumps(meta, indent=2))
+    return open_lazy_matrix(path)
+
+
+def open_lazy_matrix(path: Union[str, Path]) -> LazyMatrix:
+    """Memory-map an on-disk CSC store written by :func:`write_lazy_matrix`."""
+    path = Path(path)
+    meta_path = path / _META
+    if not meta_path.exists():
+        raise FileNotFoundError(f"No lazy-matrix store at '{path}'.")
+    meta = json.loads(meta_path.read_text())
+    if meta.get("format") != _FORMAT:
+        raise ValueError(f"Unknown lazy-matrix format: {meta.get('format')!r}.")
+
+    data = np.load(path / _DATA, mmap_mode="r")
+    indices = np.load(path / _INDICES, mmap_mode="r")
+    indptr = np.load(path / _INDPTR, mmap_mode="r")
+    return LazyMatrix(path, tuple(meta["shape"]), data, indices, indptr)
+
+
+def is_lazy(x) -> bool:
+    """True if ``x`` is a :class:`LazyMatrix` (an on-disk, memory-mapped layer)."""
+    return isinstance(x, LazyMatrix)

--- a/tests/test_lazy.py
+++ b/tests/test_lazy.py
@@ -1,0 +1,240 @@
+"""Tests for BPCells-style lazy, on-disk matrices (v0.8.0 Scale).
+
+  * write_lazy_matrix / open_lazy_matrix  (lazy.py)
+  * LazyMatrix indexing, streaming reductions, materialisation
+  * LazyMatrix as a drop-in Assay5 layer
+
+Every LazyMatrix operation is checked against the equivalent in-memory
+``scipy.sparse`` result, so the on-disk store is verified to be a faithful,
+byte-for-byte drop-in for the sparse layer it replaces. Network-free; all
+matrices are written to pytest's ``tmp_path``.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from shanuz._sparse import as_dense  # noqa: E402
+from shanuz.lazy import (  # noqa: E402
+    LazyMatrix,
+    is_lazy,
+    open_lazy_matrix,
+    write_lazy_matrix,
+)
+from shanuz.shanuz import create_shanuz_object  # noqa: E402
+
+
+def _rand_sparse(nrow=40, ncol=30, density=0.2, seed=0):
+    rng = np.random.default_rng(seed)
+    m = sp.random(nrow, ncol, density=density, format="csc", random_state=rng)
+    m.data = np.round(m.data * 10.0, 3)  # nicer values, still float64
+    return m
+
+
+# ----------------------------------------------------------------------
+# round-trip & metadata
+# ----------------------------------------------------------------------
+
+
+def test_roundtrip_preserves_values(tmp_path):
+    m = _rand_sparse()
+    lazy = write_lazy_matrix(m, tmp_path / "m.mat")
+    assert isinstance(lazy, LazyMatrix)
+    assert np.array_equal(lazy.toarray(), m.toarray())
+    # reopening the store gives the same values without re-writing
+    again = open_lazy_matrix(tmp_path / "m.mat")
+    assert np.array_equal(again.toarray(), m.toarray())
+
+
+def test_reports_shape_dtype_nnz(tmp_path):
+    m = _rand_sparse(nrow=17, ncol=23)
+    lazy = write_lazy_matrix(m, tmp_path / "m.mat")
+    assert lazy.shape == (17, 23)
+    assert lazy.nrow == 17 and lazy.ncol == 23
+    assert lazy.ndim == 2
+    assert lazy.nnz == m.nnz
+    assert lazy.dtype == m.data.dtype
+    assert len(lazy) == 17
+
+
+def test_is_lazy(tmp_path):
+    lazy = write_lazy_matrix(_rand_sparse(), tmp_path / "m.mat")
+    assert is_lazy(lazy)
+    assert not is_lazy(_rand_sparse())
+    assert not is_lazy(np.zeros((3, 3)))
+
+
+# ----------------------------------------------------------------------
+# indexing — every idiom matches scipy
+# ----------------------------------------------------------------------
+
+
+def test_column_subset_matches_scipy(tmp_path):
+    m = _rand_sparse()
+    lazy = write_lazy_matrix(m, tmp_path / "m.mat")
+    cols = [5, 0, 17, 3, 3]  # out of order, with a repeat
+    assert np.array_equal(lazy[:, cols].toarray(), m[:, cols].toarray())
+
+
+def test_row_subset_matches_scipy(tmp_path):
+    m = _rand_sparse()
+    lazy = write_lazy_matrix(m, tmp_path / "m.mat")
+    rows = [10, 2, 39, 2]
+    assert np.array_equal(lazy[rows, :].toarray(), m[rows, :].toarray())
+
+
+def test_ix_cross_product_matches_scipy(tmp_path):
+    m = _rand_sparse()
+    lazy = write_lazy_matrix(m, tmp_path / "m.mat")
+    r = [1, 8, 20, 33]
+    c = [0, 4, 9, 15, 29]
+    assert np.array_equal(
+        lazy[np.ix_(r, c)].toarray(), m[np.ix_(r, c)].toarray()
+    )
+
+
+def test_contiguous_column_slice_matches_scipy(tmp_path):
+    m = _rand_sparse()
+    lazy = write_lazy_matrix(m, tmp_path / "m.mat")
+    assert np.array_equal(lazy[:, 5:19].toarray(), m[:, 5:19].toarray())
+    assert np.array_equal(lazy[:, :].toarray(), m.toarray())
+
+
+def test_boolean_mask_matches_scipy(tmp_path):
+    m = _rand_sparse()
+    lazy = write_lazy_matrix(m, tmp_path / "m.mat")
+    col_mask = np.zeros(m.shape[1], dtype=bool)
+    col_mask[[2, 7, 11]] = True
+    assert np.array_equal(lazy[:, col_mask].toarray(), m[:, col_mask].toarray())
+
+
+# ----------------------------------------------------------------------
+# streaming reductions
+# ----------------------------------------------------------------------
+
+
+def test_sum_axes_match_scipy(tmp_path):
+    m = _rand_sparse()
+    lazy = write_lazy_matrix(m, tmp_path / "m.mat")
+    assert lazy.sum() == pytest.approx(float(m.sum()))
+    assert np.allclose(lazy.sum(axis=0), np.asarray(m.sum(axis=0)).ravel())
+    assert np.allclose(lazy.sum(axis=1), np.asarray(m.sum(axis=1)).ravel())
+
+
+def test_mean_axes_match_scipy(tmp_path):
+    m = _rand_sparse()
+    dense = m.toarray()
+    lazy = write_lazy_matrix(m, tmp_path / "m.mat")
+    assert lazy.mean() == pytest.approx(dense.mean())
+    assert np.allclose(lazy.mean(axis=0), dense.mean(axis=0))
+    assert np.allclose(lazy.mean(axis=1), dense.mean(axis=1))
+
+
+def test_nnz_per_col_matches_scipy(tmp_path):
+    m = _rand_sparse()
+    lazy = write_lazy_matrix(m, tmp_path / "m.mat")
+    assert np.array_equal(lazy.nnz_per_col(), np.diff(m.indptr))
+
+
+def test_col_blocks_reconstruct_matrix(tmp_path):
+    m = _rand_sparse(ncol=30)
+    lazy = write_lazy_matrix(m, tmp_path / "m.mat")
+    seen = 0
+    blocks = []
+    for start, stop, block in lazy.col_blocks(block_size=7):
+        assert block.shape == (m.shape[0], stop - start)
+        seen += stop - start
+        blocks.append(block)
+    assert seen == m.shape[1]
+    rebuilt = sp.hstack(blocks).toarray()
+    assert np.array_equal(rebuilt, m.toarray())
+
+
+# ----------------------------------------------------------------------
+# materialisation escape hatches
+# ----------------------------------------------------------------------
+
+
+def test_np_asarray_and_as_dense_materialise(tmp_path):
+    m = _rand_sparse()
+    lazy = write_lazy_matrix(m, tmp_path / "m.mat")
+    assert np.array_equal(np.asarray(lazy), m.toarray())
+    assert np.array_equal(as_dense(lazy), m.toarray())
+    assert np.array_equal(lazy.to_scipy().toarray(), m.toarray())
+
+
+# ----------------------------------------------------------------------
+# write guards & lifecycle
+# ----------------------------------------------------------------------
+
+
+def test_write_refuses_existing_without_overwrite(tmp_path):
+    m = _rand_sparse()
+    write_lazy_matrix(m, tmp_path / "m.mat")
+    with pytest.raises(FileExistsError):
+        write_lazy_matrix(m, tmp_path / "m.mat")
+    # overwrite replaces cleanly with a different matrix
+    m2 = _rand_sparse(nrow=40, ncol=30, seed=99)
+    lazy = write_lazy_matrix(m2, tmp_path / "m.mat", overwrite=True)
+    assert np.array_equal(lazy.toarray(), m2.toarray())
+
+
+def test_open_missing_store_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        open_lazy_matrix(tmp_path / "nope")
+
+
+def test_write_accepts_dense_and_lazy(tmp_path):
+    dense = _rand_sparse().toarray()
+    lazy = write_lazy_matrix(dense, tmp_path / "d.mat")
+    assert np.array_equal(lazy.toarray(), dense)
+    # a LazyMatrix can itself be re-persisted
+    copy = write_lazy_matrix(lazy, tmp_path / "d2.mat")
+    assert np.array_equal(copy.toarray(), dense)
+
+
+def test_context_manager_closes(tmp_path):
+    m = _rand_sparse()
+    with write_lazy_matrix(m, tmp_path / "m.mat") as lazy:
+        assert np.array_equal(lazy[:, [1, 2]].toarray(), m[:, [1, 2]].toarray())
+    assert lazy._data is None  # memmaps released
+
+
+# ----------------------------------------------------------------------
+# drop-in Assay5 layer
+# ----------------------------------------------------------------------
+
+
+def test_lazy_layer_roundtrips_through_assay5(tmp_path):
+    rng = np.random.default_rng(0)
+    G, N = 25, 40
+    counts = sp.csc_matrix(rng.poisson(0.5, size=(G, N)).astype(float))
+    features = [f"g{i}" for i in range(G)]
+    cells = [f"c{i}" for i in range(N)]
+    obj = create_shanuz_object(
+        counts=counts, assay="RNA",
+        feature_names=features, cell_names=cells,
+        meta_data=pd.DataFrame(index=cells),
+    )
+    assay = obj.get_assay()
+    original = assay.layers["counts"].toarray()
+
+    lazy = write_lazy_matrix(assay.layers["counts"], tmp_path / "counts.mat")
+    assay.set_layer_data("counts", lazy)
+    assert is_lazy(assay.layers["counts"])
+
+    # Full layer still reads back identically...
+    assert np.array_equal(as_dense(assay.layer_data("counts")), original)
+
+    # ...and a feature × cell block subset matches the in-memory answer.
+    fsub = ["g3", "g10", "g20"]
+    csub = ["c1", "c5", "c30", "c39"]
+    block = assay.layer_data("counts", cells=csub, features=fsub)
+    fidx = [features.index(f) for f in fsub]
+    cidx = [cells.index(c) for c in csub]
+    assert np.array_equal(as_dense(block), original[np.ix_(fidx, cidx)])

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -262,6 +262,8 @@ same caveat as the other tutorials.
 | Leverage scores | `LeverageScore(obj)` | `leverage_score(obj)` |
 | Sketch a large dataset | `SketchData(obj, ncells=5000, method="LeverageScore")` | `sketch_data(obj, ncells=5000)` |
 | Project sketch → full data | `ProjectData(obj, sketched.assay="sketch", reduction="pca")` | `project_data(full, sketch, refdata={"cluster_full": "seurat_clusters"})` |
+| Matrix to disk (out-of-core) | `write_matrix_dir(mat, "counts.mat")` (BPCells) | `write_lazy_matrix(mat, "counts.mat")` |
+| Open on-disk matrix | `open_matrix_dir("counts.mat")` (BPCells) | `open_lazy_matrix("counts.mat")` |
 | Markers | `FindMarkers(pbmc, ident.1)` | `find_markers(pbmc, ident_1)` |
 | All markers | `FindAllMarkers(pbmc, only.pos, logfc.threshold)` | `find_all_markers(pbmc, only_pos, logfc_threshold)` |
 | Conserved markers | `FindConservedMarkers(pbmc, ident.1, grouping.var)` | `find_conserved_markers(pbmc, ident_1, grouping_var)` |
@@ -505,6 +507,50 @@ cluster labels across.
 > a faithful embedding once it has more rows than roughly the squared feature
 > count, which the default comfortably clears for the few-thousand variable
 > features a sketch runs on.
+
+### Lazy on-disk matrices — keeping a million cells out of RAM
+
+Sketching shrinks *how many cells you analyse*; a **lazy matrix** shrinks *how much
+of the matrix is in memory at once*. A dense million-by-twenty-thousand `float64`
+matrix is 160 GB; even the sparse counts leave no room for the copies each step
+makes. Seurat's answer is the `BPCells` package, which keeps the matrix on disk and
+streams over it. `LazyMatrix` is the shanuz analogue, built on NumPy's
+memory-mapping — **no new dependency**.
+
+A matrix is written to a directory as the three memory-mapped arrays of a
+compressed-sparse-column matrix (scipy's `csc_matrix` layout). Opening it maps
+those arrays without reading them; a slice pulls only the touched cells off disk
+and hands back an ordinary `scipy.sparse` block, so it drops straight into an assay
+layer:
+
+```python
+from shanuz import write_lazy_matrix, open_lazy_matrix
+
+assay = obj.get_assay()
+
+# Persist the counts layer out-of-core, then map it back in and swap it in place.
+write_lazy_matrix(assay.layers["counts"], "counts.mat")
+lazy = open_lazy_matrix("counts.mat")
+assay.set_layer_data("counts", lazy)          # a LazyMatrix is a valid layer
+
+# Slicing reads only the selected cells' non-zeros off disk...
+block = assay.layer_data("counts", cells=obj.cell_names()[:1000])
+
+# ...and reductions stream in a single pass without materialising the matrix.
+per_cell = lazy.sum(axis=0)                    # nCount, one pass over the store
+per_gene = lazy.mean(axis=1)                   # per-feature mean
+
+# col_blocks is the streaming primitive: walk a million cells at bounded RAM.
+for start, stop, chunk in lazy.col_blocks(block_size=50_000):
+    ...                                        # chunk is a csc_matrix of those cells
+```
+
+`LazyMatrix` stores **columns** (cells) contiguously, because the operations that
+dominate at scale — sketching, cell subsetting, per-cell normalisation — select
+cells, and CSC makes reading an arbitrary set of columns cost only their own
+non-zeros. `as_dense(lazy)` / `np.asarray(lazy)` still materialise the whole thing
+when you genuinely need it — the escape hatch you keep for the small datasets and
+avoid on the million-cell path.
 
 ### Pseudobulk & conserved markers
 


### PR DESCRIPTION
Delivers the remaining **v0.8.0 Scale** item — out-of-core matrix storage so a million-cell dataset can be analysed without holding the whole matrix in RAM. **No new dependency**: built on NumPy memory-mapping alone. Completes v0.8.0 (sketching landed in #24).

## `shanuz/lazy.py`

**`LazyMatrix`** — a matrix stored on disk as three memory-mapped `.npy` arrays (the `data` / `indices` / `indptr` triple of a compressed-sparse-**column** matrix, exactly scipy's `csc_matrix` layout) plus a JSON header. Opening maps the arrays without reading them; a slice reads only the touched columns' non-zeros off disk and returns an ordinary `scipy.sparse.csc_matrix`, so it drops straight into an `Assay5` layer wherever a sparse layer sits.

- **Indexing** — `m[:, cells]`, `m[np.ix_(genes, cells)]`, `m[rows, :]`, contiguous slices, boolean masks. Tuple indexing is outer/cross-product, matching how `Assay5.layer_data` block-subsets layers.
- **Streaming reductions** — `sum` / `mean` over axis 0 (per-cell) or 1 (per-feature) in a single pass; `nnz_per_col()` (the `nFeature` count) from `indptr`; `col_blocks(block_size)` walks the matrix in cell-blocks at bounded RAM — the primitive for a million-cell reduction.
- **Materialisation escape hatches** — `toarray` / `to_scipy` / `__array__`, so `as_dense()` and `np.asarray()` route through it. Avoid on the huge path; keep for the small ones.
- **`write_lazy_matrix` / `open_lazy_matrix` / `is_lazy`** — persist (with an overwrite guard that refuses to clobber a non-store directory), map back, and test.

**CSC, not CSR** because the scale-out ops (sketching, cell subsetting, per-cell normalisation) select **cells** = columns, which CSC makes cheap. Row-only (feature) subsetting still scans the touched columns; keeping both orientations on disk (as BPCells does) and a `.toarray()` hot-path audit are noted in the docstring/ROADMAP as the natural follow-ons.

## Tests — `tests/test_lazy.py`

18 tests, each checked against the equivalent in-memory scipy result: round-trip + reopen, shape/dtype/nnz, every indexing idiom (column/row/`np.ix_`/slice/boolean), `sum`/`mean`/`nnz_per_col`/`col_blocks`, `np.asarray` + `as_dense` materialisation, overwrite guard, dense/lazy inputs, context-manager close, and a **live `Assay5` layer swap** (write `counts` to disk, `set_layer_data` the lazy matrix, read a feature×cell block back through `layer_data`).

Full suite: **328 passed** (was 310, net +18). Ruff clean on the new files.

## Docs
- **README** — new Features bullet; v0.8.0 roadmap row marked ✅ complete.
- **ROADMAP** — v0.8.0 status → complete; BPCells section rewritten as delivered with implementation + CSC design notes; priority #7 and the dependency table updated (no new dep).
- **tutorials/README** — a runnable "Lazy on-disk matrices" walkthrough (persist → map → swap into a layer → stream reductions / `col_blocks`) plus two API Quick Reference rows.

## Exports
`LazyMatrix`, `write_lazy_matrix`, `open_lazy_matrix`, `is_lazy` in `shanuz/__init__.py` (+ `__all__`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)