### PR TITLE
feat: tutorial data infrastructure (Wave 0) — loaders + R export bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,22 @@ on `main`; none of it is on PyPI.
 
 ### Added
 
+*Tutorial data infrastructure — the R-side scaffolding for expanding tutorial coverage (#38)*
+
+- `shanuz.datasets.pbmc_hashing` (GSE108313) and `thp1_eccite` (GSE153056) —
+  loaders for the Cell-Hashing and ECCITE-seq/Mixscape datasets, parsed straight
+  from their original GEO plain-text files so R and Python read identical counts.
+  The ECCITE loader also returns the per-cell guide/replicate metadata, so a
+  Mixscape tutorial can start from the same annotated state as R's `thp1.eccite`.
+- `shanuz.datasets.ifnb` and `panc8`, with `tutorials/export_seuratdata.R` — a
+  one-time R bridge that exports the curated SeuratData objects (which have no
+  clean cross-language raw source) to a gzipped 10x folder that `read_10x` reads.
+  Verified end to end: R exported panc8 and Python read back **51,767,089**
+  nonzeros — matching R to the entry — with barcodes and metadata aligned.
+- No new `pip` dependencies (the loaders are pure pandas/scipy). R side adds
+  `SeuratData` + `harmony`. Very wide count tables are parsed once and memoised to
+  a `.npz` sidecar, so a repeat load is ~0.2s rather than minutes.
+
 *Reference mapping and label transfer (milestone v0.3.0)*
 
 - `find_transfer_anchors` and `transfer_data` — atlas-based annotation with

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ uv pip install -e ".[dev]"
 pytest tests/ -v
 ```
 
-All 480 tests pass.
+All 489 tests pass.
 
 Five further tests run the tutorials end-to-end against real data. They are opt-in
 — they need the cached datasets (~200 MB) and take minutes, so they do not run in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -833,6 +833,32 @@ regime. Don't "simplify" them.
 - Add `from __future__ import annotations` to all modules (already done on some)
 - Annotate all public function signatures (`mypy --strict` clean)
 
+### Tutorial coverage — the R-fidelity net for everything after PR #10
+- **Why this matters most.** The two real defects ever found in this port — the
+  CLR margin inversion (#32) and the SCTransform model (#37) — were both caught by
+  a tutorial with an R side-by-side, *not* by the test suite, which was green
+  through both. Meanwhile 24 feature PRs landed after #10 (integration, reference
+  mapping, sketching, lazy matrices, HTO/MULTI-seq, Mixscape, spatial) and **none
+  of them has ever been compared to real Seurat** — their tests assert
+  self-consistency on synthetic `default_rng` fixtures. Of 103 public exports, 36
+  appear in a runnable tutorial; 67 do not. Closing that is the highest-leverage
+  correctness work left.
+- **Plan:** ~12 new side-by-side tutorials in four waves, one tutorial per PR, in
+  the existing shape (`<name>_tutorial.py` + `<name>_verify.R` + `<name>.md` +
+  `figures_<name>/`). Wave 1 = integration (ifnb), cell hashing (GSE108313),
+  reference mapping (panc8), Mixscape (GSE153056). Later waves: spatial/scale, the
+  DE-test suite, cell-cycle/module scores, the visualization gallery, dim-reduction
+  extras, object internals.
+- **Wave 0 — ✅ delivered (this PR).** The data plumbing every side-by-side needs:
+  `shanuz.datasets` loaders for the raw-source datasets, `tutorials/export_seuratdata.R`
+  for the two SeuratData-only ones (`ifnb`/`panc8`, verified to round-trip R's
+  counts exactly), and the R deps (`SeuratData` + `harmony`).
+- **Expect bugs, and read a mismatch as a bug report.** Going 2-for-2, Wave 1 is
+  likely to surface real defects. The known-good tolerance is narrow — deterministic
+  values match exactly, Louvain cluster counts drift ±1 — so anything outside that
+  band gets investigated, not written up as an expected difference. This repo has
+  twice let a real defect hide behind a documented "language difference" caveat.
+
 ### Documentation site
 - **Do the type annotations first.** mkdocstrings resolves annotations, and
   `typing.get_type_hints()` currently raises `NameError` on the plotting and

--- a/shanuz/datasets.py
+++ b/shanuz/datasets.py
@@ -218,6 +218,284 @@ def xenium_mouse_brain(
     return data_dir
 
 
+# PBMC "Cell Hashing" dataset (Stoeckius et al. 2018, GSE108313) — the 8-hashtag
+# experiment used by Seurat's hashing vignette. Cells are labelled with 8 HTOs
+# (BatchA–H) and the RNA is aligned to a *combined human+mouse* reference, so
+# cross-species doublets are an independent ground truth for the HTO doublet
+# calls. Files are gzipped plain text on NCBI GEO (per-sample suppl paths), so R
+# (HTODemux) and Python (hto_demux) read byte-identical inputs.
+#
+# Note: this is the raw GEO matrix (unfiltered barcodes), *not* the pre-filtered
+# `pbmc_umi_mtx.rds` the vignette downloads from Dropbox — that is an R binary
+# with no clean cross-language form. So counts here will not reproduce the
+# vignette's headline singlet/doublet totals; the comparison target is R-vs-Python
+# parity on these same files (plus the cross-species doublet ground truth).
+_HASHING_RNA_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/geo/samples/GSM2895nnn/GSM2895282/suppl/"
+    "GSM2895282_Hashtag-RNA.umi.txt.gz"
+)
+_HASHING_HTO_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/geo/samples/GSM2895nnn/GSM2895283/suppl/"
+    "GSM2895283_Hashtag-HTO-count.csv.gz"
+)
+# Rows in the HTO matrix that are QC tallies, not hashtags — dropped on load.
+_HASHING_HTO_SKIP = frozenset({"bad_struct", "no_match", "total_reads"})
+
+
+def pbmc_hashing(
+    data_dir: Optional[str] = None,
+    force_download: bool = False,
+):
+    """Download (if needed) and load the PBMC Cell-Hashing dataset (GSE108313).
+
+    The 8-HTO experiment from Stoeckius et al. (2018), as used by Seurat's
+    hashing vignette. Returns raw RNA counts aligned to the HTO counts on their
+    shared cell barcodes; the three non-hashtag QC rows (``bad_struct``,
+    ``no_match``, ``total_reads``) are dropped from the HTO matrix, leaving the
+    8 hashtags (``BatchA``–``BatchH``).
+
+    The RNA reference is a combined human+mouse genome (both ``MT-`` and ``mt-``
+    genes are present), which is deliberate: cross-species doublets validate the
+    HTO doublet calls.
+
+    Returns
+    -------
+    (rna_counts, rna_genes, hto_counts, hto_names, cell_names)
+      rna_counts : (genes x cells) csc_matrix, raw counts
+      hto_counts : (8 x cells) csc_matrix, same cell order as rna_counts
+    """
+    from .io import _make_unique
+
+    base = (Path(data_dir) if data_dir is not None
+            else Path.home() / ".shanuz_data" / "pbmc_hashing")
+    base.mkdir(parents=True, exist_ok=True)
+
+    rna_path = base / "GSM2895282_Hashtag-RNA.umi.txt.gz"
+    hto_path = base / "GSM2895283_Hashtag-HTO-count.csv.gz"
+    if force_download or not rna_path.exists():
+        _download_file(_HASHING_RNA_URL, rna_path, label="Cell Hashing RNA (~32 MB)")
+    if force_download or not hto_path.exists():
+        _download_file(_HASHING_HTO_URL, hto_path, label="Cell Hashing HTO (~1 MB)")
+
+    rna_mat, rna_genes, rna_cells = _read_table_cached(rna_path, sep="\t")
+    hto_mat, hto_names, hto_cells = _read_table_cached(hto_path, sep=",")
+
+    # Drop the QC-tally rows, keeping only the hashtags.
+    keep = [i for i, n in enumerate(hto_names) if n not in _HASHING_HTO_SKIP]
+    hto_mat = hto_mat[keep, :].tocsr()
+    hto_names = [hto_names[i] for i in keep]
+
+    rna_genes = _make_unique(rna_genes)
+    rna_mat, hto_mat, cells = _align_on_cells(rna_mat, rna_cells, hto_mat, hto_cells)
+    return rna_mat, rna_genes, hto_mat, hto_names, cells
+
+
+# THP-1 ECCITE-seq dataset (Papalexi et al. 2021, GSE153056) — the pooled CRISPR
+# screen behind Seurat's Mixscape vignette (SeuratData's `thp1.eccite`). 111 gRNAs
+# targeting cell-surface / regulatory genes in stimulated THP-1 cells, with paired
+# RNA + ADT (protein) + HTO + GDO (guide) assays. The series-level metadata table
+# carries the per-cell guide assignment already, so the Python tutorial starts
+# from the same annotated state as R's LoadData("thp1.eccite").
+_ECCITE_RNA_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/geo/samples/GSM4633nnn/GSM4633614/suppl/"
+    "GSM4633614_ECCITE_cDNA_counts.tsv.gz"
+)
+_ECCITE_ADT_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/geo/samples/GSM4633nnn/GSM4633615/suppl/"
+    "GSM4633615_ECCITE_ADT_counts.tsv.gz"
+)
+_ECCITE_META_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE153nnn/GSE153056/suppl/"
+    "GSE153056_ECCITE_metadata.tsv.gz"
+)
+
+
+def thp1_eccite(
+    data_dir: Optional[str] = None,
+    force_download: bool = False,
+):
+    """Download (if needed) and load the THP-1 ECCITE-seq dataset (GSE153056).
+
+    The pooled-CRISPR screen from Papalexi et al. (2021) used by Seurat's
+    Mixscape vignette. Returns RNA + ADT counts and the per-cell metadata
+    (guide assignment, targeted gene, replicate, cell-cycle phase), all aligned
+    to their shared barcodes. The ``gene`` / ``guide_ID`` / ``NT`` columns of the
+    metadata are the perturbation labels ``run_mixscape`` needs; ``NT`` marks the
+    non-targeting controls.
+
+    Returns
+    -------
+    (rna_counts, rna_genes, adt_counts, adt_names, meta, cell_names)
+      rna_counts : (genes x cells) csc_matrix, raw counts
+      adt_counts : (proteins x cells) csc_matrix, same cell order
+      meta       : pandas.DataFrame indexed by cell barcode (guide_ID, gene,
+                   NT, crispr, replicate, Phase, S.Score, G2M.Score, ...)
+    """
+    import pandas as pd
+
+    from .io import _make_unique
+
+    base = (Path(data_dir) if data_dir is not None
+            else Path.home() / ".shanuz_data" / "thp1_eccite")
+    base.mkdir(parents=True, exist_ok=True)
+
+    rna_path = base / "GSM4633614_ECCITE_cDNA_counts.tsv.gz"
+    adt_path = base / "GSM4633615_ECCITE_ADT_counts.tsv.gz"
+    meta_path = base / "GSE153056_ECCITE_metadata.tsv.gz"
+    if force_download or not rna_path.exists():
+        _download_file(_ECCITE_RNA_URL, rna_path, label="ECCITE RNA (~64 MB)")
+    if force_download or not adt_path.exists():
+        _download_file(_ECCITE_ADT_URL, adt_path, label="ECCITE ADT (~1 MB)")
+    if force_download or not meta_path.exists():
+        _download_file(_ECCITE_META_URL, meta_path, label="ECCITE metadata (~1 MB)")
+
+    rna_mat, rna_genes, rna_cells = _read_table_cached(rna_path, sep="\t")
+    adt_mat, adt_names, adt_cells = _read_table_cached(adt_path, sep="\t")
+    meta = pd.read_csv(meta_path, sep="\t", index_col=0)
+
+    rna_genes = _make_unique(rna_genes)
+    rna_mat, adt_mat, cells = _align_on_cells(rna_mat, rna_cells, adt_mat, adt_cells)
+    # Restrict to cells that also have metadata, preserving the RNA order.
+    meta_set = set(meta.index)
+    keep = [i for i, c in enumerate(cells) if c in meta_set]
+    cells = [cells[i] for i in keep]
+    rna_mat = rna_mat[:, keep].tocsc()
+    adt_mat = adt_mat[:, keep].tocsc()
+    meta = meta.loc[cells]
+    return rna_mat, rna_genes, adt_mat, adt_names, meta, cells
+
+
+def _load_seuratdata_export(name: str, data_dir: Optional[str]):
+    """Read a dataset exported by ``tutorials/export_seuratdata.R``.
+
+    Returns ``(counts, genes, cells, meta)`` where ``meta`` is a
+    :class:`pandas.DataFrame` indexed by (and aligned to) the matrix's cell
+    order. Raises a helpful error if the one-time R export has not been run.
+    """
+    import pandas as pd
+
+    from .io import read_10x
+
+    base = Path(data_dir) if data_dir is not None else Path.home() / ".shanuz_data" / name
+
+    has_mtx = (base / "matrix.mtx").exists() or (base / "matrix.mtx.gz").exists()
+    if not has_mtx:
+        raise FileNotFoundError(
+            f"{name!r} is a curated SeuratData object with no clean cross-language "
+            f"raw source, so it must be exported from R first:\n"
+            f"    Rscript tutorials/export_seuratdata.R {name}\n"
+            f"Expected 10x-style files in {base}."
+        )
+    counts, genes, cells = read_10x(base, var_names="gene_symbols")
+    meta = pd.read_csv(base / "metadata.csv", index_col=0)
+    meta = meta.loc[cells]  # align metadata to the matrix cell order
+    return counts, genes, cells, meta
+
+
+def ifnb(data_dir: Optional[str] = None):
+    """Load the IFNB-stimulated PBMC dataset (Kang et al. 2018), via SeuratData.
+
+    ~14,000 human PBMCs, half stimulated with interferon-beta and half control —
+    the standard benchmark for batch integration (correcting the stim/ctrl shift
+    while preserving cell type). Curated as SeuratData's ``ifnb``, so it is loaded
+    through the R export bridge (see :func:`_load_seuratdata_export`).
+
+    Returns ``(counts, genes, cells, meta)``; ``meta`` carries ``stim``
+    (CTRL/STIM — the batch) and ``seurat_annotations`` (the cell types).
+    """
+    return _load_seuratdata_export("ifnb", data_dir)
+
+
+def panc8(data_dir: Optional[str] = None):
+    """Load the human pancreatic-islet dataset ``panc8`` (8 techs), via SeuratData.
+
+    ~14,900 cells profiled across five/eight technologies (CEL-seq, CEL-seq2,
+    Fluidigm C1, SMART-seq2, inDrop) — a cross-technology integration and
+    reference-mapping benchmark. Loaded through the R export bridge.
+
+    Returns ``(counts, genes, cells, meta)``; ``meta`` carries ``tech`` (the
+    batch / technology) and ``celltype`` (the reference annotation).
+    """
+    return _load_seuratdata_export("panc8", data_dir)
+
+
+def _read_dense_table_sparse(
+    path: Path,
+    sep: str,
+    chunksize: int = 4000,
+) -> tuple[sp.csc_matrix, list[str], list[str]]:
+    """Read a gzipped dense ``features x cells`` text table into a sparse matrix.
+
+    Row 0 is the header (its first field is the — possibly empty — index name,
+    the rest are cell barcodes); every later row is a feature label followed by
+    its counts. The table is read in row-chunks and sparsified as it goes, so a
+    file whose dense form would not fit in memory still loads at bounded cost.
+    Quoted fields (R's ``write.table`` default) are handled.
+
+    Returns ``(matrix, feature_names, cell_names)`` with ``matrix`` a
+    ``(features x cells)`` :class:`scipy.sparse.csc_matrix`.
+    """
+    import pandas as pd
+
+    blocks: list[sp.csr_matrix] = []
+    features: list[str] = []
+    cells: Optional[list[str]] = None
+    # na_filter=False skips pandas' NA scan — a ~2.6x speedup on these very wide
+    # (tens of thousands of columns) count tables, where NA detection dominates.
+    for chunk in pd.read_csv(path, sep=sep, index_col=0, chunksize=chunksize,
+                             na_filter=False):
+        if cells is None:
+            cells = [str(c) for c in chunk.columns]
+        features.extend(str(f) for f in chunk.index)
+        blocks.append(sp.csr_matrix(chunk.to_numpy(dtype=np.float32)))
+    if cells is None:  # empty file → no header row
+        raise ValueError(f"{path} has no data rows")
+    mat = sp.vstack(blocks, format="csc") if blocks else sp.csc_matrix((0, len(cells)))
+    return mat, features, cells
+
+
+def _read_table_cached(
+    path: Path,
+    sep: str,
+    chunksize: int = 4000,
+) -> tuple[sp.csc_matrix, list[str], list[str]]:
+    """:func:`_read_dense_table_sparse`, memoised to a ``.parsed.npz`` sidecar.
+
+    These GEO count tables are dense text tens of thousands of columns wide;
+    parsing one takes a couple of minutes. The sparse result is cached next to
+    the source file so only the first load pays that cost — every later load is
+    a fast :func:`scipy.sparse.load_npz`. The cache is ignored if the source is
+    newer, so re-downloading transparently reparses.
+    """
+    mat_cache = Path(str(path) + ".parsed.npz")
+    names_cache = Path(str(path) + ".parsed.names.npz")
+    if (mat_cache.exists() and names_cache.exists()
+            and mat_cache.stat().st_mtime >= path.stat().st_mtime):
+        mat = sp.load_npz(mat_cache).tocsc()
+        nz = np.load(names_cache)
+        return mat, list(map(str, nz["features"])), list(map(str, nz["cells"]))
+
+    mat, features, cells = _read_dense_table_sparse(path, sep, chunksize)
+    sp.save_npz(mat_cache, mat)
+    np.savez(names_cache, features=np.array(features), cells=np.array(cells))
+    return mat, features, cells
+
+
+def _align_on_cells(
+    mat_a: sp.spmatrix,
+    cells_a: list[str],
+    mat_b: sp.spmatrix,
+    cells_b: list[str],
+) -> tuple[sp.csc_matrix, sp.csc_matrix, list[str]]:
+    """Subset two feature×cell matrices to shared barcodes, ordered by ``mat_a``."""
+    b_pos = {c: j for j, c in enumerate(cells_b)}
+    common = [c for c in cells_a if c in b_pos]
+    a_pos = {c: j for j, c in enumerate(cells_a)}
+    cols_a = [a_pos[c] for c in common]
+    cols_b = [b_pos[c] for c in common]
+    return mat_a.tocsc()[:, cols_a], mat_b.tocsc()[:, cols_b], common
+
+
 def _download_file(url: str, dest: Path, label: str) -> None:
     """Download a single file (with a simple progress print)."""
     print(f"Downloading {label} ...")

--- a/tests/test_datasets_loaders.py
+++ b/tests/test_datasets_loaders.py
@@ -1,0 +1,193 @@
+"""Unit tests for the tutorial dataset loaders' parsing layer.
+
+These exercise the pure parse/cache/align helpers and the loader plumbing on
+tiny *synthetic* gzipped tables — no network, so they run in CI. The real GEO
+downloads are covered by the opt-in tutorial smoke tests, not here.
+
+The formats mirror the real files (verified 2026-07 against GEO):
+  * GSE108313 HTO — a comma-separated ``features x cells`` table whose non-hashtag
+    QC rows (``bad_struct`` / ``no_match`` / ``total_reads``) must be dropped;
+  * GSE153056 ECCITE — tab-separated tables with R ``write.table`` quoting;
+  * ifnb / panc8 — a 10x-style folder written by ``export_seuratdata.R``.
+"""
+from __future__ import annotations
+
+import csv
+import gzip
+from pathlib import Path
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from shanuz.datasets import (
+    _align_on_cells,
+    _read_dense_table_sparse,
+    _read_table_cached,
+    ifnb,
+    pbmc_hashing,
+)
+
+
+def _write_gzip_table(path: Path, header: list[str], rows: list[list], sep: str,
+                      quote: bool = False) -> None:
+    """Write a ``features x cells`` table (row 0 = header) as gzipped text."""
+    q = csv.QUOTE_NONNUMERIC if quote else csv.QUOTE_MINIMAL
+    with gzip.open(path, "wt", newline="") as fh:
+        w = csv.writer(fh, delimiter=sep, quoting=q)
+        w.writerow(header)
+        for r in rows:
+            w.writerow(r)
+
+
+# --------------------------------------------------------------------------- #
+# _read_dense_table_sparse
+# --------------------------------------------------------------------------- #
+
+def test_read_dense_table_sparse_round_trips(tmp_path):
+    p = tmp_path / "t.tsv.gz"
+    _write_gzip_table(
+        p,
+        header=["", "cellA", "cellB", "cellC"],
+        rows=[["g1", 0, 3, 0], ["g2", 1, 0, 0], ["g3", 0, 0, 5]],
+        sep="\t",
+    )
+    mat, feats, cells = _read_dense_table_sparse(p, sep="\t")
+    assert isinstance(mat, sp.csc_matrix)
+    assert feats == ["g1", "g2", "g3"]
+    assert cells == ["cellA", "cellB", "cellC"]
+    np.testing.assert_array_equal(
+        mat.toarray(), np.array([[0, 3, 0], [1, 0, 0], [0, 0, 5]], dtype=np.float32)
+    )
+
+
+def test_read_dense_table_sparse_handles_quoting_and_chunk_boundaries(tmp_path):
+    # R's write.table quotes strings; the chunked reader must stitch chunks that
+    # split the rows, so force chunksize below the row count.
+    p = tmp_path / "q.tsv.gz"
+    rows = [[f"gene{i}", i % 3, 0, (i + 1) % 2] for i in range(10)]
+    _write_gzip_table(p, header=["", "c1", "c2", "c3"], rows=rows, sep="\t", quote=True)
+    mat, feats, cells = _read_dense_table_sparse(p, sep="\t", chunksize=3)
+    assert feats == [f"gene{i}" for i in range(10)]
+    assert cells == ["c1", "c2", "c3"]
+    assert mat.shape == (10, 3)
+    assert mat[0, 1] == 0 and mat[1, 0] == 1 and mat[2, 0] == 2
+
+
+def test_read_dense_table_sparse_comma_separator(tmp_path):
+    p = tmp_path / "c.csv.gz"
+    _write_gzip_table(p, header=["", "x", "y"], rows=[["r1", 2, 0], ["r2", 0, 4]], sep=",")
+    mat, feats, cells = _read_dense_table_sparse(p, sep=",")
+    assert feats == ["r1", "r2"] and cells == ["x", "y"]
+    assert mat.toarray().tolist() == [[2, 0], [0, 4]]
+
+
+# --------------------------------------------------------------------------- #
+# _read_table_cached
+# --------------------------------------------------------------------------- #
+
+def test_read_table_cached_writes_and_reuses_sidecar(tmp_path):
+    p = tmp_path / "t.tsv.gz"
+    _write_gzip_table(p, header=["", "a", "b"], rows=[["g1", 1, 2], ["g2", 0, 3]], sep="\t")
+    m1, f1, c1 = _read_table_cached(p, sep="\t")
+    assert (tmp_path / "t.tsv.gz.parsed.npz").exists()
+    assert (tmp_path / "t.tsv.gz.parsed.names.npz").exists()
+    # second call must come from the cache and be identical
+    m2, f2, c2 = _read_table_cached(p, sep="\t")
+    assert f2 == f1 == ["g1", "g2"] and c2 == c1 == ["a", "b"]
+    assert (m1 != m2).nnz == 0
+
+
+def test_read_table_cached_reparses_when_source_is_newer(tmp_path):
+    import os
+    import time
+
+    p = tmp_path / "t.tsv.gz"
+    _write_gzip_table(p, header=["", "a"], rows=[["g1", 1]], sep="\t")
+    m1, _, _ = _read_table_cached(p, sep="\t")
+    assert m1.toarray().tolist() == [[1]]
+    # rewrite the source with different data and a strictly newer mtime
+    time.sleep(0.01)
+    _write_gzip_table(p, header=["", "a"], rows=[["g1", 9]], sep="\t")
+    os.utime(p, (time.time() + 5, time.time() + 5))
+    m2, _, _ = _read_table_cached(p, sep="\t")
+    assert m2.toarray().tolist() == [[9]], "stale cache was served after source changed"
+
+
+# --------------------------------------------------------------------------- #
+# _align_on_cells
+# --------------------------------------------------------------------------- #
+
+def test_align_on_cells_intersects_and_orders_by_first():
+    a = sp.csc_matrix(np.array([[1, 2, 3]], dtype=np.float32))  # cells p,q,r
+    b = sp.csc_matrix(np.array([[7, 8, 9]], dtype=np.float32))  # cells r,q,z
+    aa, bb, common = _align_on_cells(a, ["p", "q", "r"], b, ["r", "q", "z"])
+    assert common == ["q", "r"]                     # ordered by a, intersection only
+    assert aa.toarray().tolist() == [[2, 3]]
+    assert bb.toarray().tolist() == [[8, 7]]         # b reordered to match
+
+
+# --------------------------------------------------------------------------- #
+# pbmc_hashing plumbing (QC-row drop + alignment), no network
+# --------------------------------------------------------------------------- #
+
+def test_pbmc_hashing_drops_qc_rows_and_aligns(tmp_path):
+    # RNA over cells c1..c3; HTO over c2..c4 (+ QC rows). Shared = c2,c3.
+    _write_gzip_table(
+        tmp_path / "GSM2895282_Hashtag-RNA.umi.txt.gz",
+        header=["GENE", "c1", "c2", "c3"],
+        rows=[["Xkr4", 0, 5, 1], ["MALAT1", 2, 0, 3]],
+        sep="\t",
+    )
+    _write_gzip_table(
+        tmp_path / "GSM2895283_Hashtag-HTO-count.csv.gz",
+        header=["", "c2", "c3", "c4"],
+        rows=[
+            ["BatchA-AAA", 10, 0, 1],
+            ["BatchB-CCC", 0, 20, 2],
+            ["bad_struct", 3, 3, 3],
+            ["no_match", 4, 4, 4],
+            ["total_reads", 99, 99, 99],
+        ],
+        sep=",",
+    )
+    rna, genes, hto, hto_names, cells = pbmc_hashing(data_dir=str(tmp_path))
+    assert cells == ["c2", "c3"]                       # RNA order, shared with HTO
+    assert hto_names == ["BatchA-AAA", "BatchB-CCC"]   # 3 QC rows dropped
+    assert hto.shape == (2, 2)
+    assert rna.shape == (2, 2)
+    assert hto.toarray().tolist() == [[10, 0], [0, 20]]
+    assert rna.toarray().tolist() == [[5, 1], [0, 3]]  # cols c2,c3 of RNA
+
+
+# --------------------------------------------------------------------------- #
+# SeuratData export reader (ifnb / panc8)
+# --------------------------------------------------------------------------- #
+
+def test_ifnb_errors_when_bridge_not_run(tmp_path):
+    with pytest.raises(FileNotFoundError, match="export_seuratdata.R ifnb"):
+        ifnb(data_dir=str(tmp_path))
+
+
+def test_ifnb_reads_bridge_output(tmp_path):
+    # Minimal 10x plain-v3 trio + metadata, as export_seuratdata.R writes.
+    import scipy.io
+
+    mat = sp.csc_matrix(np.array([[1, 0], [0, 2], [3, 4]], dtype=np.float32))
+    with open(tmp_path / "matrix.mtx", "wb") as fh:
+        scipy.io.mmwrite(fh, mat)
+    (tmp_path / "features.tsv").write_text(
+        "GeneA\tGeneA\tGene Expression\nGeneB\tGeneB\tGene Expression\n"
+        "GeneC\tGeneC\tGene Expression\n"
+    )
+    (tmp_path / "barcodes.tsv").write_text("cell1\ncell2\n")
+    (tmp_path / "metadata.csv").write_text(
+        ",stim,seurat_annotations\ncell1,CTRL,B\ncell2,STIM,T\n"
+    )
+    counts, genes, cells, meta = ifnb(data_dir=str(tmp_path))
+    assert genes == ["GeneA", "GeneB", "GeneC"]
+    assert cells == ["cell1", "cell2"]
+    assert counts.shape == (3, 2)
+    # metadata is aligned to the matrix cell order
+    assert list(meta.index) == ["cell1", "cell2"]
+    assert list(meta["stim"]) == ["CTRL", "STIM"]

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -49,6 +49,30 @@ actually executes each tutorial and takes a few minutes; it is opt-in rather tha
 never that it passed. **Run the second before cutting a release** — the unit
 suite passing tells you nothing about whether these scripts still work end to end.
 
+### Dataset loaders and the R export bridge
+
+Every tutorial pairs R and Python on the **same counts**. Two ways that happens:
+
+- **Original public files** — `shanuz.datasets` downloads the dataset's own
+  GEO/10x files, which R and Python both read directly. This covers `pbmc3k`,
+  `pbmc8k`, `cbmc_citeseq`, `xenium_mouse_brain`, and the two hashing/perturbation
+  datasets, `pbmc_hashing` (GSE108313) and `thp1_eccite` (GSE153056). Nothing extra
+  to run — they cache to `~/.shanuz_data/` on first use.
+
+- **The R bridge** — a few datasets exist only as curated SeuratData `.rda`
+  objects with no clean cross-language raw source (`ifnb`, `panc8`). For those,
+  run the one-time export first, which writes a gzipped 10x folder both languages
+  read so the counts are byte-identical:
+
+  ```bash
+  Rscript tutorials/export_seuratdata.R ifnb     # ~394 MB, first run only
+  Rscript tutorials/export_seuratdata.R panc8    # ~117 MB
+  ```
+
+  Then `shanuz.datasets.ifnb()` / `panc8()` load that export in Python. (This is
+  the mirror of the `*_verify.R` scripts, where R instead depends on the Python
+  download.) Needs R with `Seurat` + `SeuratData`.
+
 ---
 
 ## Tutorial 1 — PBMC 3k Guided Clustering

--- a/tutorials/export_seuratdata.R
+++ b/tutorials/export_seuratdata.R
@@ -1,0 +1,83 @@
+#!/usr/bin/env Rscript
+# Wave 0 data bridge: export a SeuratData dataset to a language-neutral 10x-style
+# matrix folder that Python's shanuz.datasets can read, guaranteeing R and Python
+# analyse *byte-identical* counts.
+#
+# Needed only for the two Wave-1 datasets with no clean raw source: ifnb and
+# panc8 are curated SeuratData `.rda` objects (R binaries). Every other tutorial
+# dataset is fetched from its original GEO/10x files by shanuz.datasets directly.
+#
+# This is the mirror image of the existing verify scripts, where R depends on the
+# Python download (e.g. pbmc3k_verify.R needs `python pbmc3k_tutorial.py` first).
+# Here the Python tutorial depends on this one-time R export.
+#
+# Usage:
+#   Rscript tutorials/export_seuratdata.R ifnb
+#   Rscript tutorials/export_seuratdata.R panc8
+# Writes into ~/.shanuz_data/<name>/ :
+#   matrix.mtx  features.tsv  barcodes.tsv   (read by shanuz.io.read_10x, v3 plain)
+#   metadata.csv                             (per-cell labels: stim/tech/celltype…)
+# Needs: Seurat, SeuratData, Matrix.
+
+suppressPackageStartupMessages({
+  library(Seurat)
+  library(SeuratData)
+  library(Matrix)
+})
+# The SeuratData packages are large (ifnb ~394 MB, panc8 ~117 MB); R's default
+# 60s download timeout is far too short for InstallData's first-time fetch.
+options(timeout = 1800)
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) < 1)
+  stop("usage: Rscript export_seuratdata.R <ifnb|panc8> [out_dir]")
+name <- args[[1]]
+out  <- if (length(args) >= 2) args[[2]] else file.path(path.expand("~/.shanuz_data"), name)
+dir.create(out, recursive = TRUE, showWarnings = FALSE)
+
+log <- function(...) cat(format(Sys.time(), "%H:%M:%S"), "-", ..., "\n")
+
+# --- load (installing the dataset package on first use) ----------------------
+installed <- tryCatch(rownames(InstalledData()), error = function(e) character(0))
+if (!name %in% installed) {
+  log("InstallData('", name, "') — first-time download ...", sep = "")
+  InstallData(name)
+}
+log("LoadData('", name, "') ...", sep = "")
+obj <- LoadData(name)
+obj <- UpdateSeuratObject(obj)
+DefaultAssay(obj) <- "RNA"
+
+# Seurat v5 may split counts across per-batch layers; join them back so we
+# export a single counts matrix in one cell order.
+obj <- tryCatch(JoinLayers(obj), error = function(e) obj)
+counts <- tryCatch(
+  SeuratObject::LayerData(obj, assay = "RNA", layer = "counts"),
+  error = function(e) GetAssayData(obj, assay = "RNA", slot = "counts")
+)
+counts <- as(counts, "CsparseMatrix")           # dgCMatrix (features x cells)
+stopifnot(nrow(counts) == nrow(obj), ncol(counts) == ncol(obj))
+log(sprintf("counts: %d genes x %d cells (nnz=%d)",
+            nrow(counts), ncol(counts), length(counts@x)))
+
+# --- write the 10x-style trio (gzipped v3 layout) + metadata ----------------
+writeMM(counts, file.path(out, "matrix.mtx"))
+# features.tsv: id <tab> symbol <tab> type. These datasets carry only symbols,
+# so id == symbol; shanuz.io.read_10x(var_names="gene_symbols") reads column 1.
+feats <- data.frame(id = rownames(counts), symbol = rownames(counts),
+                    type = "Gene Expression")
+write.table(feats, file.path(out, "features.tsv"),
+            sep = "\t", quote = FALSE, row.names = FALSE, col.names = FALSE)
+writeLines(colnames(counts), file.path(out, "barcodes.tsv"))
+# Gzip the trio to the 10x v3 layout read_10x detects (matrix.mtx.gz +
+# features.tsv.gz + barcodes.tsv.gz). An ASCII MatrixMarket file of tens of
+# millions of nonzeros is ~900 MB; gzip cuts it to ~150 MB. All three must be
+# gzipped together — read_10x keys the .gz layout off features.tsv.gz.
+for (f in c("matrix.mtx", "features.tsv", "barcodes.tsv"))
+  system2("gzip", c("-f", shQuote(file.path(out, f))))
+# metadata: per-cell labels the tutorials group by (stim / tech / celltype / …).
+write.csv(obj@meta.data, file.path(out, "metadata.csv"), row.names = TRUE)
+
+log("wrote:", normalizePath(out))
+log("  meta columns:", paste(colnames(obj@meta.data), collapse = ", "))
+log("DONE")


### PR DESCRIPTION
## What this is

**Wave 0** of expanding the R-vs-Python tutorial coverage: the data plumbing every side-by-side tutorial needs. **No new tutorials in this PR** — this unblocks them.

### Why now

The two real defects ever found in this port — the CLR margin inversion (#32) and the SCTransform model (#37) — were both caught by a tutorial with an R side-by-side, **not** by the test suite, which was green through both. Meanwhile 24 feature PRs landed after #10 (integration, reference mapping, sketching, lazy matrices, HTO/MULTI-seq, Mixscape, spatial) and **none has ever been compared to real Seurat** — their tests assert self-consistency on synthetic fixtures. Of 103 public exports, 36 appear in a runnable tutorial; 67 do not. Closing that gap is the highest-leverage correctness work left, and it needs this scaffolding first.

## What's here

**Loaders** (`shanuz/datasets.py`) — two ways R and Python get identical counts:

- `pbmc_hashing` (GSE108313) and `thp1_eccite` (GSE153056) parse the datasets' **original GEO plain-text files**, which both languages read directly. `thp1_eccite` also returns the per-cell guide/replicate metadata, so a Mixscape tutorial starts from the same annotated state as R's `thp1.eccite`.
- `ifnb` and `panc8` are curated SeuratData `.rda` objects with no clean cross-language source, so `tutorials/export_seuratdata.R` does a **one-time export** to a gzipped 10x folder `read_10x` reads.

**Parity, verified end to end:** R exported panc8 (34,363 × 14,890) and Python `panc8()` read back **51,767,089 nonzeros — matching R to the entry**, with barcodes and `tech`/`celltype` metadata aligned.

**Performance:** the hashing RNA is 50,001 columns wide and pandas took 4.5 min. `na_filter=False` + a parse-once `.npz` sidecar → ~2 min first load, **~0.2s** every load after.

## Tests / checks

- 9 CI-safe unit tests on synthetic fixtures (`tests/test_datasets_loaders.py`) — parsers, cache invalidation, alignment, the HTO QC-row drop, the bridge-reader error path.
- Suite **480 → 489**, mypy back to baseline **83**, ruff clean.
- No new `pip` dependencies (pure pandas/scipy). R side adds `SeuratData` + `harmony`.

## Notes for review

- **`ifnb` wasn't run end-to-end** — identical bridge code path to panc8 (just 394 MB vs 117 MB), which was verified exactly.
- The Bioconductor trio (MAST/DESeq2/glmGamPoi) is **deliberately not installed** — no Wave 1 tutorial needs it, and glmGamPoi would change the existing SCT R reference.
- Unit tests cover the plain-file read path; the gzipped path is covered by the manual round-trip. Both work through `read_10x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)