### PR TITLE
chore: move the supported-Python matrix to 3.12-3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        # 3.12 is the floor `requires-python` declares, 3.14 the newest release.
+        # Both ends are load-bearing: the bottom leg is the only thing that
+        # proves the declared floor still works, the top leg is where a
+        # dependency that has not caught up to a new CPython shows itself.
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 3.12 is the floor `requires-python` declares, 3.14 the newest release.
-        # Both ends are load-bearing: the bottom leg is the only thing that
-        # proves the declared floor still works, the top leg is where a
-        # dependency that has not caught up to a new CPython shows itself.
-        python-version: ["3.12", "3.13", "3.14"]
+        # 3.12 is the floor `requires-python` declares; the bottom leg is the
+        # only thing that proves that floor still works.
+        #
+        # 3.14 is deliberately absent despite being released and otherwise
+        # working: `harmonypy` publishes manylinux wheels for cp39-cp313 only,
+        # so a 3.14 leg falls back to building it from source, which needs BLAS
+        # and a CMake-fetched armadillo that ubuntu-latest does not have.
+        # Letting the resolver avoid that is worse — it backtracks to harmonypy
+        # 0.2.0, which depends on torch and drags in the whole CUDA stack.
+        # Everything else in the dependency set already has cp314 wheels. Add
+        # the leg once harmonypy ships one; see ROADMAP.md.
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,24 @@ on `main`; none of it is on PyPI.
 
 ### Added
 
