### PR TITLE
Fix the pandas 3 crash in the PBMC 3k tutorial and cover the tutorials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,28 @@ on `main`; none of it is on PyPI.
   This was the sole cause of the CBMC tutorial's `ADT.weight` gap against
   Seurat; eight of nine cell types now match to 0.02 or better. (#32)
 
+- `tutorials/pbmc3k_tutorial.py` — the tutorial the README sends new users to
+  first — crashed with `KeyError: 'cluster'` on every fresh install. pandas 3
+  stopped passing the grouping column into the callable of
+  `groupby(...).apply(...)`, so the top-markers table came back without the
+  column the next line filtered on. It now builds the table per cluster and runs
+  on pandas 2.0 through 3.x. (#36)
+
+  *Why it went unseen:* the old code works on pandas 2, `pyproject` declares
+  `pandas>=2.0`, and no test executed a tutorial — so a developer venv holding
+  pandas 2 passed while a fresh `pip install` resolved pandas 3 and broke. The
+  full suite passed on the very install where the tutorial died. Tutorials now
+  have execution coverage: `tests/test_tutorial_marker_tables.py` runs in CI, and
+  `tests/test_tutorial_smoke.py` runs each tutorial end-to-end behind
+  `SHANUZ_TUTORIAL_SMOKE=1`.
+
+  Note for anyone touching the plot generators: they use the same
+  `groupby(...).apply(...)` idiom and were **not** affected — they never read the
+  dropped column. They were rewritten to match anyway, preserving output exactly.
+  The obvious rewrite (`sort_values(...).groupby(...).head(n)`) is wrong there: it
+  returns the same genes interleaved across clusters, silently scrambling
+  `DoHeatmap`'s per-cluster blocks. `test_top_genes_is_cluster_major` pins it.
+
 ### Documentation
 
 - CBMC CITE-seq tutorial: Step 8's WNN section written against real figures for

--- a/README.md
+++ b/README.md
@@ -323,7 +323,18 @@ uv pip install -e ".[dev]"
 pytest tests/ -v
 ```
 
-All 156 unit tests pass.
+All 460 tests pass.
+
+Five further tests run the tutorials end-to-end against real data. They are opt-in
+— they need the cached datasets (~200 MB) and take minutes, so they do not run in
+CI:
+
+```bash
+SHANUZ_TUTORIAL_SMOKE=1 pytest tests/test_tutorial_smoke.py -v
+```
+
+Worth running before cutting a release: a green suite says nothing about the
+tutorials on its own.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -762,6 +762,25 @@ regime. Don't "simplify" them.
   after a bump until it is reinstalled — a way to be wrong that the hard-coded
   string did not have. `tests/test_packaging.py::test_version_matches_pyproject`
   exists to make it loud rather than silent.
+- **Still open — decide what the `>=` dependency floors mean.** `pyproject`
+  declares only lower bounds (`pandas>=2.0`, `numpy>=1.24`, `anndata>=0.10`,
+  `umap-learn>=0.5`, `scikit-learn>=1.3`, …), so a fresh install resolves to
+  whatever shipped this week and no two installs need agree. This has now caused
+  four distinct failures, none of them theoretical:
+  1. tutorial figures drifting against the committed R panels;
+  2. `mypy` aborting on `anndata` 0.13.2's PEP 695 syntax and silently checking
+     nothing (fixed by dropping `python_version`);
+  3. the mypy baseline spanning 81–85 across the CI matrix, because each leg
+     resolves different versions;
+  4. **pandas 3 crashing `pbmc3k_tutorial.py` on every fresh install** while a
+     developer venv pinned at pandas 2 stayed green (#36).
+  Note the asymmetry that makes this expensive: the *maintainer* never sees it.
+  Existing venvs hold old versions; only new users get the break. Pinning upper
+  bounds is not obviously right either — it locks users out of new releases and
+  ages badly. The decision to make is which of {upper bounds, a tested lockfile
+  for CI, a scheduled "resolve latest" CI leg} this project wants; the status quo
+  is "find out from a user".
+
 - **Still open — cut a release.** The tags stop at 0.2.0 (2026-07-05) while
   milestones v0.3.0–v0.9.0 have all landed on `main`, so `pip install shanuz`
   currently ships almost none of the README's feature list: of 22 advertised

--- a/tests/test_tutorial_marker_tables.py
+++ b/tests/test_tutorial_marker_tables.py
@@ -1,0 +1,175 @@
+"""Tests for the tutorials' marker-table presentation helpers.
+
+These exist because the tutorials had no execution coverage at all: the full
+suite passed on an install where ``tutorials/pbmc3k_tutorial.py`` crashed
+outright. The other tutorial tests import annotation *helpers* and run them on
+synthetic data, so nothing here reached the code that formats marker tables.
+
+The bug: ``all_markers.groupby("cluster").apply(...)`` returned a frame with no
+``cluster`` column under pandas 3 (the grouping column stopped being passed into
+the callable), and the next line filtered on it -> ``KeyError: 'cluster'``.
+
+Note the version asymmetry, because it explains why this shipped: on pandas 2
+the old code *works*. No unit test can fail on pandas 2 for a bug that only
+exists on pandas 3. What these guard is every pandas-3 environment — which is
+CI and, since ``pyproject`` declares ``pandas>=2.0``, every fresh install.
+"""
+import importlib
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tutorials.generate_advanced_plots import _top_genes  # noqa: E402
+from tutorials.pbmc3k_tutorial import top_markers_per_cluster  # noqa: E402
+from tutorials.pbmc8k_subclustering_tutorial import top_markers_table  # noqa: E402
+
+TUTORIAL_MODULES = [
+    "tutorials.pbmc3k_tutorial",
+    "tutorials.pbmc8k_subclustering_tutorial",
+    "tutorials.cbmc_citeseq_tutorial",
+    "tutorials.pbmc3k_sctransform_tutorial",
+    "tutorials.generate_plots",
+    "tutorials.generate_advanced_plots",
+    "tutorials.generate_multimodal_plots",
+    "tutorials.generate_sctransform_plots",
+    "tutorials.generate_spatial_plots",
+]
+
+
+def _markers(n_clusters=12, per_cluster=4):
+    """A find_all_markers-shaped frame.
+
+    12 clusters on purpose: cluster labels are strings, so anything sorting them
+    lexicographically orders 0, 1, 10, 11, 2 ... and a 9-cluster fixture (pbmc3k's
+    real shape) would hide it.
+
+    Within each cluster, p_val ranks genes in the reverse order of avg_log2FC, so
+    a helper that sorts by the wrong column picks visibly wrong genes rather than
+    coincidentally right ones.
+    """
+    rows = []
+    for c in range(n_clusters):
+        for i in range(per_cluster):
+            rows.append({
+                "cluster": str(c),
+                "gene": f"g{c}_{i}",
+                "p_val": 10.0 ** (-(per_cluster - i) - c),
+                "avg_log2FC": float(i + 1),
+                "pct.1": 0.9,
+                "pct.2": 0.1,
+                "p_val_adj": 10.0 ** (-(per_cluster - i) - c),
+            })
+    return pd.DataFrame(rows)
+
+
+# ----------------------------------------------------------------------
+# pbmc3k — the helper that replaced the crashing groupby.apply
+# ----------------------------------------------------------------------
+
+
+def test_top_markers_per_cluster_keys_every_cluster():
+    """The regression itself: the result must carry cluster identity.
+
+    The old code dropped the ``cluster`` column on pandas 3 and raised KeyError
+    one line later. Anything that reintroduces ``groupby(...).apply(...)`` here
+    fails this on pandas 3.
+    """
+    out = top_markers_per_cluster(_markers(), n=3)
+    assert set(out) == {str(c) for c in range(12)}
+    assert all(len(genes) == 3 for genes in out.values())
+
+
+def test_top_markers_per_cluster_picks_the_most_significant_genes():
+    """Smallest p_val wins — not largest, and not avg_log2FC.
+
+    The fixture ranks p_val opposite to avg_log2FC, so a helper that sorted by
+    the wrong column would return the exact reverse of this (``g0_3, g0_2``) —
+    which is what ``_top_genes`` correctly returns for its own log2FC ranking.
+    """
+    out = top_markers_per_cluster(_markers(), n=2)
+    assert out["0"] == ["g0_0", "g0_1"]
+    assert out["11"] == ["g11_0", "g11_1"]
+
+
+def test_top_markers_per_cluster_orders_clusters_numerically():
+    """0, 1, 2 ... 11 — not the lexicographic 0, 1, 10, 11, 2 ...
+
+    The helper sorts with ``key=int``; a plain ``sorted()`` on these string
+    labels would pass every other assertion here while printing the table in a
+    confusing order.
+    """
+    assert list(top_markers_per_cluster(_markers(), n=1)) == [str(c) for c in range(12)]
+
+
+def test_top_markers_per_cluster_handles_a_cluster_with_fewer_than_n_markers():
+    """Real marker frames are ragged — a sparse cluster must not raise."""
+    df = _markers(n_clusters=3)
+    df = df[~((df["cluster"] == "1") & (df["gene"] != "g1_0"))]
+    out = top_markers_per_cluster(df, n=3)
+    assert out["1"] == ["g1_0"]
+    assert len(out["0"]) == 3
+
+
+# ----------------------------------------------------------------------
+# pbmc8k — the helper pbmc3k's fix was modelled on (was already correct)
+# ----------------------------------------------------------------------
+
+
+def test_top_markers_table_renders_every_cluster():
+    text = top_markers_table(_markers(), n=2)
+    lines = text.splitlines()
+    assert len(lines) == 12
+    assert lines[0].startswith("    Cluster 0: ")
+    # numeric ordering, same as pbmc3k's helper
+    assert lines[-1].startswith("    Cluster 11: ")
+
+
+# ----------------------------------------------------------------------
+# plot generators — never broken, but one "simplification" away from wrong
+# ----------------------------------------------------------------------
+
+
+def test_top_genes_is_cluster_major():
+    """Gene order is load-bearing: it sets the heatmap's row order.
+
+    This is the guard that matters here. ``_top_genes`` was *not* broken by
+    pandas 3 — the old ``groupby(...).apply(...)`` still returned the right
+    genes. The hazard is the obvious-looking rewrite,
+    ``sort_values("avg_log2FC", ascending=False).groupby(...).head(n)``, which
+    returns the same *set* of genes interleaved across clusters, silently
+    turning the DoHeatmap's per-cluster blocks into noise. Verified: that
+    rewrite fails this test, on both pandas 2 and 3.
+    """
+    genes = _top_genes(_markers(n_clusters=3), n=2)
+    # groupby sorts string labels lexicographically; with 3 clusters that is also
+    # numeric order. Each cluster's genes must be contiguous and log2FC-ranked.
+    assert genes == ["g0_3", "g0_2", "g1_3", "g1_2", "g2_3", "g2_2"]
+
+
+def test_top_genes_deduplicates_but_keeps_first_position():
+    """A gene topping two clusters appears once, at its first occurrence."""
+    df = _markers(n_clusters=2, per_cluster=2)
+    df.loc[df["gene"] == "g1_1", "gene"] = "g0_1"  # now shared by both clusters
+    genes = _top_genes(df, n=2)
+    assert genes.count("g0_1") == 1
+    assert genes.index("g0_1") < genes.index("g1_0")
+
+
+# ----------------------------------------------------------------------
+# every tutorial module at least imports
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("module", TUTORIAL_MODULES)
+def test_tutorial_module_imports(module):
+    """Cheap, but it is more than the suite had before.
+
+    Would not have caught the pandas 3 crash (that was mid-function), so it is a
+    floor, not a substitute for running the tutorials. The end-to-end runs live
+    in test_tutorial_smoke.py and need the cached datasets.
+    """
+    assert importlib.import_module(module) is not None

--- a/tests/test_tutorial_smoke.py
+++ b/tests/test_tutorial_smoke.py
@@ -1,0 +1,101 @@
+"""End-to-end tutorial runs.
+
+**These do not run in CI, and are not meant to be mistaken for coverage.** They
+need the cached datasets (~200 MB under ``~/.shanuz_data``) and take minutes, so
+they are gated behind an explicit opt-in:
+
+    SHANUZ_TUTORIAL_SMOKE=1 pytest tests/test_tutorial_smoke.py -v
+
+The gate is an env var rather than a bare "skip if the data is missing" check on
+purpose. A test that silently skips wherever the data happens to be absent reads
+as green in CI while proving nothing — which is the failure mode that let
+``pbmc3k_tutorial.py`` ship broken in the first place. Requiring the opt-in means
+a skip here always means "nobody asked for this", never "this passed".
+
+What they cover that ``test_tutorial_marker_tables.py`` cannot: the actual script
+path, top to bottom, against real data. The pandas 3 regression lived in the
+middle of ``run_tutorial()`` — importable helpers and unit fixtures would not
+have reached it. Worth running before cutting a release.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DATA_ROOT = Path(os.path.expanduser("~/.shanuz_data"))
+
+OPT_IN = os.environ.get("SHANUZ_TUTORIAL_SMOKE") == "1"
+
+# script -> the dataset directory it needs cached
+TUTORIALS = [
+    ("pbmc3k_tutorial.py", "pbmc3k"),
+    ("pbmc8k_subclustering_tutorial.py", "pbmc8k"),
+    ("cbmc_citeseq_tutorial.py", "cbmc"),
+    ("pbmc3k_sctransform_tutorial.py", "pbmc3k"),
+]
+
+pytestmark = pytest.mark.skipif(
+    not OPT_IN,
+    reason="set SHANUZ_TUTORIAL_SMOKE=1 to run the tutorials end-to-end "
+           "(needs ~200MB of cached datasets, takes minutes)",
+)
+
+
+@pytest.mark.parametrize("script,dataset", TUTORIALS)
+def test_tutorial_runs_to_completion(script, dataset):
+    """The script exits 0 and reaches its final section.
+
+    Deliberately asserts on the exit code and the tail of stdout rather than on
+    any number the tutorial prints: cluster counts and marker rankings are
+    library-version dependent (see the R-comparison notes), and pinning them here
+    would turn a dependency bump into a test failure that says nothing about the
+    tutorial. What this pins is that the script *runs*.
+    """
+    if not (DATA_ROOT / dataset).is_dir():
+        pytest.skip(f"dataset {dataset!r} not cached under {DATA_ROOT}")
+
+    proc = subprocess.run(
+        [sys.executable, f"tutorials/{script}"],
+        cwd=REPO_ROOT, capture_output=True, text=True, timeout=1800,
+    )
+    assert proc.returncode == 0, (
+        f"tutorials/{script} exited {proc.returncode}\n"
+        f"--- last 40 lines of stdout ---\n{os.linesep.join(proc.stdout.splitlines()[-40:])}\n"
+        f"--- stderr ---\n{proc.stderr[-3000:]}"
+    )
+    assert proc.stdout.strip(), f"tutorials/{script} produced no output"
+
+
+@pytest.mark.parametrize("script,dataset", [TUTORIALS[0]])
+def test_pbmc3k_prints_the_marker_table(script, dataset):
+    """The exact block that the pandas 3 regression killed.
+
+    ``run_tutorial`` crashed with KeyError: 'cluster' immediately after printing
+    the "Top 3 markers per cluster:" header, so a run that reaches the header but
+    dies right after still looks half-right in a log. Assert a cluster line
+    actually follows it.
+    """
+    if not (DATA_ROOT / dataset).is_dir():
+        pytest.skip(f"dataset {dataset!r} not cached under {DATA_ROOT}")
+
+    proc = subprocess.run(
+        [sys.executable, f"tutorials/{script}"],
+        cwd=REPO_ROOT, capture_output=True, text=True, timeout=1800,
+    )
+    assert proc.returncode == 0, proc.stderr[-3000:]
+    lines = proc.stdout.splitlines()
+    header = next(
+        (i for i, ln in enumerate(lines) if "Top 3 markers per cluster" in ln), None
+    )
+    assert header is not None, "tutorial never reached the marker table"
+    cluster_lines = [
+        ln for ln in lines[header + 1: header + 12] if ln.strip().startswith("Cluster ")
+    ]
+    assert len(cluster_lines) >= 8, (
+        f"expected a line per cluster after the header, got {cluster_lines!r}"
+    )
+    # "Cluster 0: GENE, GENE, GENE" — genes present, not an empty table
+    assert all(":" in ln and ln.split(":", 1)[1].strip() for ln in cluster_lines)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -31,6 +31,24 @@ uv pip install -e ".[analysis]"
 Each tutorial has a **Python script** that runs the analysis and prints validation output,
 and a **figure-generation script** that writes plots to a `figures_*/` subfolder.
 
+The datasets download automatically on first run, to `~/.shanuz_data/` (~200 MB
+across all five tutorials).
+
+### Checking the tutorials still run
+
+Two layers, because the fast one cannot reach everything:
+
+```bash
+pytest tests/test_tutorial_marker_tables.py      # fast, no data, runs in CI
+SHANUZ_TUTORIAL_SMOKE=1 pytest tests/test_tutorial_smoke.py -v   # real runs, needs the cached data
+```
+
+The first covers the presentation helpers with synthetic frames. The second
+actually executes each tutorial and takes a few minutes; it is opt-in rather than
+"skip when the data is missing", so a skip always means nobody asked for it and
+never that it passed. **Run the second before cutting a release** — the unit
+suite passing tells you nothing about whether these scripts still work end to end.
+
 ---
 
 ## Tutorial 1 — PBMC 3k Guided Clustering

--- a/tutorials/generate_advanced_plots.py
+++ b/tutorials/generate_advanced_plots.py
@@ -38,11 +38,14 @@ def _save(fig, name):
 
 
 def _top_genes(markers, n):
-    genes = (
-        markers.groupby("cluster", group_keys=False)
-        .apply(lambda x: x.nlargest(n, "avg_log2FC"))
-        ["gene"].tolist()
-    )
+    # Iterate the groups rather than `.apply(...)`: pandas 3 stops passing the
+    # grouping column into the callable, and the heatmap needs the genes in
+    # cluster-major order, which a flat sort/head would scramble.
+    genes = [
+        gene
+        for _, group in markers.groupby("cluster", sort=True)
+        for gene in group.nlargest(n, "avg_log2FC")["gene"]
+    ]
     return list(dict.fromkeys(genes))
 
 

--- a/tutorials/generate_plots.py
+++ b/tutorials/generate_plots.py
@@ -152,11 +152,14 @@ def main(data_dir=None):
           "09b_marker_violins_counts.png")
 
     # 10. DoHeatmap — top 5 markers per cluster
-    top_genes = (
-        all_markers.groupby("cluster", group_keys=False)
-        .apply(lambda x: x.nlargest(5, "avg_log2FC"))
-        ["gene"].tolist()
-    )
+    # Iterate the groups rather than `.apply(...)`: pandas 3 stops passing the
+    # grouping column into the callable, and the heatmap needs the genes in
+    # cluster-major order, which a flat sort/head would scramble.
+    top_genes = [
+        gene
+        for _, group in all_markers.groupby("cluster", sort=True)
+        for gene in group.nlargest(5, "avg_log2FC")["gene"]
+    ]
     top_genes = list(dict.fromkeys(top_genes))
     pbmc.rename_idents({v: k for k, v in CELL_TYPE_MAP.items()})  # restore cluster numbers
     _save(do_heatmap(pbmc, top_genes, figsize=(14, min(10, max(5, len(top_genes) * 0.2)))),

--- a/tutorials/pbmc3k_tutorial.py
+++ b/tutorials/pbmc3k_tutorial.py
@@ -104,6 +104,22 @@ def section(title: str) -> None:
     print(f"{'=' * 60}")
 
 
+def top_markers_per_cluster(all_markers, n: int = 3) -> dict:
+    """Map each cluster to its `n` most significant marker genes.
+
+    Filters per cluster rather than grouping: `groupby(...).apply(...)` stopped
+    passing the grouping column into the callable in pandas 3, which silently
+    drops `cluster` from the result instead of raising. Mirrors
+    `pbmc8k_subclustering_tutorial.top_markers_table`.
+    """
+    return {
+        cluster: all_markers[all_markers["cluster"] == cluster]
+        .nsmallest(n, "p_val")["gene"]
+        .tolist()
+        for cluster in sorted(all_markers["cluster"].unique(), key=int)
+    }
+
+
 # ---------------------------------------------------------------------------
 # Main tutorial
 # ---------------------------------------------------------------------------
@@ -264,16 +280,9 @@ def run_tutorial(data_dir: str | None = None) -> None:
         pbmc, only_pos=True, min_pct=0.25, logfc_threshold=0.25
     )
     print(f"  Total marker genes: {len(all_markers)}  ({time.time() - t0:.1f}s)")
-    top_per_cluster = (
-        all_markers.groupby("cluster")
-        .apply(lambda x: x.nsmallest(3, "p_val"))
-        .reset_index(drop=True)
-    )
     print("\n  Top 3 markers per cluster:")
-    for cluster in sorted(all_markers["cluster"].unique(), key=lambda x: int(x)):
-        sub = top_per_cluster[top_per_cluster["cluster"] == cluster]
-        genes_str = ", ".join(sub["gene"].tolist())
-        print(f"    Cluster {cluster}: {genes_str}")
+    for cluster, genes in top_markers_per_cluster(all_markers, n=3).items():
+        print(f"    Cluster {cluster}: {', '.join(genes)}")
 
     # -----------------------------------------------------------------------
     section("14. Validate Canonical Marker Expression")

--- a/tutorials/pbmc8k_subclustering_tutorial.py
+++ b/tutorials/pbmc8k_subclustering_tutorial.py
@@ -265,8 +265,10 @@ def run_full(data_dir=None, verbose=True):
     cells = pbmc.cell_names()
     lymphoid_cells = [c for c, g in zip(cells, global_idents) if g in set(lymphoid_clusters)]
     if verbose:
-        print(f"  Global clusters {sorted(lymphoid_clusters, key=int)} "
-              f"-> {len(lymphoid_cells)} T/NK cells")
+        # map(str, ...) because these labels come back as numpy str_, whose repr
+        # would render the list as [np.str_('1'), np.str_('2'), ...].
+        labels = ", ".join(sorted(map(str, lymphoid_clusters), key=int))
+        print(f"  Global clusters {labels} -> {len(lymphoid_cells)} T/NK cells")
 
     sub = pbmc.subset(cells=lymphoid_cells)
     # Re-analyse from counts; data layer is already normalised, so skip renorm.


### PR DESCRIPTION
## The bug

`tutorials/pbmc3k_tutorial.py` — the tutorial the README sends new users to first — **exits 1 with `KeyError: 'cluster'` on every fresh install of `main`.**

pandas 3 stopped passing the grouping column into the callable of `groupby(...).apply(...)`, so the top-markers table came back without the column the next line filtered on:

```python
top_per_cluster = (
    all_markers.groupby("cluster")
    .apply(lambda x: x.nsmallest(3, "p_val"))   # pandas 3: `x` has no "cluster"
    .reset_index(drop=True)
)
sub = top_per_cluster[top_per_cluster["cluster"] == cluster]   # KeyError
```

Fixed by building the table per cluster — the idiom `pbmc8k_subclustering_tutorial.top_markers_table` already used, which is exactly why pbmc8k never broke. **Verified end-to-end on pandas 2.3.3 and 3.0.3.**

## Why nobody saw it

The old code *works* on pandas 2. `pyproject` declares `pandas>=2.0`. So an existing dev venv (this repo's is pinned at 2.3.3) stays green while a fresh `pip install shanuz` resolves 3.0.3 and breaks. **The maintainer never sees it; only new users do.**

This is the unpinned `>=` floors problem for the **fourth** time — after the tutorial figure drift, the `anndata` PEP 695 mypy abort, and the 81–85 mypy spread across the CI matrix. ROADMAP now records it as an open infra decision rather than a recurring surprise. No floors were changed here: pinning `pandas<3` would lock users out of pandas 3, where the code now works.

## The real gap

**The suite passed 444/444 on the exact install where the tutorial died**, because nothing executed a tutorial. The two existing tutorial test files import annotation *helpers* and run them on synthetic data; `pbmc3k_tutorial.py` had no test at all.

| file | what | runs in CI |
|---|---|:--:|
| `tests/test_tutorial_marker_tables.py` | 16 tests — the marker-table helpers on synthetic frames, plus an import check per tutorial module | ✅ |
| `tests/test_tutorial_smoke.py` | 5 tests — each tutorial executed end-to-end against real data | ❌ opt-in |

The smoke tests are gated on `SHANUZ_TUTORIAL_SMOKE=1` rather than "skip if the data is missing" **on purpose**: a test that skips wherever data happens to be absent reads as green while proving nothing — the failure mode that let this ship. A skip here always means nobody asked for it. Verified passing (171s, all four tutorials) and verified *failing* on the reverted code.

## Mutation testing

Every guard was broken deliberately to confirm it fails:

| mutation | pandas 3 | pandas 2.3.3 |
|---|:--:|:--:|
| revert to the crashing `groupby.apply` | CAUGHT | **MISSED** |
| lexicographic cluster order (drop `key=int`) | CAUGHT | CAUGHT |
| rank by largest `p_val` instead of smallest | CAUGHT | CAUGHT |
| the naive flat-sort rewrite (scrambles heatmap) | CAUGHT | CAUGHT |

The MISSED is not a weak test — **it cannot be caught on pandas 2, because the old code genuinely works there.** That asymmetry *is* the bug's story, and it's documented in the test module rather than left for the next reader to rediscover.

## A correction worth flagging

The plot generators (`generate_plots.py`, `generate_advanced_plots.py`) use the same idiom and **were never broken** — they read `["gene"]` and never touch the dropped column. I checked rather than assumed. They're rewritten to match anyway, with output verified identical on both pandas versions.

Worth knowing before "simplifying" them: the obvious rewrite, `sort_values("avg_log2FC", ascending=False).groupby(...).head(n)`, is **wrong**. It returns the same genes interleaved across clusters, silently scrambling `DoHeatmap`'s per-cluster blocks — a visual regression no assertion would catch. `test_top_genes_is_cluster_major` pins it.

## Also fixed while here

- pbmc8k printed its cluster list as `[np.str_('1'), np.str_('2'), ...]`; now `Global clusters 1, 2, 3, 4, 7, 8, 9`, matching the R script's format.
- README claimed **"All 156 unit tests pass"**. The suite is **460**.

## Verification

- **460 passed, 5 skipped — identical on pandas 2.3.3 and 3.0.3.** Count moved 444 → 460, exactly the 16 tests added; nothing collected out.
- `tutorials/pbmc3k_tutorial.py` runs to completion on pandas 3 (exit 0).
- `ruff check shanuz` unchanged at 75 (CI's scope; no `shanuz/` files touched). New test files lint clean; no lint delta on the three changed tutorials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)