### PR TITLE
Add the v0.10.0 packaging infrastructure and a CHANGELOG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,67 @@ jobs:
         # full check is informational; it must not gate the build.
         run: uv run ruff check shanuz || true
 
+      - name: Type check (mypy, advisory)
+        # Same footing as ruff, and for the same reason: 81 pre-existing errors
+        # across 15 modules. `mypy --strict` clean is a v0.10.0 goal (676 errors
+        # away), not today's state, so this reports without gating. Scope and
+        # settings come from [tool.mypy] in pyproject.toml, so this bare `mypy`
+        # and a developer's bare `mypy` check the identical file set.
+        run: uv run mypy || true
+
       - name: Run tests
-        run: uv run pytest tests/ -q
+        run: uv run pytest tests/ -q --cov=shanuz --cov-report=term --cov-report=xml
+
+      - name: Upload coverage
+        # One matrix leg is enough; the other two would upload the same numbers.
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+
+  build:
+    name: Build and verify the distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Check the metadata PyPI will render
+        run: uvx twine check dist/*
+
+      - name: Install the wheel clean and verify it imports
+        # Two things this catches that the test job cannot. First, the test job
+        # installs `-e .[all]`, so it never proves the *wheel* is complete or
+        # that a plain `pip install shanuz` works without the optional
+        # scientific stack — the base deps are numpy/scipy/pandas/packaging and
+        # everything heavier is imported lazily. Second, `__version__` now comes
+        # from importlib.metadata, so it can only be verified against a real
+        # (non-editable) install, where the dist-info is freshly written.
+        #
+        # `cd /tmp` matters: from the checkout root, `import shanuz` would find
+        # the source tree on sys.path and prove nothing about the wheel.
+        run: |
+          EXPECTED=$(grep -m1 '^version = ' pyproject.toml | cut -d'"' -f2)
+          uv venv --python 3.12 /tmp/wheel-venv
+          uv pip install --python /tmp/wheel-venv/bin/python dist/*.whl
+          cd /tmp
+          EXPECTED="$EXPECTED" /tmp/wheel-venv/bin/python -c '
+          import os, shanuz
+          expected = os.environ["EXPECTED"]
+          assert shanuz.__version__ == expected, (
+              f"wheel reports {shanuz.__version__!r}, pyproject declares {expected!r}"
+          )
+          print("wheel OK:", shanuz.__version__, "from", shanuz.__file__)
+          '
+
+      - name: Upload the distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Tags, not just the tip. tests/test_packaging.py cross-checks the
+          # release tags against CHANGELOG.md, and the default depth-1 clone
+          # fetches no tags at all — so that test skipped silently here, inert in
+          # the one place it should catch a tag nobody wrote an entry for.
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -32,11 +38,15 @@ jobs:
         run: uv run ruff check shanuz || true
 
       - name: Type check (mypy, advisory)
-        # Same footing as ruff, and for the same reason: 81 pre-existing errors
-        # across 15 modules. `mypy --strict` clean is a v0.10.0 goal (676 errors
-        # away), not today's state, so this reports without gating. Scope and
-        # settings come from [tool.mypy] in pyproject.toml, so this bare `mypy`
-        # and a developer's bare `mypy` check the identical file set.
+        # Same footing as ruff, and for the same reason: ~80 pre-existing errors
+        # across 15 modules, several hundred more under --strict. Clean is a
+        # v0.10.0 goal, not today's state, so this reports without gating. Scope
+        # and settings come from [tool.mypy] in pyproject.toml, so this bare
+        # `mypy` and a developer's bare `mypy` check the same file set.
+        #
+        # The count differs per leg (81-85) because each resolves its own
+        # dependency versions against the `>=` floors in pyproject. Read it as a
+        # scale, not a score; only a jump is worth chasing.
         run: uv run mypy || true
 
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ uv.lock
 # Testing
 .pytest_cache/
 .coverage
+coverage.xml
 htmlcov/
 .tox/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,193 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> **Milestones are not releases.** [`ROADMAP.md`](ROADMAP.md) tracks progress in
+> `v0.N.0` *milestones*, named after the slice of Seurat they port. Those are
+> planning labels and never become version numbers on their own — the milestone
+> sequence even runs `v0.9.0` → `v0.10.0` with nothing in between. The versions
+> below are the ones actually tagged and released, and the two have drifted a
+> long way apart: the tags stop at 0.2.0 while the milestones have run through
+> v0.9.0. Everything in between sits under [Unreleased]. A milestone can also
+> span releases — v0.7.0's spatial loaders shipped in 0.1.1 while the rest of it
+> is still unreleased — so the two sequences do not line up item for item.
+
+## [Unreleased]
+
+Work from six milestones — reference mapping, extra reductions, pseudobulk DE,
+spatial, scale, and the specialized assays — plus one breaking fix. All of it is
+on `main`; none of it is on PyPI.
+
+### Added
+
+*Reference mapping and label transfer (milestone v0.3.0)*
+
+- `find_transfer_anchors` and `transfer_data` — atlas-based annotation with
+  `pcaproject`/`cca` reduction and both classification and imputation. (#22)
+- `map_query` and `project_umap` — place a query dataset in the reference's
+  existing UMAP. (#23)
+
+*Integration (milestone v0.2.0, completing it)*
+
+- `integrate_data` and `integrate_layers` — CCA/RPCA anchor-based integration,
+  alongside the Harmony path released in 0.2.0. (#21)
+
+*Dimensionality reduction (milestone v0.5.0)*
+
+- `run_spca` — supervised PCA. (#19)
+- `glm_pca` — GLM-PCA with Poisson (#19) and negative-binomial (#20) families.
+  Pure NumPy/SciPy; the `glmpca-py` dependency proved unnecessary.
+
+*Pseudobulk and differential expression (milestone v0.6.0)*
+
+- `aggregate_expression` and `find_conserved_markers`. (#10)
+- `find_markers(test_use="deseq2")` — pseudobulk DESeq2 via optional
+  `pydeseq2`. (#11)
+- `find_markers(test_use="mast")` — MAST two-part hurdle test. (#12)
+- `find_markers(test_use="bimod")` — the McDavid 2013 likelihood-ratio
+  test. (#13)
+
+*Spatial transcriptomics (milestone v0.7.0)*
+
+- `load_merscope` — Vizgen MERSCOPE loader. (#14)
+- `find_spatially_variable_features` — Moran's I (#15) and markvariogram (#18).
+- `VisiumV2` and `load_visium(image=)` — the tissue-image data layer. (#16)
+- `spatial_dim_plot` and `spatial_feature_plot` — H&E overlays. (#17)
+
+*Scale and performance (milestone v0.8.0)*
+
+- `sketch_data`, `project_data`, and `leverage_score` — leverage-weighted
+  subsampling for million-cell datasets. (#24)
+- `LazyMatrix` — BPCells-style on-disk matrices built on NumPy memory-mapping,
+  no new dependency. (#25)
+
+*Specialized assays (milestone v0.9.0)*
+
+- `hto_demux` — `HTODemux` cell-hashing demultiplexing. (#26)
+- `multiseq_demux` — MULTI-seq demultiplexing. (#27)
+- `calc_perturb_sig` and `run_mixscape` — pooled-CRISPR analysis. (#28)
+- `mixscape_lda` — supervised map separating guide populations. (#29)
+- `plot_perturb_score` and `mixscape_heatmap`. (#30)
+- `shanuz._clara` and `hto_demux(kfunc="clara")` — an in-tree port of R's
+  `cluster::clara` k-medoids, which is what `HTODemux` actually uses. Needs no
+  sklearn. (#33)
+
+  **Known caveat:** R's `clara` is *not* reproducible across CPU architectures —
+  it accepts swaps on any improvement below zero, so one ulp in one distance
+  flips the whole clustering, and `clara.c` fuses a multiply-add on arm64 that
+  it rounds twice on x86-64. "Match R" is therefore not well-defined. This port
+  deliberately follows plain IEEE double arithmetic (= `clara.c` on x86-64,
+  and what NumPy gives everywhere), and is exact against that reference. It can
+  disagree with an arm64 R build, by design.
+
+### Changed
+
+- **`hto_demux` now defaults to `kfunc="clara"`**, matching Seurat; it first
+  shipped defaulting to `"kmeans"`. Callers who never passed `kfunc` get
+  different output: ~1% of cells change class on synthetic panels, rising with
+  tag count to ~3.5% at 12 tags — where `clara` is also the *more* accurate of
+  the two. Accuracy is otherwise a wash, so this is a fidelity change, not a
+  quality one. `"kmeans"` remains available. Both scale linearly in cells;
+  `clara` costs a roughly constant 4× (~1.3 s vs ~0.3 s at 100k cells), so
+  choose on fidelity rather than speed. (#34)
+- `find_multi_modal_neighbors` is now a full two-stage port of Seurat's WNN
+  (`FindModalityWeights` + `MultiModalNN`), replacing an approximation that used
+  a linear distance ratio and blended per-modality SNN graphs instead of doing a
+  joint neighbour search. The old formula was monotone in the right quantity but
+  had no dynamic range, pinning every weight near 0.5 — a weight stuck at 0.5
+  cannot say "this cell is decided by protein", which is the one thing WNN
+  exists to say. On synthetic data where one group separates only in RNA and
+  another only in ADT, the port now gives them ADT weights of 0.073 and 0.993
+  (previously 0.482 and 0.575). (#31)
+- `hto_demux` and `multiseq_demux` default to `margin=1` instead of `margin=2`.
+  **Their behaviour is unchanged** — this compensates for the `_clr_normalize`
+  fix below, which would otherwise have silently broken both. Note that
+  `margin=1` for hashing is deliberate and correct despite Seurat's *ADT* advice
+  being `margin=2`: hashing wants per-hashtag-across-cells, which is what
+  Seurat's hashing vignette does at its own default. (#32)
+
+### Fixed
+
+- **BREAKING** — `normalize_data`'s CLR `margin` argument was inverted relative
+  to Seurat. `margin=1` is now per-feature across cells (Seurat's default) and
+  `margin=2` is per-cell across features (what ADT panels want), matching the
+  axis R's `CustomNormalize` passes to `apply(data, MARGIN = margin, ...)`.
+  Verified against R: shanuz `margin=2` reproduced Seurat `margin=1` and vice
+  versa, agreeing to 5e-6. Only the axis was wrong — the per-vector kernel was
+  always exact.
+
+  *Who is affected:* callers passing `margin` explicitly to `normalize_data`,
+  `hto_demux`, or `multiseq_demux`. Callers using the defaults are unaffected.
+
+  This was the sole cause of the CBMC tutorial's `ADT.weight` gap against
+  Seurat; eight of nine cell types now match to 0.02 or better. (#32)
+
+### Documentation
+
+- CBMC CITE-seq tutorial: Step 8's WNN section written against real figures for
+  the first time, which is what exposed both the WNN approximation and the CLR
+  margin bug. (#31, #32)
+- Side-by-side R Seurat plots added to the PBMC 8k and CBMC tutorials, and
+  misleading R/Python figure comparisons corrected. (#8, #9)
+
+## [0.2.0] - 2026-07-05
+
+First release with batch correction, and the last release to date.
+
+### Added
+
+- `run_harmony` and `integrate_layers` — Harmony batch correction. (#6)
+- `find_multi_modal_neighbors` and `run_umap(graph=)` — WNN. (#6)
+  *Superseded:* see the full WNN port under [Unreleased].
+- `run_ica` and `run_tsne` — additional reductions. (#6)
+
+### Fixed
+
+- Spatial tutorial figures are written next to the script rather than into the
+  working directory, so the tutorial is safe to run standalone. (#5)
+- README links use absolute GitHub URLs, so they resolve on the PyPI page. (#7)
+
+## [0.1.1] - 2026-07-04
+
+First release published to PyPI — `pip install shanuz` works from here on.
+
+### Added
+
+- Spatial Seurat parity: loaders, neighborhood analysis, niches, and
+  composition. (#4)
+- Xenium spatial tutorial, verified against R Seurat to 8 significant
+  figures. (#4)
+- [`ROADMAP.md`](ROADMAP.md) — the milestone plan. (#2)
+- `shanuz/py.typed` — the package ships PEP 561 type information, so a
+  downstream `mypy` reads shanuz's annotations rather than treating it as
+  untyped. (#4)
+
+### Fixed
+
+- Pin `numba>=0.59` so the `[analysis]` and `[all]` extras resolve on Python
+  3.10+. (#2)
+- The README Quick Start example now produces the 500 cells it claims. (#3)
+
+## [0.1.0] - 2026-06-30
+
+Initial release: a port of Seurat's core data structures and analysis pipeline.
+Tagged but never published to PyPI; `0.1.1` was the first release on PyPI.
+
+### Added
+
+- Core objects: `Shanuz`, `Assay`, `Assay5`, `StdAssay`, `DimReduc`, `Graph`,
+  `Neighbor`, `LogMap`, `JackStrawData`, `ShanuzCommand`.
+- Pipeline: `normalize_data`, `find_variable_features`, `scale_data`,
+  `percentage_feature_set`, `run_pca`, `find_neighbors`, `find_clusters`,
+  `run_umap`, `find_markers`.
+- `sctransform`, `module_score`, `jack_straw`.
+- Spatial primitives: `FOV`, `Centroids`, `Segmentation`, `Molecules`.
+- Plotting, I/O, AnnData interop, and the bundled example datasets.
+
+[Unreleased]: https://github.com/GenomicAI/shanuz/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/GenomicAI/shanuz/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/GenomicAI/shanuz/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/GenomicAI/shanuz/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -49,9 +49,16 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 ## Installation
 
 Shanuz is published on [PyPI](https://pypi.org/project/shanuz/) — `pip install shanuz` just works.
-Installing from source (editable install) is only needed if you want to modify shanuz itself.
 
-### From PyPI (recommended)
+> **The PyPI release lags `main` by a long way right now.** The newest release is
+> **0.2.0** (2026-07-05), and much of the Features list above landed after it:
+> reference mapping, sketching, `LazyMatrix`, cell hashing, Mixscape,
+> `run_spca`/`glm_pca`, pseudobulk DE, and the MERSCOPE/Visium additions are
+> **not** in `pip install shanuz` yet — only in a source install.
+> [`CHANGELOG.md`](https://github.com/GenomicAI/shanuz/blob/main/CHANGELOG.md)
+> records exactly what has and has not been released.
+
+### From PyPI — the released core
 
 ```bash
 pip install shanuz                 # core: object model, preprocessing, PCA, markers
@@ -67,7 +74,7 @@ Or with [uv](https://docs.astral.sh/uv/):
 uv pip install "shanuz[analysis]"
 ```
 
-### From source (for development)
+### From source — everything above
 
 ```bash
 git clone https://github.com/GenomicAI/shanuz.git
@@ -289,7 +296,11 @@ Shanuz
 
 ## Roadmap
 
-See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)** for the full development plan. Milestones:
+See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)** for the full
+development plan, and **[`CHANGELOG.md`](https://github.com/GenomicAI/shanuz/blob/main/CHANGELOG.md)**
+for what has actually shipped. The two are not the same thing: these milestones are planning
+labels rather than release versions, and most of the ✅ rows below are on `main` but not yet in
+any release. Milestones:
 
 | Milestone | Focus |
 |-----------|-------|
@@ -301,7 +312,7 @@ See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)**
 | v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I + markvariogram), `image_*` plots, `VisiumV2` tissue images, `spatial_*` H&E plots ✅ *(delivered — see Tutorial 5)* |
 | v0.8.0 | Scale — `SketchData`/`ProjectData` (leverage-score sketching) ✅; BPCells-style lazy on-disk matrices (`LazyMatrix`) ✅ *(complete)* |
 | v0.9.0 | Specialized — `HTODemux` ✅ + `MULTIseqDemux` ✅ (cell hashing); Mixscape ✅ (`CalcPerturbSig` + `RunMixscape` + `MixscapeLDA` + `PlotPerturbScore` + `MixscapeHeatmap`, CRISPR screens) — **complete** |
-| v0.10.0 | Infrastructure — PyPI, GitHub Actions CI, type annotations, MkDocs site |
+| v0.10.0 | Infrastructure — PyPI ✅, GitHub Actions CI ✅ (3.10–3.12 matrix, wheel build + clean-install verification, coverage), [`CHANGELOG.md`](https://github.com/GenomicAI/shanuz/blob/main/CHANGELOG.md) ✅, `mypy` wired advisory ✅ (annotating to `--strict` clean still open); MkDocs site still open |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -795,9 +795,12 @@ regime. Don't "simplify" them.
   and easy to confuse), and `ignore_missing_imports` silences the stub-less
   scientific stack — without it the run is 222 errors, 139 of them purely
   "this third party has no stubs".
-- **Baseline to work down:** 81 errors in 15 modules on default settings; 676 in
-  47 under `--strict`. The package already ships `py.typed`, so these annotations
-  are what a downstream `mypy` trusts.
+- **Baseline to work down:** ~80 errors in 15 modules on default settings, ~540
+  in 47 under `--strict`. Neither is a fixed target: both drift with the
+  interpreter and with the dependency versions each resolves against the `>=`
+  floors in `pyproject.toml` (the CI matrix spans 81–85 on default settings), so
+  read them as a scale rather than a score. The package already ships `py.typed`,
+  so these annotations are what a downstream `mypy` trusts.
 - **Start here — 21 of the 81 are `[name-defined]`,** and they are real rather
   than pedantic: string annotations naming symbols that are never in module scope
   (`-> "plt.Figure"` across 17 plotting functions where `plt` is only imported

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -749,28 +749,72 @@ regime. Don't "simplify" them.
 ## v0.10.0 — Package Infrastructure
 
 ### PyPI publication — ✅ delivered
-- `pip install shanuz` works: published as [`shanuz` v0.1.1](https://pypi.org/project/shanuz/)
-  (`build` + `twine` added to `[dev]` extras; published to TestPyPI then PyPI;
-  verified with a clean-venv install + import + mini-pipeline smoke test)
-- Still open: replace the hard-coded `__version__` string in `shanuz/__init__.py`
-  with an `importlib.metadata.version("shanuz")` lookup, so the version is
-  defined in exactly one place (`pyproject.toml`)
+- `pip install shanuz` works: published as [`shanuz`](https://pypi.org/project/shanuz/),
+  currently 0.2.0 (`build` + `twine` added to `[dev]` extras; published to
+  TestPyPI then PyPI; verified with a clean-venv install + import + mini-pipeline
+  smoke test)
+- ~~Still open: replace the hard-coded `__version__` string~~ — ✅ delivered:
+  `shanuz/__init__.py` reads `importlib.metadata.version("shanuz")`, with a
+  PEP 440-valid `0.0.0+unknown` fallback for a source tree that has no installed
+  distribution. `pyproject.toml` is now the only place the version is written.
+  **Tradeoff worth knowing:** that lookup resolves through the *install-time*
+  `dist-info` snapshot, so an editable install keeps reporting the old version
+  after a bump until it is reinstalled — a way to be wrong that the hard-coded
+  string did not have. `tests/test_packaging.py::test_version_matches_pyproject`
+  exists to make it loud rather than silent.
+- **Still open — cut a release.** The tags stop at 0.2.0 (2026-07-05) while
+  milestones v0.3.0–v0.9.0 have all landed on `main`, so `pip install shanuz`
+  currently ships almost none of the README's feature list: of 22 advertised
+  entry points sampled, 19 are absent from the published wheel (reference
+  mapping, sketching, `LazyMatrix`, hashing, Mixscape, `run_spca`/`glm_pca`,
+  pseudobulk DE, MERSCOPE/Visium). The README now says so out loud, but the real
+  fix is a release. This is the highest-value remaining infra item.
 
 ### GitHub Actions CI — ✅ delivered
 - **File:** `.github/workflows/ci.yml`
 - **Matrix:** Python 3.10, 3.11, 3.12 on ubuntu-latest, via `astral-sh/setup-uv`
-- **Jobs:** `ruff check shanuz/` (advisory — pre-existing lint debt not yet
-  cleared, so it doesn't gate the build) and `pytest tests/ -q`
 - **Triggers:** push to `main`, all PRs
-- Still open: a dedicated `build` job (`python -m build`, verifies the wheel
-  itself builds cleanly) and coverage reporting (`--cov=shanuz --cov-report=xml`)
+- **`test` job:** `ruff check shanuz` and `mypy`, both advisory (pre-existing debt
+  not yet cleared, so neither gates the build), then `pytest tests/ -q` with
+  `--cov=shanuz` (80%); the coverage XML is uploaded as an artifact from the 3.12
+  leg rather than sent to a third-party service
+- ~~Still open: a dedicated `build` job and coverage reporting~~ — ✅ delivered:
+  the **`build` job** runs `uv build` (sdist + wheel), `twine check` on both, then
+  installs the wheel into a clean venv and imports it **from outside the source
+  tree**, asserting `__version__` matches `pyproject.toml`. That last step covers
+  two things the `test` job structurally cannot: the test job installs `-e .[all]`,
+  so it never proves the *wheel* is complete or that a plain `pip install shanuz`
+  works without the optional scientific stack; and `__version__` now comes from
+  installed metadata, which only a real non-editable install exercises.
 
 ### Type annotations
+- ~~Add `mypy` to the CI lint job~~ — ✅ delivered: advisory, on the same footing
+  as ruff. `[tool.mypy]` in `pyproject.toml` pins `files = ["shanuz"]` so a bare
+  `mypy` checks exactly what CI checks (ruff takes its scope from the command
+  line, where `ruff check shanuz` = 75 and `ruff check .` = 163 are both correct
+  and easy to confuse), and `ignore_missing_imports` silences the stub-less
+  scientific stack — without it the run is 222 errors, 139 of them purely
+  "this third party has no stubs".
+- **Baseline to work down:** 81 errors in 15 modules on default settings; 676 in
+  47 under `--strict`. The package already ships `py.typed`, so these annotations
+  are what a downstream `mypy` trusts.
+- **Start here — 21 of the 81 are `[name-defined]`,** and they are real rather
+  than pedantic: string annotations naming symbols that are never in module scope
+  (`-> "plt.Figure"` across 17 plotting functions where `plt` is only imported
+  inside function bodies; `graph.py`/`neighbor.py` annotating each other's
+  classes to dodge a circular import). Runtime is unaffected — string annotations
+  are never evaluated, which is why 444 tests pass — but `typing.get_type_hints()`
+  raises `NameError` on them, which **blocks the documentation site below**, since
+  mkdocstrings resolves annotations. Fix with `if TYPE_CHECKING:` imports; keep
+  the lazy runtime imports exactly as they are (they keep matplotlib optional and
+  the import graph acyclic).
 - Add `from __future__ import annotations` to all modules (already done on some)
 - Annotate all public function signatures (`mypy --strict` clean)
-- Add `mypy` to the CI lint job
 
 ### Documentation site
+- **Do the type annotations first.** mkdocstrings resolves annotations, and
+  `typing.get_type_hints()` currently raises `NameError` on the plotting and
+  `graph`/`neighbor` signatures — the site would hit that on day one.
 - **Tool:** MkDocs + mkdocstrings (Material theme)
 - **Structure:**
   ```
@@ -783,10 +827,22 @@ regime. Don't "simplify" them.
   ```
 - **Deploy:** GitHub Actions → GitHub Pages on every push to `main`
 
-### Changelog
-- **File:** `CHANGELOG.md` at repo root
-- Follow [Keep a Changelog](https://keepachangelog.com) format
-- Populate retroactively for v0.1.0 from git log
+### Changelog — ✅ delivered
+- **File:** [`CHANGELOG.md`](CHANGELOG.md) at repo root, in
+  [Keep a Changelog](https://keepachangelog.com) format
+- Populated retroactively for 0.1.0, 0.1.1 and 0.2.0 — but deliberately **not**
+  straight from the git log as this item originally said: there is a
+  `chore: bump version to 0.1.2` commit, yet 0.1.2 was never tagged and never
+  reached PyPI, so it is not a release and gets no entry. Taking the log at face
+  value would have documented a version that never existed. (0.1.0 was tagged but
+  never published; 0.1.1 was the first release on PyPI.)
+- Carries a standing note that the milestones on this page are **not** releases,
+  because the two sequences have diverged far enough to mislead: the tags stop at
+  0.2.0 while the milestones run to v0.9.0, and a milestone can straddle releases
+  (v0.7.0's spatial loaders shipped in 0.1.1; the rest of v0.7.0 has not shipped).
+- Everything since 0.2.0 sits under `[Unreleased]`, including the three entries
+  queued by earlier PRs: #32's `BREAKING` CLR margin fix, #33's clara
+  cross-architecture caveat, and #34's `hto_demux` default change.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "pytest>=7",
     "pytest-cov",
     "ruff",
+    "mypy",
     "build",
     "twine",
 ]
@@ -69,3 +70,15 @@ addopts = "-v"
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+
+[tool.mypy]
+python_version = "3.10"
+# Pinned here, not just in CI's command, so a bare `mypy` checks exactly what CI
+# checks. `ruff` takes its scope from the command line, where `ruff check shanuz`
+# (75 errors) and `ruff check .` (163) are both correct and easy to confuse.
+files = ["shanuz"]
+# The scientific stack (scipy, sklearn, numba, umap-learn, igraph, anndata, ...)
+# ships no type information. Without this the run is 222 errors, of which 139 are
+# only "this third party has no stubs" — silencing them leaves 81 that are about
+# our own code.
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dev = [
     "mypy",
     "build",
     "twine",
+    # tomllib is stdlib from 3.11; without this the 3.10 leg skips
+    # test_version_matches_pyproject instead of running it.
+    "tomli>=2.0 ; python_version < '3.11'",
 ]
 all = ["shanuz[analysis,anndata,integration,deseq2,dev]"]
 
@@ -72,13 +75,20 @@ line-length = 100
 target-version = "py310"
 
 [tool.mypy]
-python_version = "3.10"
-# Pinned here, not just in CI's command, so a bare `mypy` checks exactly what CI
-# checks. `ruff` takes its scope from the command line, where `ruff check shanuz`
-# (75 errors) and `ruff check .` (163) are both correct and easy to confuse.
+# Deliberately no `python_version`. Pinning it to our 3.10 floor also makes mypy
+# parse every *followed* import as 3.10, third-party source included — and
+# `anndata>=0.10` resolves to 0.13.2 on Python 3.12, which uses PEP 695
+# `def _reduce[T](...)` syntax. mypy then aborts the whole run with "errors
+# prevented further checking" and silently checks nothing, while `|| true` keeps
+# CI green. Each leg targets its own interpreter instead; the 3.10 leg is what
+# proves the package still supports 3.10.
+#
+# Scope is pinned here rather than only in CI's command, so a bare `mypy` checks
+# exactly what CI checks. `ruff` takes its scope from the command line, where
+# `ruff check shanuz` (75 errors) and `ruff check .` (163) are both correct and
+# easy to confuse.
 files = ["shanuz"]
 # The scientific stack (scipy, sklearn, numba, umap-learn, igraph, anndata, ...)
-# ships no type information. Without this the run is 222 errors, of which 139 are
-# only "this third party has no stubs" — silencing them leaves 81 that are about
-# our own code.
+# ships no type information. Without this, ~140 errors saying only "this third
+# party has no stubs" drown the ~80 that are about our own code.
 ignore_missing_imports = true

--- a/shanuz/__init__.py
+++ b/shanuz/__init__.py
@@ -1,5 +1,7 @@
 """shanuz — Python port of satijalab/seurat-object (v5.4.0)."""
 
+from importlib.metadata import PackageNotFoundError, version as _metadata_version
+
 from .assay import Assay, create_assay_object
 from .assay5 import Assay5, StdAssay, create_assay5_object
 from .command import ShanuzCommand, log_shanuz_command
@@ -90,7 +92,13 @@ from .plotting import (
     mixscape_heatmap,
 )
 
-__version__ = "0.2.0"
+try:
+    __version__ = _metadata_version("shanuz")
+except PackageNotFoundError:  # pragma: no cover - needs an uninstalled source tree
+    # A source tree on sys.path with no installed distribution: the package still
+    # imports and works, only its version is unknowable. PEP 440-valid on purpose,
+    # so `packaging.version.Version(shanuz.__version__)` parses on this path too.
+    __version__ = "0.0.0+unknown"
 
 __all__ = [
     # Core classes

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -19,6 +19,11 @@ from packaging.version import InvalidVersion, Version
 
 import shanuz
 
+try:  # stdlib from 3.11; `tomli` backfills 3.10 via the [dev] extra
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - only on Python 3.10
+    import tomli as tomllib
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 CHANGELOG = REPO_ROOT / "CHANGELOG.md"
@@ -67,7 +72,6 @@ def test_version_matches_pyproject():
     hard-coded string this replaced could not drift this way, so the single
     source of truth is only worth having if something checks it is still single.
     """
-    tomllib = pytest.importorskip("tomllib")  # stdlib on 3.11+; the 3.10 leg skips
     declared = tomllib.loads(PYPROJECT.read_text())["project"]["version"]
     assert shanuz.__version__ == declared, (
         f"__version__ is {shanuz.__version__!r} but pyproject.toml declares "

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,174 @@
+"""Packaging and release metadata (v0.10.0).
+
+Nothing here tests behaviour. These guard the seams where one fact is written
+down twice — pyproject.toml, the installed distribution's metadata, the git
+tags, and CHANGELOG.md — and can drift apart without a single behavioural test
+noticing.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+from packaging.version import InvalidVersion, Version
+
+import shanuz
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+FALLBACK_VERSION = "0.0.0+unknown"
+
+# "## [0.2.0] - 2026-07-05" or "## [Unreleased]" -> ("0.2.0", "2026-07-05") / ("Unreleased", "")
+_HEADING = re.compile(r"^## \[([^\]]+)\](?:\s+-\s+(\d{4}-\d{2}-\d{2}))?\s*$", re.M)
+
+
+def _changelog_headings() -> list[tuple[str, str]]:
+    return _HEADING.findall(CHANGELOG.read_text())
+
+
+# ----------------------------------------------------------------------
+# __version__
+# ----------------------------------------------------------------------
+
+
+def test_version_agrees_with_the_installed_distribution():
+    """``__version__`` and the distribution metadata report the same string.
+
+    Note what this does *not* pin, despite being the obvious place to look for
+    it: hard-code ``__version__ = "0.2.0"`` again and this still passes, because
+    the literal and the metadata agree. The *mechanism* is pinned by
+    ``test_version_falls_back_when_the_distribution_is_missing`` — a literal
+    cannot fall back. Kept for the case where the two genuinely disagree.
+    """
+    from importlib.metadata import version
+
+    assert shanuz.__version__ == version("shanuz")
+
+
+def test_version_is_pep440():
+    assert Version(shanuz.__version__)
+
+
+def test_version_matches_pyproject():
+    """Catches a stale editable install — a hazard the metadata lookup introduced.
+
+    ``__version__`` resolves through the *installed* dist-info, which is a
+    snapshot written at install time: the directory is literally named
+    ``shanuz-<version>.dist-info``. Editing pyproject.toml does not rewrite it,
+    so an editable install keeps reporting the old number until someone
+    reinstalls (verified: pyproject at 9.9.9 still imported as 0.2.0). The
+    hard-coded string this replaced could not drift this way, so the single
+    source of truth is only worth having if something checks it is still single.
+    """
+    tomllib = pytest.importorskip("tomllib")  # stdlib on 3.11+; the 3.10 leg skips
+    declared = tomllib.loads(PYPROJECT.read_text())["project"]["version"]
+    assert shanuz.__version__ == declared, (
+        f"__version__ is {shanuz.__version__!r} but pyproject.toml declares "
+        f"{declared!r}. The installed metadata is stale — reinstall with "
+        f"`uv pip install -e .`"
+    )
+
+
+def test_version_falls_back_when_the_distribution_is_missing():
+    """A source tree on sys.path with nothing installed must still import.
+
+    Load-bearing well beyond the fallback: this is the *only* test in the suite
+    that fails if ``__version__`` reverts to a hard-coded literal, since a
+    literal cannot fall back (verified by mutation). Don't drop it as a slow
+    edge case — it is what holds pyproject.toml as the single source of truth.
+
+    Subprocessed because the lookup runs once, at import. The in-process
+    alternative is ``importlib.reload`` on a 50-module package mid-suite, which
+    rebinds every class object and breaks ``isinstance`` in whatever runs next.
+    """
+    code = textwrap.dedent(
+        f"""
+        import importlib.metadata
+
+        def _missing(name):
+            raise importlib.metadata.PackageNotFoundError(name)
+
+        importlib.metadata.version = _missing
+
+        import shanuz
+        assert shanuz.__version__ == {FALLBACK_VERSION!r}, shanuz.__version__
+        print("ok")
+        """
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "ok"
+
+
+def test_the_fallback_version_is_itself_pep440():
+    """So ``Version(shanuz.__version__)`` parses on that path too, and sorts low."""
+    assert Version(FALLBACK_VERSION) < Version("0.1.0")
+
+
+# ----------------------------------------------------------------------
+# CHANGELOG.md
+# ----------------------------------------------------------------------
+
+
+def test_changelog_exists_and_leads_with_unreleased():
+    assert CHANGELOG.is_file(), "CHANGELOG.md is missing from the repo root"
+    headings = [name for name, _ in _changelog_headings()]
+    assert headings, "CHANGELOG.md has no `## [version]` headings"
+    assert headings[0] == "Unreleased", "`## [Unreleased]` must come first"
+
+
+def test_changelog_documents_the_current_version():
+    """Whatever ``pip install shanuz`` reports has to be findable in the changelog."""
+    headings = [name for name, _ in _changelog_headings()]
+    assert shanuz.__version__ in headings, (
+        f"__version__ is {shanuz.__version__!r} with no `## [{shanuz.__version__}]` "
+        f"section; the changelog has {headings}"
+    )
+
+
+def test_changelog_releases_are_valid_versions_in_descending_order():
+    versions = []
+    for name, _ in _changelog_headings():
+        if name == "Unreleased":
+            continue
+        try:
+            versions.append(Version(name))
+        except InvalidVersion:
+            pytest.fail(f"`## [{name}]` is not a PEP 440 version")
+    assert versions == sorted(versions, reverse=True), "releases are out of order"
+
+
+def test_changelog_releases_are_dated():
+    for name, date in _changelog_headings():
+        if name != "Unreleased":
+            assert date, f"`## [{name}]` is missing its `- YYYY-MM-DD` date"
+
+
+def test_every_tagged_release_is_in_the_changelog():
+    """A tag with no entry is a release nobody wrote down."""
+    try:
+        proc = subprocess.run(
+            ["git", "tag", "--list", "v*"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:  # pragma: no cover - git absent
+        pytest.skip("git is not available")
+    if proc.returncode != 0:  # pragma: no cover - not a checkout
+        pytest.skip("not a git checkout")
+
+    tagged = {tag[1:] for tag in proc.stdout.split() if tag.startswith("v")}
+    if not tagged:  # pragma: no cover - shallow clone with no tags
+        pytest.skip("no release tags visible")
+
+    documented = {name for name, _ in _changelog_headings()}
+    missing = sorted(tagged - documented)
+    assert not missing, f"tagged but undocumented in CHANGELOG.md: {missing}"


### PR DESCRIPTION
Delivers four of the five v0.10.0 infra items: the `importlib.metadata` version lookup, a `build` job, coverage reporting, `mypy` wired into CI, and `CHANGELOG.md`. The MkDocs site is deliberately left out — and picked up a second reason to wait, below.

## The version lookup costs something the hard-coded string didn't

`__version__` now reads `importlib.metadata.version("shanuz")`, making `pyproject.toml` the only place the version is written. That resolves through the **install-time `dist-info` snapshot**, so an editable install keeps reporting the old version after a bump until someone reinstalls. Verified:

| | |
|---|---|
| `pyproject.toml` set to | `9.9.9` |
| `shanuz.__version__` reported | `0.2.0` |

The ROADMAP's "defined in exactly one place" goal is met, but only if something checks the one place is still current — that is what `test_version_matches_pyproject` is for, and it fails with an actionable "reinstall with `uv pip install -e .`". The fallback is `0.0.0+unknown`, PEP 440-valid on purpose so `Version(shanuz.__version__)` parses on that path and sorts below every real release.

## CI: mypy advisory, plus a build job that proves something

`mypy` is advisory (`|| true`), on the same footing as ruff and for the same reason — 81 pre-existing errors across 15 modules, 676 under `--strict`. `[tool.mypy]` pins `files = ["shanuz"]` **in config** rather than only in CI's command, so a bare `mypy` and CI's `mypy` cannot drift apart the way `ruff check shanuz` (75) and `ruff check .` (163) can. `ignore_missing_imports` takes the run from 222 to 81 by silencing 139 errors that only report the scientific stack shipping no stubs.

The `build` job runs `uv build`, `twine check`, then installs the wheel into a clean venv and imports it **from `/tmp`**. Both details are load-bearing:

- the `test` job installs `-e .[all]`, so it never proves the wheel is complete, nor that a plain `pip install shanuz` works without the optional scientific stack;
- importing from the checkout root would find the source tree on `sys.path` and prove nothing about the wheel.

It asserts `__version__` matches `pyproject.toml` — which only a real non-editable install exercises.

## The CHANGELOG, and what writing it exposed

Populated retroactively — but **not** from the git log, which the roadmap item specified. There is a `bump version to 0.1.2` commit, yet 0.1.2 was never tagged and never reached PyPI. Taking the log at face value would have documented a release that never existed. (0.1.0 was tagged but never published; 0.1.1 was the first on PyPI.) Everything since 0.2.0 is `[Unreleased]`, including the three entries queued by earlier PRs: **#32's `BREAKING` CLR margin fix**, **#33's clara cross-architecture caveat**, and **#34's `hto_demux` default change**.

Writing it surfaced a live user-facing problem. The tags stop at 0.2.0 while milestones v0.3.0–v0.9.0 have all landed, so `pip install shanuz` ships almost none of the README's feature list. Sampling 22 advertised entry points against the published wheel:

```
README advertises, PyPI HAS   : run_harmony, find_multi_modal_neighbors, run_pca
README advertises, PyPI LACKS : find_transfer_anchors, transfer_data, map_query,
  project_umap, sketch_data, leverage_score, project_data, LazyMatrix, hto_demux,
  multiseq_demux, run_mixscape, mixscape_lda, run_spca, glm_pca,
  aggregate_expression, find_conserved_markers, load_merscope,
  find_spatially_variable_features, spatial_dim_plot
```

19 of 22 absent. The README told readers a source install was *"only needed if you want to modify shanuz itself"* — false. It now says which features need one. **The real fix is a release**, which is not this PR's call to make; ROADMAP records it as the highest-value remaining infra item.

## Why MkDocs waits

Beyond scope, mypy found **21 `[name-defined]` errors that are real rather than pedantic**: string annotations naming symbols never in module scope (`-> "plt.Figure"` across 17 plotting functions where `plt` is imported only inside function bodies; `graph.py`/`neighbor.py` annotating each other's classes around a circular import). Runtime is unaffected — string annotations are never evaluated, which is why 444 tests pass — but:

```
typing.get_type_hints(shanuz.plotting.vln_plot)       -> NameError: name 'plt' is not defined
typing.get_type_hints(shanuz.graph.Graph.as_neighbor) -> NameError: name 'Neighbor' is not defined
```

mkdocstrings resolves annotations, so the site would have hit this on day one. ROADMAP now orders the typing work before the site.

## Tests

434 → 444. All ten guards were mutation-tested, and the result is worth recording: reverting `__version__` to a hard-coded literal fails **exactly one** — and not the one whose name promised it. `test_version_comes_from_the_installed_distribution` *passed* the mutation, because the literal and the metadata both said `0.2.0`. It is renamed to what it actually checks; the fallback test is the real guard (a literal cannot fall back) and its docstring now says so.

| Mutation | Fails |
|---|---|
| `__version__` back to a hard-coded literal | `test_version_falls_back_when_the_distribution_is_missing` |
| bump `pyproject.toml`, don't reinstall | `test_version_matches_pyproject` |
| drop the `[0.2.0]` heading from CHANGELOG | `test_changelog_documents_the_current_version`, `test_every_tagged_release_is_in_the_changelog` |

Also: `coverage.xml` was not gitignored, and `--cov-report=xml` makes it appear on every run.

**ruff unchanged** — 75 in CI's scope, 163 across the repo; delta 0 in both. Coverage is 80%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)