### PR TITLE
Add MULTI-seq cell-hashing demultiplexing (multiseq_demux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 - **Reference mapping** — `find_transfer_anchors` (project a query into a reference; `pcaproject` or `cca`) + `transfer_data` (annotate the query with reference labels, or impute reference expression onto it); `project_umap` / `map_query` place the query in the reference's own UMAP in one call
 - **Scale (sketching)** — `sketch_data` draws a leverage-weighted subset of a huge dataset (rare states kept, not lost), `leverage_score` computes the per-cell scores via a CountSketch (no full SVD), and `project_data` extends the sketch's PCA/UMAP/labels back to every cell
 - **Scale (lazy on-disk matrices)** — `LazyMatrix` keeps a matrix out-of-core as memory-mapped compressed-sparse-column arrays (BPCells-style); `write_lazy_matrix` / `open_lazy_matrix` persist and map it, a slice reads only the touched cells off disk, `col_blocks` streams a million cells at bounded RAM, and it drops straight into an `Assay5` layer — no new dependency
-- **Cell hashing (demultiplexing)** — `hto_demux` (Seurat's `HTODemux`) demultiplexes pooled samples from hashtag counts: CLR normalize → k-means (`k = n_hashtags + 1`) → per-hashtag negative-binomial background threshold → singlet / doublet / negative calls, written to `meta_data` (`HTO_maxID`, `HTO_classification`, …) plus a `hash.ID` identity
+- **Cell hashing (demultiplexing)** — `hto_demux` (Seurat's `HTODemux`) demultiplexes pooled samples from hashtag counts: CLR normalize → k-means (`k = n_hashtags + 1`) → per-hashtag negative-binomial background threshold → singlet / doublet / negative calls, written to `meta_data` (`HTO_maxID`, `HTO_classification`, …) plus a `hash.ID` identity. `multiseq_demux` (Seurat's `MULTIseqDemux`) is the MULTI-seq alternative — a Gaussian-KDE quantile threshold per barcode, with an `autothresh` sweep — writing `MULTI_ID` / `MULTI_classification`
 - **Nearest-neighbour graph** — `find_neighbors` (KNN + SNN)
 - **Multimodal WNN** — `find_multi_modal_neighbors` (per-cell RNA/protein weights, joint `wknn`/`wsnn` graphs)
 - **Clustering** — `find_clusters` (Louvain via python-igraph, Leiden via leidenalg)
@@ -299,7 +299,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`), bimod (`test_use="bimod"`) ✅ *(complete)* |
 | v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I + markvariogram), `image_*` plots, `VisiumV2` tissue images, `spatial_*` H&E plots ✅ *(delivered — see Tutorial 5)* |
 | v0.8.0 | Scale — `SketchData`/`ProjectData` (leverage-score sketching) ✅; BPCells-style lazy on-disk matrices (`LazyMatrix`) ✅ *(complete)* |
-| v0.9.0 | Specialized — `HTODemux` (cell hashing) ✅; Mixscape (CRISPR screens) |
+| v0.9.0 | Specialized — `HTODemux` ✅ + `MULTIseqDemux` ✅ (cell hashing); Mixscape (CRISPR screens) |
 | v0.10.0 | Infrastructure — PyPI, GitHub Actions CI, type annotations, MkDocs site |
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -518,10 +518,19 @@ brute-force loop over every cell pair (`tests/test_markvariogram.py`).
   `obj.misc["hto_demux"]`. `normalize=False` reuses a prior
   `normalize_data(method="CLR")` layer. Built on the existing CLR helper +
   sklearn k-means — no new dependency.
-- **Still open:** `multiseq_demux` (McGinnis et al. — quantile-sweep bar-code
-  classification); it shares `hto_demux`'s normalize-then-threshold skeleton.
-  Seurat's `"clara"` k-medoids clustering option is not ported (`kfunc="kmeans"`
-  only).
+- **`multiseq_demux` — ✅ delivered** (`shanuz/multiseq.py`): the MULTI-seq
+  chemistry (McGinnis et al.). Reuses `hto_demux`'s CLR extraction, then thresholds
+  each barcode straight off its distribution shape rather than a background fit — a
+  Gaussian KDE over a 100-point grid exposes the background and positive modes as
+  the two tallest local maxima and the cutoff sits a fraction `quantile` (0.7)
+  between them. Cells clearing zero / one / many barcodes are singlet / doublet /
+  negative. `autothresh=True` runs McGinnis's iterative `deMULTIplex` sweep — pick
+  the `q` maximising the singlet rate, peel off negatives, re-threshold the
+  remainder up to `maxiter` rounds. Writes `MULTI_ID` (also the active identity)
+  and `MULTI_classification`; thresholds stashed in `obj.misc["multiseq_demux"]`.
+  KDE via `scipy.stats.gaussian_kde` — no new dependency.
+- **Still open:** Seurat's `"clara"` k-medoids clustering option for `hto_demux` is
+  not ported (`kfunc="kmeans"` only).
 
 ### Mixscape (pooled CRISPR screen analysis)
 - **R:** `RunMixscape(obj, target.gene.ident, nt.class.name)`

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -37,6 +37,7 @@ from .mapping import map_query, project_umap
 from .sketch import sketch_data, project_data, leverage_score
 from .lazy import LazyMatrix, write_lazy_matrix, open_lazy_matrix, is_lazy
 from .hto import hto_demux
+from .multiseq import multiseq_demux
 from .markers import find_markers, find_all_markers, find_conserved_markers
 from .aggregate import aggregate_expression
 from .sctransform import sctransform
@@ -165,6 +166,7 @@ __all__ = [
     "open_lazy_matrix",
     "is_lazy",
     "hto_demux",
+    "multiseq_demux",
     "find_markers",
     "find_all_markers",
     "find_conserved_markers",

--- a/shanuz/multiseq.py
+++ b/shanuz/multiseq.py
@@ -1,0 +1,273 @@
+"""MULTI-seq demultiplexing — Seurat's ``MULTIseqDemux``.
+
+MULTI-seq (McGinnis, Patterson et al. 2019) is a second cell-hashing chemistry:
+lipid- or cholesterol-anchored barcode oligos label each *sample* before pooling,
+exactly as antibody hashtags do in Cell Hashing. Demultiplexing is the same
+problem as :func:`shanuz.hto_demux` solves — turn the per-cell barcode count
+matrix back into singlet / doublet / negative calls — but MULTI-seq reaches the
+answer a different way, and the two methods often disagree at the margins, so
+having both is useful.
+
+Where ``HTODemux`` learns each tag's cutoff by fitting a **negative binomial** to
+its background cluster, ``MULTIseqDemux`` reads the cutoff straight off the shape
+of each barcode's distribution:
+
+1. **Normalize.** Barcode counts are compositional, so they are centered-log-ratio
+   (CLR) normalized — the same transform :func:`shanuz.normalize_data` applies with
+   ``method="CLR"`` (margin 2, per barcode across cells, for small panels). As with
+   :func:`shanuz.hto_demux`, ``normalize=True`` (default) recomputes this from the
+   raw counts so the function works straight after object creation; ``normalize=False``
+   uses the assay's existing ``data`` layer, matching Seurat's expectation that you
+   normalize first.
+2. **Find each barcode's threshold.** For one barcode, the CLR values across all
+   cells form a bimodal distribution — a tall low mode (cells the barcode never
+   stained: its background) and a shorter high mode (cells it did stain). A smooth
+   Gaussian kernel density estimate over a 100-point grid exposes those two modes
+   as the two tallest local maxima. The threshold is placed a fraction ``quantile``
+   of the way from the low mode to the high mode (``quantile=0.7`` sits 70 % toward
+   the positive peak). A cell is positive for the barcode when its CLR value clears
+   that threshold. Barcodes with no discernible second mode get no threshold and
+   mark no cells (Seurat likewise skips them).
+3. **Classify.** Count how many barcodes each cell clears: zero → ``Negative``,
+   one → that barcode (``Singlet``), more than one → ``Doublet``.
+
+The ``quantile`` that best separates the data is not known a priori. With
+``autothresh=True`` the classifier sweeps ``qrange`` (Seurat's default
+``0.1 … 0.9``), picks the ``q`` that yields the most singlets, strips the cells it
+calls negative, and repeats on the remainder — up to ``maxiter`` rounds — so that
+peeling away empty droplets sharpens the modes for the cells that remain. This is
+the iterative "semi-supervised" thresholding from McGinnis's ``deMULTIplex``.
+
+Results are written to ``obj.meta_data`` under Seurat's names: ``MULTI_ID`` — the
+barcode name for singlets, ``"Doublet"``, or ``"Negative"`` — which is also set as
+the active identity (so ``subset`` can pull a sample's singlets immediately), and a
+character copy in ``MULTI_classification``. The learned per-barcode thresholds are
+stashed in ``obj.misc["multiseq_demux"]``.
+"""
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+from .hto import _hto_matrices
+
+
+# ----------------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------------
+
+
+def multiseq_demux(
+    seurat,
+    assay: str = "HTO",
+    quantile: float = 0.7,
+    autothresh: bool = False,
+    maxiter: int = 5,
+    qrange: Optional[Sequence[float]] = None,
+    normalize: bool = True,
+    margin: int = 2,
+    verbose: bool = False,
+):
+    """Demultiplex pooled samples from barcode counts (Seurat's ``MULTIseqDemux``).
+
+    Mirrors ``MULTIseqDemux(object, assay = "HTO", quantile = 0.7)``. For each
+    barcode a Gaussian-kernel-density threshold is placed a fraction ``quantile``
+    of the way between its background and positive modes; cells positive for zero /
+    one / many barcodes are called ``Negative`` / ``Singlet`` / ``Doublet``.
+
+    The object is mutated in place: ``MULTI_ID`` and ``MULTI_classification``
+    metadata columns are written, the active identity is set to ``MULTI_ID``, and
+    the learned thresholds are stashed in ``obj.misc["multiseq_demux"]``.
+
+    Parameters
+    ----------
+    seurat     : a :class:`~shanuz.Shanuz` object carrying a hashtag/barcode assay.
+    assay      : the barcode assay to demultiplex (default ``"HTO"``).
+    quantile   : fraction between each barcode's background and positive modes at
+                 which its positive cutoff is placed (Seurat default 0.7). Ignored
+                 when ``autothresh`` is True.
+    autothresh : sweep ``qrange`` for the quantile that maximizes the singlet rate,
+                 iteratively removing negatives and re-thresholding the remainder
+                 (up to ``maxiter`` rounds). Overrides ``quantile``.
+    maxiter    : maximum auto-threshold rounds (default 5).
+    qrange     : quantiles swept when ``autothresh`` is True (default
+                 ``0.1, 0.15, … 0.9``).
+    normalize  : CLR-normalize the counts internally (default). Set False to use the
+                 assay's existing ``data`` layer (e.g. a prior
+                 ``normalize_data(method="CLR")``).
+    margin     : CLR margin when ``normalize`` is True — 2 (per barcode across cells,
+                 recommended for small panels) or 1.
+    verbose    : print each auto-threshold round's chosen quantile.
+
+    Returns
+    -------
+    Shanuz
+        ``seurat``, with the ``MULTI_ID`` classification and identity.
+    """
+    _, data, feats, cells = _hto_matrices(seurat, assay, normalize, margin)
+    n_bc, n_cells = data.shape
+    if n_bc < 2:
+        raise ValueError(
+            f"MULTIseqDemux needs at least 2 barcodes; assay {assay!r} has {n_bc}."
+        )
+
+    if qrange is None:
+        qrange = np.round(np.arange(0.1, 0.9 + 1e-9, 0.05), 4)
+    else:
+        qrange = np.asarray(qrange, dtype=float)
+
+    if autothresh:
+        calls, thresholds, q_used = _auto_classify(
+            data, feats, qrange, maxiter, verbose
+        )
+    else:
+        calls, thresholds = _classify_cells(data, feats, quantile)
+        q_used = quantile
+
+    _write_calls(seurat, calls, cells)
+    seurat.misc.setdefault("multiseq_demux", {})[assay] = {
+        "thresholds": thresholds,
+        "quantile": float(q_used),
+        "autothresh": bool(autothresh),
+    }
+    return seurat
+
+
+# ----------------------------------------------------------------------
+# Internals
+# ----------------------------------------------------------------------
+
+
+def _local_maxima(y: np.ndarray) -> np.ndarray:
+    """Indices of local maxima of ``y`` (mirrors Seurat's ``LocalMaxima``, which
+    pads with ``-inf`` so a peak sitting on either boundary is still found)."""
+    padded = np.concatenate(([-np.inf], np.asarray(y, dtype=float)))
+    rising = np.diff(padded) > 0                # rising[i] True if y rose into i
+    n = y.size
+    peaks = [
+        i for i in range(n)
+        if rising[i] and (i == n - 1 or not rising[i + 1])
+    ]
+    return np.asarray(peaks, dtype=int)
+
+
+def _barcode_threshold(x: np.ndarray, q: float) -> Optional[float]:
+    """Positive cutoff for one barcode: a fraction ``q`` of the way from its low
+    (background) mode to its high (positive) mode, read off a Gaussian KDE.
+
+    Returns ``None`` when the barcode has no spread or shows fewer than two modes —
+    i.e. no threshold can be learned — in which case it marks no cells positive.
+    """
+    from scipy.stats import gaussian_kde
+
+    x = np.asarray(x, dtype=float)
+    if x.size < 2 or np.ptp(x) <= 0:
+        return None
+    try:
+        kde = gaussian_kde(x)
+    except Exception:
+        return None
+
+    grid = np.linspace(x.min(), x.max(), 100)
+    dens = kde(grid)
+    peaks = _local_maxima(dens)
+    if peaks.size < 2:
+        return None
+
+    # The two tallest modes are the background and positive populations; place the
+    # cutoff a fraction q between their positions (quantile of the two, as Seurat).
+    top2 = peaks[np.argsort(dens[peaks])[-2:]]
+    lo, hi = np.sort(grid[top2])
+    return float(lo + q * (hi - lo))
+
+
+def _classify_cells(data: np.ndarray, feats, q: float):
+    """One thresholding pass at quantile ``q``.
+
+    Returns ``(calls, thresholds)`` — a per-cell array of barcode name /
+    ``"Doublet"`` / ``"Negative"``, and the per-barcode cutoff dict (``inf`` for a
+    barcode that yielded no threshold).
+    """
+    n_bc, n_cells = data.shape
+    thresholds: dict[str, float] = {}
+    discrete = np.zeros((n_bc, n_cells), dtype=bool)
+    for i in range(n_bc):
+        thr = _barcode_threshold(data[i], q)
+        if thr is None:
+            thresholds[feats[i]] = float("inf")
+            continue
+        thresholds[feats[i]] = thr
+        discrete[i] = data[i] > thr
+
+    npos = discrete.sum(axis=0)
+    calls = np.empty(n_cells, dtype=object)
+    for j in range(n_cells):
+        if npos[j] == 0:
+            calls[j] = "Negative"
+        elif npos[j] == 1:
+            calls[j] = feats[int(np.argmax(discrete[:, j]))]
+        else:
+            calls[j] = "Doublet"
+    return calls, thresholds
+
+
+def _find_best_q(data: np.ndarray, feats, qrange) -> float:
+    """The quantile in ``qrange`` that classifies the most cells as singlets
+    (Seurat maximizes ``pSinglet`` over the sweep; ties keep the earliest ``q``)."""
+    n_cells = data.shape[1]
+    best_q = float(qrange[0])
+    best_frac = -1.0
+    for q in qrange:
+        calls, _ = _classify_cells(data, feats, float(q))
+        nsing = int(np.sum((calls != "Negative") & (calls != "Doublet")))
+        frac = nsing / n_cells if n_cells else 0.0
+        if frac > best_frac:
+            best_frac = frac
+            best_q = float(q)
+    return best_q
+
+
+def _auto_classify(data: np.ndarray, feats, qrange, maxiter: int, verbose: bool):
+    """Iterative auto-thresholding: sweep for the best quantile, peel off the
+    cells it calls negative, and re-threshold the remainder until nothing new is
+    negative or ``maxiter`` rounds elapse.
+
+    Returns ``(calls, thresholds, q_used)`` where ``thresholds``/``q_used`` are
+    from the final round.
+    """
+    n_bc, n_cells = data.shape
+    remaining = np.arange(n_cells)
+    final = np.array(["Negative"] * n_cells, dtype=object)
+    thresholds: dict[str, float] = {feats[i]: float("inf") for i in range(n_bc)}
+    q_used = float(qrange[0])
+
+    for it in range(1, maxiter + 1):
+        sub = data[:, remaining]
+        q_used = _find_best_q(sub, feats, qrange)
+        calls, thresholds = _classify_cells(sub, feats, q_used)
+        final[remaining] = calls
+
+        neg_local = np.where(calls == "Negative")[0]
+        if verbose:
+            print(
+                f"[multiseq] round {it}: q={q_used:g}, "
+                f"{neg_local.size} new negatives"
+            )
+        if neg_local.size == 0:
+            break
+        remaining = np.setdiff1d(remaining, remaining[neg_local])
+        if remaining.size == 0:
+            break
+
+    return final, thresholds, q_used
+
+
+def _write_calls(seurat, calls, cells) -> None:
+    """Write ``MULTI_ID`` / ``MULTI_classification`` and set the active identity."""
+    target = seurat.cell_names()
+    aligned = pd.Series(list(calls), index=cells).reindex(target).values
+    seurat.meta_data["MULTI_ID"] = list(aligned)
+    seurat.meta_data["MULTI_classification"] = list(aligned)
+    seurat.idents = list(aligned)

--- a/tests/test_multiseq.py
+++ b/tests/test_multiseq.py
@@ -1,0 +1,193 @@
+"""Tests for MULTI-seq demultiplexing (v0.9.0 Specialized Assays).
+
+  * multiseq_demux  (multiseq.py)
+
+Like the HTODemux tests, a synthetic barcode matrix with *known* ground truth —
+clean singlets per barcode, doublets spanning barcode pairs, empty-ish negatives —
+is built and ``multiseq_demux`` is asked to recover it. The Seurat metadata
+columns (``MULTI_ID`` / ``MULTI_classification``), the identity, and the
+singlet / doublet / negative accuracy are checked against ground truth, for both
+the single-pass and ``autothresh`` paths. Network-free and deterministic.
+"""
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from shanuz.multiseq import multiseq_demux  # noqa: E402
+from shanuz.preprocessing import normalize_data  # noqa: E402
+from shanuz.shanuz import create_shanuz_object  # noqa: E402
+
+TAGS = ["HTO-A", "HTO-B", "HTO-C", "HTO-D"]
+DOUBLET_PAIRS = [(0, 1), (1, 2), (2, 3), (0, 2), (1, 3)]
+
+
+def _hashing_counts(seed=0):
+    """A barcode count matrix (4 × N) plus per-cell ground-truth labels."""
+    rng = np.random.default_rng(seed)
+    H = len(TAGS)
+    cols, truth = [], []
+
+    bg = 1.0
+    for h in range(H):                       # 30 singlets per barcode
+        for _ in range(30):
+            col = rng.poisson(bg, size=H).astype(float)
+            col[h] = rng.poisson(100.0)
+            cols.append(col)
+            truth.append(TAGS[h])
+
+    for _ in range(4):                       # 20 doublets across barcode pairs
+        for a, b in DOUBLET_PAIRS:
+            col = rng.poisson(bg, size=H).astype(float)
+            col[a] = rng.poisson(70.0)
+            col[b] = rng.poisson(70.0)
+            cols.append(col)
+            truth.append("Doublet")
+
+    for _ in range(15):                      # 15 negatives (only background)
+        cols.append(rng.poisson(bg, size=H).astype(float))
+        truth.append("Negative")
+
+    counts = np.asarray(cols).T              # H × N
+    return counts, np.asarray(truth)
+
+
+def _hashing_object(seed=0):
+    counts, truth = _hashing_counts(seed)
+    cells = [f"c{i}" for i in range(counts.shape[1])]
+    obj = create_shanuz_object(
+        counts=sp.csc_matrix(counts), assay="HTO",
+        feature_names=TAGS, cell_names=cells,
+        meta_data=pd.DataFrame(index=cells),
+    )
+    return obj, truth
+
+
+# ----------------------------------------------------------------------
+# metadata columns & identity
+# ----------------------------------------------------------------------
+
+
+def test_writes_multi_metadata_columns():
+    obj, _ = _hashing_object()
+    multiseq_demux(obj)
+    for col in ("MULTI_ID", "MULTI_classification"):
+        assert col in obj.meta_data.columns
+    assert list(obj.meta_data["MULTI_ID"]) == list(obj.meta_data["MULTI_classification"])
+
+
+def test_multi_id_domain():
+    obj, _ = _hashing_object()
+    multiseq_demux(obj)
+    vals = set(obj.meta_data["MULTI_ID"])
+    assert vals <= set(TAGS) | {"Doublet", "Negative"}
+
+
+def test_idents_set_to_multi_id():
+    obj, _ = _hashing_object()
+    multiseq_demux(obj)
+    assert len(obj.idents) == len(obj.cell_names())
+    assert list(obj.idents) == list(obj.meta_data["MULTI_ID"])
+
+
+# ----------------------------------------------------------------------
+# recovery against ground truth
+# ----------------------------------------------------------------------
+
+
+def test_singlets_recovered():
+    obj, truth = _hashing_object()
+    multiseq_demux(obj)
+    call = obj.meta_data["MULTI_ID"].to_numpy()
+    singlet = np.isin(truth, TAGS)
+    # a called singlet is neither Doublet nor Negative, and names its true barcode
+    assert (call[singlet] == truth[singlet]).mean() >= 0.9
+
+
+def test_doublets_recovered():
+    obj, truth = _hashing_object()
+    multiseq_demux(obj)
+    call = obj.meta_data["MULTI_ID"].to_numpy()
+    doublet = truth == "Doublet"
+    assert (call[doublet] == "Doublet").mean() >= 0.7
+
+
+def test_negatives_recovered():
+    obj, truth = _hashing_object()
+    multiseq_demux(obj)
+    call = obj.meta_data["MULTI_ID"].to_numpy()
+    negative = truth == "Negative"
+    assert (call[negative] == "Negative").mean() >= 0.7
+
+
+# ----------------------------------------------------------------------
+# options, autothresh, bookkeeping & guards
+# ----------------------------------------------------------------------
+
+
+def test_thresholds_stored_in_misc():
+    obj, _ = _hashing_object()
+    multiseq_demux(obj)
+    info = obj.misc["multiseq_demux"]["HTO"]
+    assert set(info["thresholds"]) == set(TAGS)
+    assert info["quantile"] == 0.7
+    assert info["autothresh"] is False
+    # well-separated barcodes each learn a finite threshold
+    assert all(np.isfinite(t) for t in info["thresholds"].values())
+
+
+def test_quantile_shifts_threshold():
+    obj_lo, _ = _hashing_object()
+    obj_hi, _ = _hashing_object()
+    multiseq_demux(obj_lo, quantile=0.3)
+    multiseq_demux(obj_hi, quantile=0.9)
+    lo = obj_lo.misc["multiseq_demux"]["HTO"]["thresholds"]
+    hi = obj_hi.misc["multiseq_demux"]["HTO"]["thresholds"]
+    # a larger quantile pushes each cutoff toward the positive peak
+    for tag in TAGS:
+        assert hi[tag] >= lo[tag] - 1e-9
+
+
+def test_autothresh_recovers_singlets():
+    obj, truth = _hashing_object()
+    multiseq_demux(obj, autothresh=True)
+    info = obj.misc["multiseq_demux"]["HTO"]
+    assert info["autothresh"] is True
+    call = obj.meta_data["MULTI_ID"].to_numpy()
+    singlet = np.isin(truth, TAGS)
+    assert (call[singlet] == truth[singlet]).mean() >= 0.9
+
+
+def test_normalize_false_uses_data_layer():
+    obj, truth = _hashing_object()
+    normalize_data(obj, normalization_method="CLR", margin=2, assay="HTO")
+    multiseq_demux(obj, normalize=False)
+    call = obj.meta_data["MULTI_ID"].to_numpy()
+    singlet = np.isin(truth, TAGS)
+    assert (call[singlet] == truth[singlet]).mean() >= 0.9
+
+
+def test_deterministic():
+    obj_a, _ = _hashing_object()
+    obj_b, _ = _hashing_object()
+    multiseq_demux(obj_a)
+    multiseq_demux(obj_b)
+    assert list(obj_a.meta_data["MULTI_ID"]) == list(obj_b.meta_data["MULTI_ID"])
+
+
+def test_requires_two_barcodes():
+    rng = np.random.default_rng(0)
+    counts = sp.csc_matrix(rng.poisson(5.0, size=(1, 20)).astype(float))
+    cells = [f"c{i}" for i in range(20)]
+    obj = create_shanuz_object(
+        counts=counts, assay="HTO",
+        feature_names=["HTO-A"], cell_names=cells,
+        meta_data=pd.DataFrame(index=cells),
+    )
+    with pytest.raises(ValueError):
+        multiseq_demux(obj)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -265,6 +265,7 @@ same caveat as the other tutorials.
 | Matrix to disk (out-of-core) | `write_matrix_dir(mat, "counts.mat")` (BPCells) | `write_lazy_matrix(mat, "counts.mat")` |
 | Open on-disk matrix | `open_matrix_dir("counts.mat")` (BPCells) | `open_lazy_matrix("counts.mat")` |
 | Demultiplex hashtags | `HTODemux(obj, assay="HTO")` | `hto_demux(obj, assay="HTO")` |
+| Demultiplex (MULTI-seq) | `MULTIseqDemux(obj, assay="HTO")` | `multiseq_demux(obj, assay="HTO")` |
 | Markers | `FindMarkers(pbmc, ident.1)` | `find_markers(pbmc, ident_1)` |
 | All markers | `FindAllMarkers(pbmc, only.pos, logfc.threshold)` | `find_all_markers(pbmc, only_pos, logfc_threshold)` |
 | Conserved markers | `FindConservedMarkers(pbmc, ident.1, grouping.var)` | `find_conserved_markers(pbmc, ident_1, grouping_var)` |
@@ -596,6 +597,33 @@ By default `hto_demux` CLR-normalizes internally; if you already ran
 `normalize=False` to reuse that `data` layer. The negative binomial — not a fixed
 threshold — is what makes the call robust to each antibody's own staining
 background and each run's own depth.
+
+**MULTI-seq — the other demultiplexer.** MULTI-seq (McGinnis et al.) uses
+lipid-anchored barcodes instead of antibodies, and Seurat's `MULTIseqDemux` calls
+it a different way: rather than a background fit, it reads each barcode's cutoff
+straight off the *shape* of its distribution. `multiseq_demux` is a drop-in
+alternative that often disagrees with `hto_demux` at the margins, so it is handy
+as a second opinion:
+
+```python
+from shanuz import multiseq_demux
+
+# Same "HTO" assay of barcode counts. For each barcode a Gaussian KDE exposes its
+# background and positive modes; the cutoff sits a fraction `quantile` between them.
+multiseq_demux(obj, assay="HTO", quantile=0.7)     # 0.7 is the Seurat default
+
+obj.meta_data["MULTI_ID"]                          # barcode name / "Doublet" / "Negative"
+obj.meta_data["MULTI_classification"]              # a character copy of MULTI_ID
+obj.misc["multiseq_demux"]["HTO"]["thresholds"]    # learned per-barcode cutoffs
+
+# Don't want to guess `quantile`? Let it sweep for the value that maximises the
+# singlet rate, peeling off negatives and re-thresholding until it settles:
+multiseq_demux(obj, assay="HTO", autothresh=True)  # ignores `quantile`
+```
+
+`MULTI_ID` is set as the active identity, so subsetting one sample's singlets works
+exactly as with `hash.ID` above. As with `hto_demux`, pass `normalize=False` to
+reuse an existing CLR `data` layer instead of recomputing it.
 
 ### Pseudobulk & conserved markers
 


### PR DESCRIPTION
Ports Seurat's **`MULTIseqDemux`** (McGinnis et al.) as the second cell-hashing demultiplexer in the v0.9.0 Specialized Assays milestone, alongside the `hto_demux` (HTODemux) that shipped in #26.

## What it does

Where HTODemux learns each tag's cutoff from a **negative-binomial background fit**, MULTI-seq reads the cutoff straight off the *shape* of each barcode's CLR distribution:

1. **Normalize** — CLR (reuses `hto._hto_matrices`; `normalize=True` recomputes from counts, `normalize=False` uses an existing `data` layer).
2. **Threshold per barcode** — a Gaussian KDE over a 100-point grid exposes the background and positive modes as the two tallest local maxima; the cutoff sits a fraction `quantile` (default 0.7) between them.
3. **Classify** — cells clearing zero / one / many barcodes are `Negative` / `Singlet` / `Doublet`.

`autothresh=True` runs McGinnis's iterative `deMULTIplex` sweep: pick the `q` that maximises the singlet rate, peel off the negatives, and re-threshold the remainder (up to `maxiter` rounds) so that removing empty droplets sharpens the modes.

Writes `MULTI_ID` (also set as the active identity) and `MULTI_classification`; learned per-barcode thresholds are stashed in `obj.misc["multiseq_demux"]`. KDE via `scipy.stats.gaussian_kde` — **no new dependency**.

## Changes
- **`shanuz/multiseq.py`** (new) — `multiseq_demux()` + internals; `_local_maxima` mirrors Seurat's boundary-inclusive `LocalMaxima`.
- **`tests/test_multiseq.py`** (new, 12 tests) — ground-truth synthetic panel (same fixture style as `test_hto.py`): metadata columns/identity, `MULTI_ID` domain, singlet/doublet/negative recovery (all 1.000 single-pass), `quantile` shifts the threshold, `autothresh` path, `normalize=False` data-layer path, determinism, `<2`-barcode `ValueError` guard.
- **`shanuz/__init__.py`** — export `multiseq_demux`.
- **README / ROADMAP / tutorials** — feature bullet, v0.9.0 row, promote `multiseq_demux` from "still open" to delivered, and a MULTI-seq walkthrough + API quick-reference row.

## Testing
Full suite **353 passed** (was 341, +12). Ruff clean. `gaussian_kde` is RNG-free, so recovery is deterministic across builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)