+*Guards against supported-Python drift (#47)*
+
+- Three tests in `tests/test_packaging.py` cross-checking the four places the
+  supported-version decision is written down — `requires-python`, the trove
+  classifiers, `[tool.ruff] target-version`, and the CI matrix. Nothing read
+  those together before, and each is quiet when wrong in a different way: a
+  stale classifier misinforms PyPI without breaking a build; a matrix that has
+  moved above the declared floor stops testing the floor, which is the version
+  most likely to break; a ruff target below the floor silently disables the lint
+  the floor just earned.
+- Mutation-tested in all four directions — drop a classifier, raise the floor,
+  revert the ruff target, drop the lowest matrix leg — each caught by the
+  specific guard(s) it should be, none firing indiscriminately.
+- The matrix is parsed from the workflow YAML with a regex rather than PyYAML:
+  PyYAML is not a declared dependency, so importing it would pass today and
+  begin silently skipping the day that transitive edge disappears — the exact
+  drift these tests exist to catch.
+
 *Leverage-score sketching tutorial — side by side with R Seurat (#46)*
 
 - `tutorials/sketch_vignette.md` with `ifnb_sketch_tutorial.py`,
@@ -312,6 +330,30 @@ on `main`; none of it is on PyPI.
   disagree with an arm64 R build, by design.
 
 ### Changed
+
+- **Supported Python is now 3.12–3.14; 3.10 and 3.11 are dropped.** The CI matrix
+  moves with it, and `requires-python` becomes `>=3.12`.
+
+  The floor tracks [SPEC 0](https://scientific-python.org/specs/spec-0000/) — the
+  three-years-past-release window numpy, scipy, pandas and scikit-learn keep for
+  themselves — rather than CPython's five-year EOL. By that rule 3.10 lapsed in
+  Oct 2024 and 3.11 in Oct 2025, both already past; going by EOL alone would have
+  held 3.11 until Oct 2027. Those four packages are what actually constrain this
+  library, so theirs is the calendar worth following.
+
+  Checked before committing to it, not after: all 91 resolved packages ship
+  native `cp313` **and** `cp314` manylinux x86-64 wheels — `numba` 0.66 /
+  `llvmlite` 0.48 included, historically the last to arrive — with `igraph` and
+  `leidenalg` on stable-ABI wheels. No leg builds from source. The full suite
+  passes identically on 3.12, 3.13 and 3.14, as do all 17 tutorial smoke tests on
+  3.14 against the real datasets.
+
+  **Nothing breaks retroactively.** `pip` on 3.10 or 3.11 resolves to 0.2.0, the
+  last release declaring `>=3.10`.
+
+  *Also removed:* the `tomli` dev dependency (`tomllib` is stdlib from 3.11) and
+  its import fallback in `tests/test_packaging.py` — the only version-gated code
+  in the repo. `[tool.ruff] target-version` moves to `py312`.
 
 - **`hto_demux` now defaults to `kfunc="clara"`**, matching Seurat; it first
   shipped defaulting to `"kmeans"`. Callers who never passed `kfunc` get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,7 +331,7 @@ on `main`; none of it is on PyPI.
 
 ### Changed
 
-- **Supported Python is now 3.12–3.14; 3.10 and 3.11 are dropped.** The CI matrix
+- **Supported Python is now 3.12–3.13; 3.10 and 3.11 are dropped.** The CI matrix
   moves with it, and `requires-python` becomes `>=3.12`.
 
   The floor tracks [SPEC 0](https://scientific-python.org/specs/spec-0000/) — the
@@ -341,12 +341,19 @@ on `main`; none of it is on PyPI.
   held 3.11 until Oct 2027. Those four packages are what actually constrain this
   library, so theirs is the calendar worth following.
 
-  Checked before committing to it, not after: all 91 resolved packages ship
-  native `cp313` **and** `cp314` manylinux x86-64 wheels — `numba` 0.66 /
-  `llvmlite` 0.48 included, historically the last to arrive — with `igraph` and
-  `leidenalg` on stable-ABI wheels. No leg builds from source. The full suite
-  passes identically on 3.12, 3.13 and 3.14, as do all 17 tutorial smoke tests on
-  3.14 against the real datasets.
+  The full suite passes identically on both legs — 616 passed / 17 skipped — as
+  do all 17 tutorial smoke tests, which CI skips on every leg, run here against
+  the real datasets.
+
+  **Python 3.14 is not included, though it very nearly works.** Every package in
+  the set has a cp314 manylinux wheel except `harmonypy`, which publishes
+  cp39–cp313 only. Without a wheel, uv builds it from source, and that needs BLAS
+  plus a CMake-fetched armadillo `ubuntu-latest` does not have. Forcing a
+  wheels-only resolve is worse: it backtracks to `harmonypy` 0.2.0, which depends
+  on torch and pulls in triton and 24 `nvidia-*` packages. Dropping the
+  `integration` extra on a 3.14 leg does resolve clean (95 packages, wheels only)
+  but would leave 18 harmony tests unrun there. Deferred until `harmonypy` ships
+  a cp314 wheel; see `ROADMAP.md`.
 
   **Nothing breaks retroactively.** `pip` on 3.10 or 3.11 resolves to 0.2.0, the
   last release declaring `>=3.10`.

--- a/README.md
+++ b/README.md
@@ -55,11 +55,16 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 
 Shanuz is published on [PyPI](https://pypi.org/project/shanuz/) — `pip install shanuz` just works.
 
-**Requires Python 3.12 or newer**, and CI tests 3.12, 3.13 and 3.14. The floor
-follows [SPEC 0](https://scientific-python.org/specs/spec-0000/), the support
-window numpy, scipy, pandas and scikit-learn themselves keep — three years past
-each Python release — rather than CPython's longer EOL calendar. On 3.10 or 3.11,
+**Requires Python 3.12 or newer**, and CI tests 3.12 and 3.13. The floor follows
+[SPEC 0](https://scientific-python.org/specs/spec-0000/), the support window
+numpy, scipy, pandas and scikit-learn themselves keep — three years past each
+Python release — rather than CPython's longer EOL calendar. On 3.10 or 3.11,
 `pip` resolves to **0.2.0**, the last release that declared `>=3.10`.
+
+Python 3.14 is not yet tested: [`harmonypy`](https://pypi.org/project/harmonypy/)
+ships manylinux wheels only through cp313, and the alternatives are a source
+build needing BLAS or a resolver backtrack that pulls in torch. Everything else
+in the dependency set already has 3.14 wheels, so this is one package away.
 
 > **The PyPI release lags `main` by a long way right now.** The newest release is
 > **0.2.0** (2026-07-05), and much of the Features list above landed after it:
@@ -347,7 +352,7 @@ any release. Milestones:
 | v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I + markvariogram), `image_*` plots, `VisiumV2` tissue images, `spatial_*` H&E plots ✅ *(delivered — see Tutorial 5)* |
 | v0.8.0 | Scale — `SketchData`/`ProjectData` (leverage-score sketching) ✅; BPCells-style lazy on-disk matrices (`LazyMatrix`) ✅ *(complete)* |
 | v0.9.0 | Specialized — `HTODemux` ✅ + `MULTIseqDemux` ✅ (cell hashing); Mixscape ✅ (`CalcPerturbSig` + `RunMixscape` + `MixscapeLDA` + `PlotPerturbScore` + `MixscapeHeatmap`, CRISPR screens) — **complete** |
-| v0.10.0 | Infrastructure — PyPI ✅, GitHub Actions CI ✅ (3.12–3.14 matrix, wheel build + clean-install verification, coverage), [`CHANGELOG.md`](https://github.com/GenomicAI/shanuz/blob/main/CHANGELOG.md) ✅, `mypy` wired advisory ✅ (annotating to `--strict` clean still open); MkDocs site still open |
+| v0.10.0 | Infrastructure — PyPI ✅, GitHub Actions CI ✅ (3.12–3.13 matrix, wheel build + clean-install verification, coverage), [`CHANGELOG.md`](https://github.com/GenomicAI/shanuz/blob/main/CHANGELOG.md) ✅, `mypy` wired advisory ✅ (annotating to `--strict` clean still open); MkDocs site still open |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Shanuz — Python Single-Cell Genomics Toolkit
 
 [![PyPI](https://img.shields.io/pypi/v/shanuz.svg)](https://pypi.org/project/shanuz/)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 **Shanuz** is a Python port of the [Seurat](https://satijalab.org/seurat/) single-cell RNA-seq
@@ -54,6 +54,12 @@ dimensionality reduction, clustering, and marker detection — entirely in Pytho
 ## Installation
 
 Shanuz is published on [PyPI](https://pypi.org/project/shanuz/) — `pip install shanuz` just works.
+
+**Requires Python 3.12 or newer**, and CI tests 3.12, 3.13 and 3.14. The floor
+follows [SPEC 0](https://scientific-python.org/specs/spec-0000/), the support
+window numpy, scipy, pandas and scikit-learn themselves keep — three years past
+each Python release — rather than CPython's longer EOL calendar. On 3.10 or 3.11,
+`pip` resolves to **0.2.0**, the last release that declared `>=3.10`.
 
 > **The PyPI release lags `main` by a long way right now.** The newest release is
 > **0.2.0** (2026-07-05), and much of the Features list above landed after it:
@@ -341,7 +347,7 @@ any release. Milestones:
 | v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I + markvariogram), `image_*` plots, `VisiumV2` tissue images, `spatial_*` H&E plots ✅ *(delivered — see Tutorial 5)* |
 | v0.8.0 | Scale — `SketchData`/`ProjectData` (leverage-score sketching) ✅; BPCells-style lazy on-disk matrices (`LazyMatrix`) ✅ *(complete)* |
 | v0.9.0 | Specialized — `HTODemux` ✅ + `MULTIseqDemux` ✅ (cell hashing); Mixscape ✅ (`CalcPerturbSig` + `RunMixscape` + `MixscapeLDA` + `PlotPerturbScore` + `MixscapeHeatmap`, CRISPR screens) — **complete** |
-| v0.10.0 | Infrastructure — PyPI ✅, GitHub Actions CI ✅ (3.10–3.12 matrix, wheel build + clean-install verification, coverage), [`CHANGELOG.md`](https://github.com/GenomicAI/shanuz/blob/main/CHANGELOG.md) ✅, `mypy` wired advisory ✅ (annotating to `--strict` clean still open); MkDocs site still open |
+| v0.10.0 | Infrastructure — PyPI ✅, GitHub Actions CI ✅ (3.12–3.14 matrix, wheel build + clean-install verification, coverage), [`CHANGELOG.md`](https://github.com/GenomicAI/shanuz/blob/main/CHANGELOG.md) ✅, `mypy` wired advisory ✅ (annotating to `--strict` clean still open); MkDocs site still open |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -799,7 +799,21 @@ regime. Don't "simplify" them.
 
 ### GitHub Actions CI — ✅ delivered
 - **File:** `.github/workflows/ci.yml`
-- **Matrix:** Python 3.10, 3.11, 3.12 on ubuntu-latest, via `astral-sh/setup-uv`
+- **Matrix:** Python 3.12, 3.13, 3.14 on ubuntu-latest, via `astral-sh/setup-uv`
+  (was 3.10–3.12; moved to track [SPEC 0](https://scientific-python.org/specs/spec-0000/),
+  which had already retired 3.10 in Oct 2024 and 3.11 in Oct 2025). Verified before
+  the change rather than after: all 91 resolved packages have native `cp313`/`cp314`
+  manylinux wheels, `numba`/`llvmlite` included, so no leg builds from source.
+- **Open — the matrix no longer varies dependencies.** Dropping 3.10 removed
+  something nobody had written down: because the floors are `>=`, that leg was
+  resolving numpy 2.2.6 / scipy 1.15.3 / pandas 2.3.3 where the others got
+  2.4.6 / 1.18.0 / 3.0.3, so it was the *only* coverage of an older scientific
+  stack. All three legs now resolve one identical set — three interpreters, one
+  dependency version. This surfaced through `test_leverage_scores_are_not_flat`,
+  whose docstring had attributed its 3.10 failure to CPython when the real
+  variable was the resolved numpy. The fix is a dedicated oldest-supported-deps
+  leg (install against the declared floors, not the latest), not keeping an EOL
+  Python around as an accidental proxy for it.
 - **Triggers:** push to `main`, all PRs
 - **`test` job:** `ruff check shanuz` and `mypy`, both advisory (pre-existing debt
   not yet cleared, so neither gates the build), then `pytest tests/ -q` with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -799,11 +799,25 @@ regime. Don't "simplify" them.
 
 ### GitHub Actions CI — ✅ delivered
 - **File:** `.github/workflows/ci.yml`
-- **Matrix:** Python 3.12, 3.13, 3.14 on ubuntu-latest, via `astral-sh/setup-uv`
+- **Matrix:** Python 3.12, 3.13 on ubuntu-latest, via `astral-sh/setup-uv`
   (was 3.10–3.12; moved to track [SPEC 0](https://scientific-python.org/specs/spec-0000/),
-  which had already retired 3.10 in Oct 2024 and 3.11 in Oct 2025). Verified before
-  the change rather than after: all 91 resolved packages have native `cp313`/`cp314`
-  manylinux wheels, `numba`/`llvmlite` included, so no leg builds from source.
+  which had already retired 3.10 in Oct 2024 and 3.11 in Oct 2025).
+- **Open — add the 3.14 leg when `harmonypy` ships a cp314 wheel.** 3.14 was in
+  this change and came out again: it is the *only* package in the set without
+  one (manylinux cp39–cp313 only), and both ways around it are worse than
+  waiting. Building from source needs BLAS plus a CMake-fetched armadillo that
+  `ubuntu-latest` lacks — that is the failure we hit. Forcing a wheels-only
+  resolve instead backtracks to `harmonypy` 0.2.0, which depends on torch and
+  pulls triton and 24 `nvidia-*` packages. Everything else resolves clean: 95
+  packages, wheels only, on `x86_64-manylinux_2_28`/3.14. Recheck with
+  `uv pip compile pyproject.toml --extra all --python-platform
+  x86_64-manylinux_2_28 --python-version 3.14 --only-binary :all:`.
+- **Verify wheels on the *target* platform, not the dev machine.** The 3.14 leg
+  was signed off locally on macOS arm64, where the harmonypy source build
+  succeeds because Accelerate supplies BLAS — so a clean local install proved
+  nothing about Linux, and CI found it in 23 seconds. `--python-platform` +
+  `--only-binary :all:` is the check that would have caught it; the hand-picked
+  PyPI wheel survey that preceded it missed harmonypy entirely.
 - **Open — the matrix no longer varies dependencies.** Dropping 3.10 removed
   something nobody had written down: because the floors are `>=`, that leg was
   resolving numpy 2.2.6 / scipy 1.15.3 / pandas 2.3.3 where the others got

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,20 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
-requires-python = ">=3.10"
+# Tracks SPEC 0, the support window the scientific stack itself follows: three
+# years past a Python release. That put 3.10 out in Oct 2024 and 3.11 in Oct
+# 2025 — both already past — while upstream EOL alone would have kept 3.11 until
+# Oct 2027. numpy/scipy/pandas/scikit-learn are the versions that actually
+# constrain us, so their calendar is the one worth tracking, not CPython's.
+#
+# Published releases stay installable on the versions they declared: a 3.11 user
+# resolves to 0.2.0, the last release with `>=3.10`. Nothing breaks retroactively.
+requires-python = ">=3.12"
 dependencies = [
     "numpy>=1.24",
     "scipy>=1.10",
@@ -52,9 +60,6 @@ dev = [
     "mypy",
     "build",
     "twine",
-    # tomllib is stdlib from 3.11; without this the 3.10 leg skips
-    # test_version_matches_pyproject instead of running it.
-    "tomli>=2.0 ; python_version < '3.11'",
 ]
 all = ["shanuz[analysis,anndata,integration,deseq2,dev]"]
 
@@ -72,16 +77,17 @@ addopts = "-v"
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py312"
 
 [tool.mypy]
-# Deliberately no `python_version`. Pinning it to our 3.10 floor also makes mypy
-# parse every *followed* import as 3.10, third-party source included — and
-# `anndata>=0.10` resolves to 0.13.2 on Python 3.12, which uses PEP 695
-# `def _reduce[T](...)` syntax. mypy then aborts the whole run with "errors
+# Deliberately no `python_version`. Pinning it to our floor also makes mypy parse
+# every *followed* import at that version, third-party source included — and
+# `anndata>=0.10` resolves to 0.13.2, which uses PEP 695 `def _reduce[T](...)`
+# syntax. Under a pre-3.12 setting mypy aborts the whole run with "errors
 # prevented further checking" and silently checks nothing, while `|| true` keeps
-# CI green. Each leg targets its own interpreter instead; the 3.10 leg is what
-# proves the package still supports 3.10.
+# CI green. The floor is 3.12 now, so that particular trap is behind us, but the
+# shape of it is not: each leg targets its own interpreter instead, and the
+# lowest leg is what proves the package still supports the floor it declares.
 #
 # Scope is pinned here rather than only in CI's command, so a bare `mypy` checks
 # exactly what CI checks. `ruff` takes its scope from the command line, where

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 # Tracks SPEC 0, the support window the scientific stack itself follows: three

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -12,6 +12,7 @@ import re
 import subprocess
 import sys
 import textwrap
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -19,14 +20,10 @@ from packaging.version import InvalidVersion, Version
 
 import shanuz
 
-try:  # stdlib from 3.11; `tomli` backfills 3.10 via the [dev] extra
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - only on Python 3.10
-    import tomli as tomllib
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
 FALLBACK_VERSION = "0.0.0+unknown"
 
@@ -176,3 +173,100 @@ def test_every_tagged_release_is_in_the_changelog():
     documented = {name for name, _ in _changelog_headings()}
     missing = sorted(tagged - documented)
     assert not missing, f"tagged but undocumented in CHANGELOG.md: {missing}"
+
+
+# ----------------------------------------------------------------------
+# Supported Python versions
+# ----------------------------------------------------------------------
+#
+# One decision — which Pythons we support — is written down in four places that
+# no other test reads together: `requires-python`, the trove classifiers,
+# ruff's `target-version`, and the CI matrix. Each is independently plausible
+# when wrong, and the failure modes are quiet in different directions.
+# Classifiers are pure metadata, so a stale one misinforms PyPI forever without
+# breaking a build. A CI matrix that has moved past the declared floor stops
+# testing the floor, which is the one version most likely to break. A ruff
+# target below the floor silently disables the modernisation lint the floor
+# just earned. Nothing here would have caught the 3.10/3.11 drop being applied
+# to three of the four.
+
+
+def _pyproject() -> dict:
+    return tomllib.loads(PYPROJECT.read_text())
+
+
+def _classifier_versions() -> list[Version]:
+    """Minor versions from the `Programming Language :: Python :: X.Y` trove tags."""
+    out = []
+    for entry in _pyproject()["project"]["classifiers"]:
+        match = re.fullmatch(r"Programming Language :: Python :: (\d+\.\d+)", entry)
+        if match:  # the bare `:: 3` tag carries no minor version, so it is skipped
+            out.append(Version(match.group(1)))
+    return sorted(out)
+
+
+def _requires_python_floor() -> Version:
+    spec = _pyproject()["project"]["requires-python"]
+    match = re.fullmatch(r">=\s*(\d+\.\d+)", spec.strip())
+    assert match, f"requires-python is {spec!r}; this test assumes a bare `>=X.Y` floor"
+    return Version(match.group(1))
+
+
+def _ci_matrix_versions() -> list[Version]:
+    """The `python-version:` matrix, read out of the workflow YAML.
+
+    Parsed with a regex rather than PyYAML deliberately: PyYAML is not a
+    declared dependency of this package. It arrives transitively today, so
+    importing it would pass now and start skipping this test the day that
+    transitive edge disappears — the exact silent-drift failure this section
+    exists to prevent.
+    """
+    text = CI_WORKFLOW.read_text()
+    match = re.search(r"^\s*python-version:\s*\[(.+?)\]\s*$", text, re.M)
+    assert match, "no `python-version: [...]` matrix found in ci.yml"
+    return sorted(Version(v.strip().strip("\"'")) for v in match.group(1).split(","))
+
+
+def test_classifiers_match_the_ci_matrix():
+    """Every version we claim to support is tested, and vice versa.
+
+    The two drift in opposite directions and both are quiet. A classifier with
+    no matrix leg is a support claim nothing backs; a matrix leg with no
+    classifier means PyPI under-sells what already works.
+    """
+    classifiers = _classifier_versions()
+    matrix = _ci_matrix_versions()
+    assert classifiers == matrix, (
+        f"pyproject classifiers list {[str(v) for v in classifiers]} but the CI "
+        f"matrix tests {[str(v) for v in matrix]}"
+    )
+
+
+def test_requires_python_floor_is_the_lowest_tested_version():
+    """The declared floor is exercised, not just asserted.
+
+    If the matrix moves above `requires-python`, pip still installs on the floor
+    while nothing runs there — the failure surfaces as a user's traceback rather
+    than a red build.
+    """
+    floor = _requires_python_floor()
+    lowest = _ci_matrix_versions()[0]
+    assert floor == lowest, (
+        f"requires-python declares >={floor} but the lowest CI leg is {lowest}; "
+        f"the floor is either untested or understated"
+    )
+
+
+def test_ruff_target_version_matches_the_floor():
+    """ruff's `target-version` is the same floor, spelled ruff's way.
+
+    Set below the floor it suppresses valid modernisation lint; above it, ruff
+    can suggest syntax that does not parse on a version we still ship to.
+    """
+    floor = _requires_python_floor()
+    target = _pyproject()["tool"]["ruff"]["target-version"]
+    expected = f"py{floor.major}{floor.minor}"
+    assert target == expected, (
+        f"requires-python declares >={floor} (ruff `{expected}`) but "
+        f"[tool.ruff] target-version is {target!r}"
+    )

--- a/tests/test_sketch.py
+++ b/tests/test_sketch.py
@@ -124,10 +124,16 @@ def test_leverage_scores_are_not_flat():
         ================  ==========  ============
 
     An earlier version of this test asserted ``> 1.5``, which sat directly on the
-    fixed value and duly failed on Python 3.10 at 1.4956 while passing on 3.11
-    and 3.12 — the SVD drifts ~2 % across versions. 1.25 leaves ~20 % either way.
-    If this ever fails again, check that the *sum* test above still passes before
-    touching the number: a genuine regression shows up there first.
+    fixed value and duly failed at 1.4956 on what was then the Python 3.10 leg
+    while passing on 3.11 and 3.12. The cause was not the interpreter, as
+    originally recorded here: `>=` dependency floors let that leg resolve numpy
+    2.2.6 / scipy 1.15.3 where the others got 2.4.6 / 1.18.0, and the SVD differs
+    by ~2 % between them. Measured across the current 3.12-3.14 matrix, where all
+    three legs resolve identical versions, the value agrees to four decimals
+    (1.5246 everywhere) — so the margin buys nothing *today*. Keep it: the floors
+    are still `>=`, and the next leg to resolve something different will not
+    announce itself. If this ever fails, check that the *sum* test above still
+    passes before touching the number: a genuine regression shows up there first.
     """
     obj, _ = _clustered_object(sizes=(200, 200), G=600, nfeatures=400)
 


### PR DESCRIPTION
Drops Python 3.10 and 3.11, adds 3.13. `requires-python` becomes `>=3.12`, with the classifiers, ruff target and CI matrix moved to match.

> **3.14 was in this PR and came back out.** It failed CI on `harmonypy`, which has no cp314 wheel — see below. The change as merged is 3.12 + 3.13.

## Why this floor

The floor tracks [SPEC 0](https://scientific-python.org/specs/spec-0000/) — three years past each Python release, the support window numpy, scipy, pandas and scikit-learn keep for themselves — rather than CPython's five-year EOL. By that rule 3.10 lapsed in **Oct 2024** and 3.11 in **Oct 2025**, both already past. Going by upstream EOL alone would have held 3.11 until Oct 2027. Those four packages are what actually constrain this library, so theirs is the calendar worth following.

**Nothing breaks retroactively.** `pip` on 3.10 or 3.11 resolves to 0.2.0, the last release declaring `>=3.10`.

## CI

| leg | interpreter | tests | ruff | mypy |
|---|---|---|---|---|
| 3.12 | CPython 3.12.13 | **616 passed / 17 skipped** | 74 | 85 |
| 3.13 | CPython 3.13.14 | **616 passed / 17 skipped** | 74 | 85 |
| Build | — | wheel built, `twine` checked, clean install imported | | |

Counts read from the job logs. 616 = main's 613 plus the three drift guards below. ruff 74 is the untouched baseline; mypy 85 is inside the documented 81–85 per-leg band.

All 17 tutorial smoke tests were also run locally against the real datasets — that suite is env-gated off in CI on every leg, so those pipelines are otherwise unexercised.

## Why 3.14 is not here

Every package in the dependency set has a cp314 manylinux wheel **except `harmonypy`**, which publishes cp39–cp313 only. Without a wheel, uv builds it from source, and that needs BLAS plus a CMake-fetched armadillo `ubuntu-latest` does not have. Both ways around it are worse than waiting:

- **Forcing a wheels-only resolve** backtracks to `harmonypy` 0.2.0, which depends on torch and pulls in triton and 24 `nvidia-*` packages.
- **Dropping the `integration` extra on a 3.14 leg** does resolve clean — 95 packages, wheels only — but leaves 18 harmony tests unrun there.

One upstream release away. `ROADMAP.md` carries the open item and the recheck command; `README.md` says why 3.14 is absent rather than leaving it unexplained.

**This was caught by CI, not by me.** I verified 3.14 locally on macOS arm64 and reported it as working. It installed there because macOS supplies BLAS via Accelerate, so the harmonypy source build *succeeded* — the venv's wheel tag reads `macosx_26_0_arm64`, a local build rather than a download. A clean install on the dev machine was never evidence about the runner. The check that would have caught it, now recorded in ROADMAP:

```
uv pip compile pyproject.toml --extra all \
  --python-platform x86_64-manylinux_2_28 --python-version 3.14 --only-binary :all:
```

Note `manylinux_2_28`, not `manylinux2014` — the older tag is below modern numpy's wheels and produces a misleading failure.

## Drift guards (new)

The supported-version decision was written in four places nothing read together: `requires-python`, the trove classifiers, `[tool.ruff] target-version`, and the CI matrix. Each is quiet when wrong, in a different direction — a stale classifier misinforms PyPI without breaking a build; a matrix above the declared floor stops testing the floor, the version most likely to break; a ruff target below the floor silently disables the lint the floor just earned.

Three tests now cross-check them. Passing proves nothing on its own, so each fact was broken in turn:

| mutation | caught by |
|---|---|
| drop the newest classifier | classifiers-vs-matrix |
| raise `requires-python` a minor version | floor-is-lowest-leg **+** ruff-target |
| revert ruff target to `py310` | ruff-target |
| drop the lowest leg from the matrix | classifiers-vs-matrix **+** floor-is-lowest-leg |

All four caught, each by a specific subset rather than everything firing at once. They earned their keep immediately: pulling 3.14 back out meant editing four files, and these are what confirmed all four agreed afterwards.

The matrix is parsed with a regex rather than PyYAML on purpose: PyYAML is not a declared dependency, so importing it would pass today and start silently skipping the day that transitive edge disappears — the exact drift these guards exist to catch.

## One correction, and one thing this exposed

`test_leverage_scores_are_not_flat` justified its threshold with "the SVD drifts ~2% across Python versions," citing an old 3.10 CI failure at 1.4956. **That explanation was wrong.** Measured on 3.12/3.13/3.14 the value is **1.5246 on all three, identical to four decimals**. The 3.10 leg differed because `>=` floors let it resolve numpy 2.2.6 / scipy 1.15.3 where the others got 2.4.6 / 1.18.0 — the interpreter was never the variable. Docstring rewritten; the margin stays, because the floors are still `>=`.

That surfaces something worth naming: **the matrix no longer varies dependencies.** That 3.10 leg was the only coverage of an older scientific stack, and nobody had written that down — it was doing a job it wasn't hired for. Both remaining legs resolve one identical set. Recorded in `ROADMAP.md` as open, with the honest fix being a dedicated oldest-supported-deps leg rather than keeping an EOL Python around as an accidental proxy for it.

## Not in scope

The pinned actions are well behind — `setup-uv@v5` → v8.3.2, `checkout@v4` → v7, `upload-artifact@v4` → v7. Not a blocker, and deliberately left out so a version-matrix change stays readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
