### PR TITLE
Add HTODemux cell-hashing demultiplexing (hto_demux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Reference mapping** — `find_transfer_anchors` (project a query into a reference; `pcaproject` or `cca`) + `transfer_data` (annotate the query with reference labels, or impute reference expression onto it); `project_umap` / `map_query` place the query in the reference's own UMAP in one call
 - **Scale (sketching)** — `sketch_data` draws a leverage-weighted subset of a huge dataset (rare states kept, not lost), `leverage_score` computes the per-cell scores via a CountSketch (no full SVD), and `project_data` extends the sketch's PCA/UMAP/labels back to every cell
 - **Scale (lazy on-disk matrices)** — `LazyMatrix` keeps a matrix out-of-core as memory-mapped compressed-sparse-column arrays (BPCells-style); `write_lazy_matrix` / `open_lazy_matrix` persist and map it, a slice reads only the touched cells off disk, `col_blocks` streams a million cells at bounded RAM, and it drops straight into an `Assay5` layer — no new dependency
+- **Cell hashing (demultiplexing)** — `hto_demux` (Seurat's `HTODemux`) demultiplexes pooled samples from hashtag counts: CLR normalize → k-means (`k = n_hashtags + 1`) → per-hashtag negative-binomial background threshold → singlet / doublet / negative calls, written to `meta_data` (`HTO_maxID`, `HTO_classification`, …) plus a `hash.ID` identity
 - **Nearest-neighbour graph** — `find_neighbors` (KNN + SNN)
 - **Multimodal WNN** — `find_multi_modal_neighbors` (per-cell RNA/protein weights, joint `wknn`/`wsnn` graphs)
 - **Clustering** — `find_clusters` (Louvain via python-igraph, Leiden via leidenalg)
@@ -298,7 +299,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`), bimod (`test_use="bimod"`) ✅ *(complete)* |
 | v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I + markvariogram), `image_*` plots, `VisiumV2` tissue images, `spatial_*` H&E plots ✅ *(delivered — see Tutorial 5)* |
 | v0.8.0 | Scale — `SketchData`/`ProjectData` (leverage-score sketching) ✅; BPCells-style lazy on-disk matrices (`LazyMatrix`) ✅ *(complete)* |
-| v0.9.0 | Specialized — `HTODemux`, Mixscape (CRISPR screens) |
+| v0.9.0 | Specialized — `HTODemux` (cell hashing) ✅; Mixscape (CRISPR screens) |
 | v0.10.0 | Infrastructure — PyPI, GitHub Actions CI, type annotations, MkDocs site |
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -507,12 +507,21 @@ brute-force loop over every cell pair (`tests/test_markvariogram.py`).
 
 ### `HTODemux` / `MULTIseqDemux` (cell hashing)
 - **R:** `HTODemux(obj)`, `MULTIseqDemux(obj)`
-- **Plan:**
-  - `hto_demux`: k-means (`k = n_hashtags + 1`) on CLR-normalised HTO counts;
-    per-hashtag negative-binomial threshold to call positive cells; classify as
-    singlet / doublet / negative
-  - `multiseq_demux`: quantile-based bar-code classification
-  - Both store `HTO_classification`, `HTO_maxID`, `nCount_HTO` in `meta_data`
+- **`hto_demux` — ✅ delivered** (`shanuz/hto.py`): k-means (`k = n_hashtags + 1`)
+  on CLR-normalised HTO counts, then a per-hashtag **negative-binomial** fit
+  (maximum likelihood) to the tag's *lowest-expressing* cluster — its background —
+  thresholded at `positive_quantile` (0.99) to call positive cells. Cells positive
+  for zero / one / many hashtags are classified singlet / doublet / negative.
+  Writes the Seurat columns `HTO_maxID`, `HTO_secondID`, `HTO_margin`,
+  `HTO_classification`, `HTO_classification.global` plus a convenient `hash.ID`
+  (also set as the active identity); learned cutoffs are stashed in
+  `obj.misc["hto_demux"]`. `normalize=False` reuses a prior
+  `normalize_data(method="CLR")` layer. Built on the existing CLR helper +
+  sklearn k-means — no new dependency.
+- **Still open:** `multiseq_demux` (McGinnis et al. — quantile-sweep bar-code
+  classification); it shares `hto_demux`'s normalize-then-threshold skeleton.
+  Seurat's `"clara"` k-medoids clustering option is not ported (`kfunc="kmeans"`
+  only).
 
 ### Mixscape (pooled CRISPR screen analysis)
 - **R:** `RunMixscape(obj, target.gene.ident, nt.class.name)`

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -36,6 +36,7 @@ from .transfer import (
 from .mapping import map_query, project_umap
 from .sketch import sketch_data, project_data, leverage_score
 from .lazy import LazyMatrix, write_lazy_matrix, open_lazy_matrix, is_lazy
+from .hto import hto_demux
 from .markers import find_markers, find_all_markers, find_conserved_markers
 from .aggregate import aggregate_expression
 from .sctransform import sctransform
@@ -163,6 +164,7 @@ __all__ = [
     "write_lazy_matrix",
     "open_lazy_matrix",
     "is_lazy",
+    "hto_demux",
     "find_markers",
     "find_all_markers",
     "find_conserved_markers",

--- a/shanuz/hto.py
+++ b/shanuz/hto.py
@@ -1,0 +1,330 @@
+"""Cell-hashing demultiplexing — Seurat's ``HTODemux``.
+
+Cell Hashing (Stoeckius et al. 2018) tags each *sample* with a distinct
+antibody-conjugated oligo — a **hashtag** (HTO) — before the samples are pooled
+and run together on one droplet lane. Every droplet then carries, on top of its
+mRNA, a little barcode of hashtag counts saying which sample the cell came from.
+Demultiplexing turns that hashtag matrix back into a per-cell assignment: this
+cell is a **singlet** from sample 3, that droplet caught two cells and is a
+**doublet** of samples 1 and 2, this empty-ish droplet is **negative**. Pooling
+many samples this way is cheap and cancels batch effects, but only if the
+demultiplexing is trustworthy — that is what :func:`hto_demux` provides.
+
+The hard part is picking, per hashtag, the count above which a cell is genuinely
+"positive" for that tag. A fixed threshold fails because every antibody has its
+own staining background and every experiment its own depth. Seurat's ``HTODemux``
+learns the threshold from the data:
+
+1. **Normalize.** Hashtag counts are compositional (what matters is a cell's
+   *relative* tag levels, not its total), so they are centered-log-ratio (CLR)
+   normalized — the same transform :func:`shanuz.normalize_data` applies with
+   ``method="CLR"``. Margin 2 (across cells, per hashtag) is the usual choice for
+   small panels.
+2. **Cluster.** k-means with ``k = n_hashtags + 1`` splits the cells into one
+   high cluster per hashtag plus a background cluster. For any given hashtag, the
+   cluster with the *lowest* average expression of that tag is its **negative**
+   population — real cells that were never stained by this antibody, i.e. a clean
+   sample of the tag's background.
+3. **Fit a background model.** A negative binomial is fit (maximum likelihood) to
+   the raw counts of that hashtag in its negative cluster, and the
+   ``positive.quantile`` (default 0.99) of the fitted distribution becomes the
+   cutoff. A cell is positive for the hashtag when its raw count exceeds the
+   cutoff. The negative binomial — not Poisson — is used because antibody
+   background is overdispersed; when the data happen to be Poisson-like the fit
+   degenerates to Poisson on its own.
+4. **Classify.** Count how many hashtags each cell is positive for: zero →
+   ``Negative``, one → ``Singlet`` (assigned to that hashtag), more than one →
+   ``Doublet`` (labelled by its top two tags).
+
+The per-cell results are written to ``obj.meta_data`` under the Seurat column
+names (``<assay>_maxID``, ``<assay>_secondID``, ``<assay>_margin``,
+``<assay>_classification``, ``<assay>_classification.global``) plus a convenient
+``hash.ID`` — the hashtag name for singlets, ``"Doublet"``, or ``"Negative"`` —
+which is also set as the active identity so ``subset`` can immediately pull the
+singlets of a given sample.
+
+Seurat also ships ``MULTIseqDemux`` (McGinnis et al., a quantile-sweep
+alternative to the negative-binomial threshold); it shares this module's
+normalize-then-threshold skeleton and is the natural follow-on.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+
+from .preprocessing import _clr_normalize
+
+
+# ----------------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------------
+
+
+def hto_demux(
+    seurat,
+    assay: str = "HTO",
+    positive_quantile: float = 0.99,
+    init: Optional[int] = None,
+    nstarts: int = 10,
+    kfunc: str = "kmeans",
+    normalize: bool = True,
+    margin: int = 2,
+    seed: int = 42,
+    verbose: bool = False,
+):
+    """Demultiplex pooled samples from hashtag counts (Seurat's ``HTODemux``).
+
+    Mirrors ``HTODemux(object, assay = "HTO", positive.quantile = 0.99)``. Each
+    hashtag's positive/negative cutoff is learned by fitting a negative binomial
+    to the tag's background — the k-means cluster in which it is least expressed —
+    and thresholding at ``positive_quantile``. Cells positive for zero / one /
+    many hashtags are called ``Negative`` / ``Singlet`` / ``Doublet``.
+
+    The object is mutated in place: five ``<assay>_*`` metadata columns plus
+    ``hash.ID`` are written (matching Seurat), the active identity is set to
+    ``hash.ID``, and the learned cutoffs are stashed in ``obj.misc["hto_demux"]``.
+
+    Parameters
+    ----------
+    seurat            : a :class:`~shanuz.Shanuz` object carrying a hashtag assay.
+    assay             : the hashtag assay to demultiplex (default ``"HTO"``).
+    positive_quantile : quantile of each tag's fitted background at which the
+                        positive cutoff is set (Seurat default 0.99).
+    init              : number of k-means centers; default ``n_hashtags + 1``.
+    nstarts           : k-means restarts (``n_init``). Seurat uses 100; 10 is a
+                        faster, usually-equivalent default.
+    kfunc             : clustering function. Only ``"kmeans"`` is implemented;
+                        Seurat's default ``"clara"`` (k-medoids) is not ported.
+    normalize         : CLR-normalize the counts internally for clustering and
+                        margins (default). Set False to use the assay's existing
+                        ``data`` layer (e.g. a prior ``normalize_data(method="CLR")``).
+    margin            : CLR margin when ``normalize`` is True — 2 (per hashtag
+                        across cells, recommended for small panels) or 1.
+    seed              : random seed for k-means.
+    verbose           : print each hashtag's learned cutoff.
+
+    Returns
+    -------
+    Shanuz
+        ``seurat``, with the classification metadata and ``hash.ID`` identity.
+    """
+    if kfunc != "kmeans":
+        raise NotImplementedError(
+            f"kfunc={kfunc!r} is not supported; only 'kmeans' is implemented "
+            "(Seurat's 'clara' k-medoids is not ported)."
+        )
+
+    counts, data, feats, cells = _hto_matrices(seurat, assay, normalize, margin)
+    n_htos, n_cells = data.shape
+    if n_htos < 2:
+        raise ValueError(
+            f"HTODemux needs at least 2 hashtags; assay {assay!r} has {n_htos}."
+        )
+
+    labels, ncenters = _cluster_cells(data, init, nstarts, seed)
+
+    # Average (de-logged) expression of each hashtag within each cluster, so the
+    # least-expressing cluster can be read off as that hashtag's background.
+    expd = np.expm1(data)
+    avg = np.full((n_htos, ncenters), np.inf)
+    for c in range(ncenters):
+        mask = labels == c
+        if mask.any():
+            avg[:, c] = expd[:, mask].mean(axis=1)
+
+    # Per-hashtag negative-binomial threshold on its background cluster.
+    discrete = np.zeros((n_htos, n_cells), dtype=bool)
+    cutoffs: dict[str, float] = {}
+    for i in range(n_htos):
+        neg_cluster = int(np.argmin(avg[i]))
+        values_use = counts[i, labels == neg_cluster]
+        cutoff = _positive_cutoff(values_use, positive_quantile)
+        cutoffs[feats[i]] = cutoff
+        discrete[i] = counts[i] > cutoff
+        if verbose:
+            print(f"Cutoff for {feats[i]}: {cutoff:g} reads")
+
+    _write_classification(
+        seurat, assay, data, discrete, feats, cells,
+    )
+    seurat.misc.setdefault("hto_demux", {})[assay] = {
+        "cutoffs": cutoffs,
+        "ncenters": ncenters,
+        "positive_quantile": positive_quantile,
+    }
+    return seurat
+
+
+# ----------------------------------------------------------------------
+# Internals
+# ----------------------------------------------------------------------
+
+
+def _dense(mat) -> np.ndarray:
+    """Densify a possibly-sparse matrix to a float ``ndarray`` (hashtag panels
+    are only a handful of features, so densifying is cheap)."""
+    if sp.issparse(mat):
+        return np.asarray(mat.toarray(), dtype=float)
+    return np.asarray(mat, dtype=float)
+
+
+def _hto_matrices(seurat, assay, normalize, margin):
+    """Return ``(counts, data, feature_names, cell_names)`` for the hashtag assay.
+
+    ``counts`` are the raw hashtag counts (for the background fit) and ``data`` is
+    the CLR-normalized matrix (for clustering and margins) — either recomputed
+    from the counts (``normalize``) or taken from the assay's ``data`` layer.
+    """
+    from .assay5 import Assay5
+    from ._sparse import is_matrix_empty
+
+    if assay not in seurat.assays:
+        raise KeyError(f"Assay {assay!r} not found on the object.")
+    assay_obj = seurat.assays[assay]
+
+    if isinstance(assay_obj, Assay5):
+        feats = list(assay_obj._all_feature_names)
+        cells = list(assay_obj._all_cell_names)
+        counts = assay_obj.layers.get("counts")
+        if counts is None:
+            counts = assay_obj.layers.get("data")
+        data_layer = assay_obj.layers.get("data")
+    else:
+        feats = list(assay_obj._feature_names)
+        cells = list(assay_obj._cell_names)
+        counts = assay_obj.counts
+        data_layer = None if is_matrix_empty(assay_obj.data) else assay_obj.data
+
+    if counts is None:
+        raise ValueError(f"Assay {assay!r} has no counts to demultiplex.")
+
+    counts = _dense(counts)
+    if normalize or data_layer is None:
+        data = _clr_normalize(counts, margin=margin)
+    else:
+        data = _dense(data_layer)
+    return counts, data, feats, cells
+
+
+def _cluster_cells(data: np.ndarray, init, nstarts: int, seed: int):
+    """k-means the cells (columns) into ``init or n_hashtags + 1`` groups.
+
+    Returns ``(labels, ncenters)`` with one integer cluster label per cell.
+    """
+    from sklearn.cluster import KMeans
+
+    n_htos, n_cells = data.shape
+    ncenters = init if init is not None else n_htos + 1
+    ncenters = int(min(ncenters, n_cells))
+    if ncenters < 2:
+        raise ValueError("Too few cells to cluster for HTODemux.")
+
+    km = KMeans(n_clusters=ncenters, n_init=nstarts, random_state=seed)
+    labels = km.fit_predict(data.T)
+    return labels, ncenters
+
+
+def _fit_nbinom(x: np.ndarray) -> Optional[tuple[float, float]]:
+    """Maximum-likelihood negative binomial fit, returning ``(size, mu)``.
+
+    The MLE of the mean is the sample mean; the dispersion ``size`` (``r``) is
+    found by a 1-D optimization of the profile log-likelihood. Under-dispersed
+    (Poisson-like) data drive ``size`` to the upper bound, where the negative
+    binomial converges to Poisson — exactly the desired degenerate behaviour.
+    Returns ``None`` when the background mean is zero (no positive threshold to
+    learn).
+    """
+    from scipy.optimize import minimize_scalar
+    from scipy.special import gammaln
+
+    x = np.asarray(x, dtype=float)
+    if x.size == 0:
+        return None
+    mu = float(x.mean())
+    if mu <= 0:
+        return None
+
+    def neg_ll(log_r: float) -> float:
+        r = np.exp(log_r)
+        p = r / (r + mu)
+        return -np.sum(
+            gammaln(x + r) - gammaln(r) - gammaln(x + 1)
+            + r * np.log(p) + x * np.log1p(-p)
+        )
+
+    res = minimize_scalar(
+        neg_ll, bounds=(np.log(1e-4), np.log(1e8)), method="bounded"
+    )
+    return float(np.exp(res.x)), mu
+
+
+def _positive_cutoff(values_use: np.ndarray, positive_quantile: float) -> float:
+    """Positive cutoff for one hashtag: the ``positive_quantile`` of the negative
+    binomial fit to its background counts (falls back sanely when degenerate)."""
+    from scipy.stats import nbinom
+
+    fit = _fit_nbinom(values_use)
+    if fit is None:
+        return 0.0
+    r, mu = fit
+    p = r / (r + mu)
+    cutoff = float(nbinom.ppf(positive_quantile, r, p))
+    if not np.isfinite(cutoff):
+        return float(values_use.max()) if values_use.size else 0.0
+    return cutoff
+
+
+def _write_classification(seurat, assay, data, discrete, feats, cells) -> None:
+    """Turn the per-hashtag positive calls into the Seurat metadata columns."""
+    n_cells = data.shape[1]
+    cols = np.arange(n_cells)
+
+    # Top-two hashtags per cell (by normalized expression) and their margin.
+    order = np.argsort(-data, axis=0)
+    max_idx = order[0]
+    second_idx = order[1]
+    hash_max = data[max_idx, cols]
+    hash_second = data[second_idx, cols]
+    max_id = [feats[i] for i in max_idx]
+    second_id = [feats[i] for i in second_idx]
+    margin = hash_max - hash_second
+
+    npos = discrete.sum(axis=0)
+    global_class = np.where(
+        npos == 0, "Negative", np.where(npos == 1, "Singlet", "Doublet")
+    )
+
+    classification = []
+    hash_id = []
+    for j in range(n_cells):
+        g = global_class[j]
+        if g == "Singlet":
+            classification.append(max_id[j])
+            hash_id.append(max_id[j])
+        elif g == "Doublet":
+            classification.append("_".join(sorted((max_id[j], second_id[j]))))
+            hash_id.append("Doublet")
+        else:
+            classification.append("Negative")
+            hash_id.append("Negative")
+
+    target = seurat.cell_names()
+
+    def put(col, values):
+        seurat.meta_data[col] = (
+            pd.Series(list(values), index=cells).reindex(target).values
+        )
+
+    put(f"{assay}_maxID", max_id)
+    put(f"{assay}_secondID", second_id)
+    put(f"{assay}_margin", margin)
+    put(f"{assay}_classification", classification)
+    put(f"{assay}_classification.global", list(global_class))
+    put("hash.ID", hash_id)
+
+    seurat.idents = list(
+        pd.Series(hash_id, index=cells).reindex(target).values
+    )

--- a/tests/test_hto.py
+++ b/tests/test_hto.py
@@ -1,0 +1,201 @@
+"""Tests for cell-hashing demultiplexing (v0.9.0 Specialized Assays).
+
+  * hto_demux  (hto.py)
+
+A synthetic hashtag matrix is built with *known* ground truth — clean singlets
+for each of four hashtags, doublets spanning tag pairs, and empty-ish negatives —
+and ``hto_demux`` is asked to recover it. The Seurat metadata columns, the
+``hash.ID`` identity, and the singlet/doublet/negative accuracy are all checked
+against that ground truth. Network-free and deterministic (fixed RNG + seed).
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from shanuz.hto import hto_demux  # noqa: E402
+from shanuz.preprocessing import normalize_data  # noqa: E402
+from shanuz.shanuz import create_shanuz_object  # noqa: E402
+
+TAGS = ["HTO-A", "HTO-B", "HTO-C", "HTO-D"]
+DOUBLET_PAIRS = [(0, 1), (1, 2), (2, 3), (0, 2), (1, 3)]
+
+
+def _hashing_counts(seed=0):
+    """A hashtag count matrix (4 × N) plus per-cell ground-truth labels."""
+    rng = np.random.default_rng(seed)
+    H = len(TAGS)
+    cols, truth = [], []
+
+    # Background staining is ~uniform per antibody across all droplets; a cell is
+    # "positive" for a tag only when its on-target signal towers over that floor.
+    bg = 1.0
+    for h in range(H):                       # 30 singlets per hashtag
+        for _ in range(30):
+            col = rng.poisson(bg, size=H).astype(float)
+            col[h] = rng.poisson(100.0)
+            cols.append(col)
+            truth.append(TAGS[h])
+
+    for _ in range(4):                       # 20 doublets across tag pairs
+        for a, b in DOUBLET_PAIRS:
+            col = rng.poisson(bg, size=H).astype(float)
+            col[a] = rng.poisson(70.0)
+            col[b] = rng.poisson(70.0)
+            cols.append(col)
+            truth.append("Doublet")
+
+    for _ in range(15):                      # 15 negatives (only background)
+        cols.append(rng.poisson(bg, size=H).astype(float))
+        truth.append("Negative")
+
+    counts = np.asarray(cols).T              # H × N
+    return counts, np.asarray(truth)
+
+
+def _hashing_object(seed=0):
+    counts, truth = _hashing_counts(seed)
+    cells = [f"c{i}" for i in range(counts.shape[1])]
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(counts), assay="HTO",
+        feature_names=TAGS, cell_names=cells,
+        meta_data=pd.DataFrame(index=cells),
+    )
+    return obj, truth
+
+
+# ----------------------------------------------------------------------
+# metadata columns & identity
+# ----------------------------------------------------------------------
+
+
+def test_writes_seurat_metadata_columns():
+    obj, _ = _hashing_object()
+    hto_demux(obj)
+    for col in (
+        "HTO_maxID", "HTO_secondID", "HTO_margin",
+        "HTO_classification", "HTO_classification.global", "hash.ID",
+    ):
+        assert col in obj.meta_data.columns
+
+
+def test_global_classification_domain():
+    obj, _ = _hashing_object()
+    hto_demux(obj)
+    vals = set(obj.meta_data["HTO_classification.global"])
+    assert vals <= {"Negative", "Singlet", "Doublet"}
+
+
+def test_idents_set_to_hash_id():
+    obj, _ = _hashing_object()
+    hto_demux(obj)
+    assert len(obj.idents) == len(obj.cell_names())
+    assert list(obj.idents) == list(obj.meta_data["hash.ID"])
+
+
+def test_margin_nonnegative_and_ids_distinct():
+    obj, _ = _hashing_object()
+    hto_demux(obj)
+    margin = obj.meta_data["HTO_margin"].to_numpy()
+    assert (margin >= -1e-9).all()
+    max_id = obj.meta_data["HTO_maxID"].to_numpy()
+    second_id = obj.meta_data["HTO_secondID"].to_numpy()
+    assert (max_id != second_id).all()
+
+
+# ----------------------------------------------------------------------
+# recovery against ground truth
+# ----------------------------------------------------------------------
+
+
+def test_singlets_recovered():
+    obj, truth = _hashing_object()
+    hto_demux(obj)
+    gclass = obj.meta_data["HTO_classification.global"].to_numpy()
+    hash_id = obj.meta_data["hash.ID"].to_numpy()
+
+    singlet = np.isin(truth, TAGS)
+    assert (gclass[singlet] == "Singlet").mean() >= 0.9
+    # correct singlets are assigned to their true hashtag
+    assert (hash_id[singlet] == truth[singlet]).mean() >= 0.9
+
+
+def test_doublets_recovered():
+    obj, truth = _hashing_object()
+    hto_demux(obj)
+    gclass = obj.meta_data["HTO_classification.global"].to_numpy()
+    doublet = truth == "Doublet"
+    assert (gclass[doublet] == "Doublet").mean() >= 0.75
+    # a called doublet's classification names its two tags, sorted + joined
+    hto_class = obj.meta_data["HTO_classification"].to_numpy()
+    for lab in hto_class[doublet & (gclass == "Doublet")]:
+        assert "_" in lab and lab == "_".join(sorted(lab.split("_")))
+
+
+def test_negatives_recovered():
+    obj, truth = _hashing_object()
+    hto_demux(obj)
+    gclass = obj.meta_data["HTO_classification.global"].to_numpy()
+    negative = truth == "Negative"
+    assert (gclass[negative] == "Negative").mean() >= 0.8
+
+
+# ----------------------------------------------------------------------
+# bookkeeping, options & guards
+# ----------------------------------------------------------------------
+
+
+def test_cutoffs_stored_in_misc():
+    obj, _ = _hashing_object()
+    hto_demux(obj)
+    info = obj.misc["hto_demux"]["HTO"]
+    assert set(info["cutoffs"]) == set(TAGS)
+    assert info["ncenters"] == len(TAGS) + 1
+    assert all(np.isfinite(c) for c in info["cutoffs"].values())
+
+
+def test_init_overrides_center_count():
+    obj, _ = _hashing_object()
+    hto_demux(obj, init=6)
+    assert obj.misc["hto_demux"]["HTO"]["ncenters"] == 6
+
+
+def test_normalize_false_uses_data_layer():
+    obj, truth = _hashing_object()
+    normalize_data(obj, normalization_method="CLR", margin=2, assay="HTO")
+    hto_demux(obj, normalize=False)
+    gclass = obj.meta_data["HTO_classification.global"].to_numpy()
+    singlet = np.isin(truth, TAGS)
+    assert (gclass[singlet] == "Singlet").mean() >= 0.9
+
+
+def test_deterministic():
+    obj_a, _ = _hashing_object()
+    obj_b, _ = _hashing_object()
+    hto_demux(obj_a, seed=7)
+    hto_demux(obj_b, seed=7)
+    assert list(obj_a.meta_data["hash.ID"]) == list(obj_b.meta_data["hash.ID"])
+
+
+def test_requires_two_hashtags():
+    rng = np.random.default_rng(0)
+    counts = sp.csc_matrix(rng.poisson(5.0, size=(1, 20)).astype(float))
+    cells = [f"c{i}" for i in range(20)]
+    obj = create_shanuz_object(
+        counts=counts, assay="HTO",
+        feature_names=["HTO-A"], cell_names=cells,
+        meta_data=pd.DataFrame(index=cells),
+    )
+    with pytest.raises(ValueError):
+        hto_demux(obj)
+
+
+def test_unsupported_kfunc_raises():
+    obj, _ = _hashing_object()
+    with pytest.raises(NotImplementedError):
+        hto_demux(obj, kfunc="clara")

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -264,6 +264,7 @@ same caveat as the other tutorials.
 | Project sketch → full data | `ProjectData(obj, sketched.assay="sketch", reduction="pca")` | `project_data(full, sketch, refdata={"cluster_full": "seurat_clusters"})` |
 | Matrix to disk (out-of-core) | `write_matrix_dir(mat, "counts.mat")` (BPCells) | `write_lazy_matrix(mat, "counts.mat")` |
 | Open on-disk matrix | `open_matrix_dir("counts.mat")` (BPCells) | `open_lazy_matrix("counts.mat")` |
+| Demultiplex hashtags | `HTODemux(obj, assay="HTO")` | `hto_demux(obj, assay="HTO")` |
 | Markers | `FindMarkers(pbmc, ident.1)` | `find_markers(pbmc, ident_1)` |
 | All markers | `FindAllMarkers(pbmc, only.pos, logfc.threshold)` | `find_all_markers(pbmc, only_pos, logfc_threshold)` |
 | Conserved markers | `FindConservedMarkers(pbmc, ident.1, grouping.var)` | `find_conserved_markers(pbmc, ident_1, grouping_var)` |
@@ -551,6 +552,50 @@ cells, and CSC makes reading an arbitrary set of columns cost only their own
 non-zeros. `as_dense(lazy)` / `np.asarray(lazy)` still materialise the whole thing
 when you genuinely need it — the escape hatch you keep for the small datasets and
 avoid on the million-cell path.
+
+### Cell hashing — demultiplexing pooled samples
+
+Cell Hashing (Stoeckius et al.) tags each *sample* with a distinct
+antibody-oligo **hashtag** before pooling the samples on one lane. Every droplet
+then carries a little vector of hashtag counts saying which sample it came from —
+and droplets that caught two cells carry two tags. `hto_demux` (Seurat's
+`HTODemux`) turns that hashtag matrix back into per-cell calls: **singlet** (one
+tag), **doublet** (two or more), or **negative** (none).
+
+The hashtags live in their own assay alongside the RNA. `hto_demux` learns each
+tag's positive cutoff from the data — it CLR-normalizes the counts, k-means
+clusters the cells (`k = n_hashtags + 1`), fits a negative binomial to each tag's
+*background* (the cluster where it is least expressed), and thresholds at the
+0.99 quantile:
+
+```python
+from shanuz import hto_demux
+
+# `obj` has an "HTO" assay of hashtag counts (features = hashtags, columns = cells).
+hto_demux(obj, assay="HTO")                    # positive_quantile=0.99 by default
+
+# Per-cell results land in meta_data under the Seurat column names:
+obj.meta_data["HTO_classification.global"]     # "Singlet" / "Doublet" / "Negative"
+obj.meta_data["HTO_maxID"]                      # the top hashtag per cell
+obj.meta_data["HTO_classification"]            # tag name (singlet) or "HTOa_HTOb" (doublet)
+obj.meta_data["hash.ID"]                        # tag name / "Doublet" / "Negative"
+
+# hash.ID is also set as the active identity, so keeping only the clean singlets
+# of one sample is a one-liner:
+singlets = obj.meta_data["HTO_classification.global"] == "Singlet"
+sample3 = obj.subset(cells=obj.meta_data.index[
+    singlets & (obj.meta_data["hash.ID"] == "HTO-3")
+].tolist())
+
+# The learned per-hashtag cutoffs are kept for inspection:
+obj.misc["hto_demux"]["HTO"]["cutoffs"]         # {"HTO-1": 6.0, "HTO-2": 5.0, ...}
+```
+
+By default `hto_demux` CLR-normalizes internally; if you already ran
+`normalize_data(obj, normalization_method="CLR", margin=2, assay="HTO")`, pass
+`normalize=False` to reuse that `data` layer. The negative binomial — not a fixed
+threshold — is what makes the call robust to each antibody's own staining
+background and each run's own depth.
 
 ### Pseudobulk & conserved markers
 


### PR DESCRIPTION
## Summary

Ports Seurat's **`HTODemux`** to shanuz as `hto_demux` (`shanuz/hto.py`) — the first item of the **v0.9.0 Specialized Assay Methods** milestone. It demultiplexes pooled samples from antibody-hashtag (HTO) counts into **singlet / doublet / negative** calls.

## Algorithm (faithful to Seurat)

1. **CLR-normalize** the hashtag counts (reuses `preprocessing._clr_normalize`; margin 2 for small panels).
2. **k-means** with `k = n_hashtags + 1` → one high cluster per tag plus a background cluster.
3. Per hashtag, fit a **negative binomial** (MLE `size`+`mu`) to its *lowest-expressing* cluster — the tag's background — and threshold at `positive_quantile` (0.99). NB degenerates cleanly to Poisson when the background is under-dispersed.
4. Count crossings per cell → `Negative` / `Singlet` / `Doublet`.

## Output

Writes the Seurat metadata columns `HTO_maxID`, `HTO_secondID`, `HTO_margin`, `HTO_classification`, `HTO_classification.global`, plus a convenient **`hash.ID`** (tag name for singlets, `"Doublet"`, or `"Negative"`) which is also set as the active identity. Learned cutoffs are stashed in `obj.misc["hto_demux"]`. `normalize=False` reuses a prior `normalize_data(method="CLR")` layer.

Built on the existing CLR helper + sklearn k-means — **no new dependency**.

## Tests

`tests/test_hto.py` — **13 tests**, all passing. A synthetic 4-hashtag panel with known ground truth (120 singlets / 20 doublets / 15 negatives) checks the metadata columns, the `hash.ID` identity, singlet/doublet/negative recovery, determinism, the `init` override, the `normalize=False` path, and the `<2-hashtags` / unsupported-`kfunc` guards.

Full suite **341 passing** (was 328, **+13**); ruff clean on all touched files.

## Scope / follow-ons

Delivers `HTODemux`; the v0.9.0 line also names **`MULTIseqDemux`** (McGinnis et al. quantile-sweep variant), which shares this module's normalize-then-threshold skeleton — noted as the natural follow-on. Seurat's `"clara"` k-medoids clustering option is not ported (`kfunc="kmeans"` only).

## Docs

README feature bullet + roadmap-table row; ROADMAP v0.9.0 section marked delivered; tutorials API-reference row + a runnable **"Cell hashing"** walkthrough section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)