### PR TITLE
fix(typing): resolve all 21 unresolvable annotations under TYPE_CHECKING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,30 @@ on `main`; none of it is on PyPI.
 
 ### Fixed
 
+- **Twenty-one annotations named symbols that existed nowhere at module scope.**
+  Seventeen plotting functions were declared `-> "plt.Figure"` while `plt` was
+  only ever a local inside each body (`plt = _mpl()`); `Graph.as_neighbor`,
+  `Neighbor.as_graph` and `from_anndata` named classes imported at call time to
+  dodge a circular import. `from __future__ import annotations` makes every
+  signature an unevaluated string, so this cost nothing at runtime and no test
+  noticed — but it is exactly what a type checker, an IDE, or a documentation
+  generator reads. Both mypy (`name-defined`) and ruff (`F821`) had been
+  reporting all 21 for as long as the annotations existed.
+
+  Each is now a `if TYPE_CHECKING:` import, which those tools read and the
+  interpreter never runs. The plotting signatures say `-> "Figure"` from
+  `matplotlib.figure`, which is the class the functions actually return.
+  matplotlib stays an optional dependency: `import shanuz` eagerly imports
+  `shanuz.plotting` and still does not pull it in.
+
+  mypy drops **81 → 60** errors and ruff **72 → 51** on `shanuz` (222 → 201
+  repo-wide) — the same 21 in both counts, so any baseline recorded before this
+  is 21 high on both tools. `tests/test_annotations_resolve.py` walks the AST of
+  every module in the package and fails on any annotation whose root name is not
+  bound at module scope, and separately asserts each deferred import stays
+  *inside* its `TYPE_CHECKING` block — hoisting it would satisfy both checkers
+  while making matplotlib mandatory.
+
 - **`find_all_markers` was missing Seurat's `return.thresh`, and did not break
   p-value ties.** `FindAllMarkers` defaults to `return.thresh = 1e-2` and
   returns only genes below it; shanuz returned everything that survived the

--- a/shanuz/compat/anndata.py
+++ b/shanuz/compat/anndata.py
@@ -4,11 +4,17 @@ Requires: pip install seurat-object[anndata]
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
+
+if TYPE_CHECKING:
+    # `shanuz.shanuz` pulls in the assay and reduction stack, which this module
+    # is itself imported from — hence the deferred import inside `from_anndata`.
+    # Annotation-only, so the return type resolves without reinstating the cycle.
+    from ..shanuz import Shanuz
 
 
 def as_anndata(seurat, assay: Optional[str] = None):

--- a/shanuz/graph.py
+++ b/shanuz/graph.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 import scipy.sparse as sp
+
+if TYPE_CHECKING:
+    # `Graph` and `Neighbor` convert into each other, so importing this at
+    # module scope would be a genuine cycle. The runtime conversions therefore
+    # import inside the function body, and this block — which never executes —
+    # exists only so the annotations naming `Neighbor` resolve to the class
+    # rather than to nothing.
+    from .neighbor import Neighbor
 
 
 class Graph:

--- a/shanuz/neighbor.py
+++ b/shanuz/neighbor.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 import scipy.sparse as sp
+
+if TYPE_CHECKING:
+    # The other half of the Graph/Neighbor cycle — see the matching block in
+    # `graph.py`. Annotation-only; `as_graph` still imports at call time.
+    from .graph import Graph
 
 
 class Neighbor:

--- a/shanuz/plotting.py
+++ b/shanuz/plotting.py
@@ -22,10 +22,19 @@ All functions return a matplotlib Figure so the caller can save or display it:
 from __future__ import annotations
 
 import re
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 import pandas as pd
+
+if TYPE_CHECKING:
+    # Annotation-only, so matplotlib stays an optional runtime dependency: the
+    # block never executes, and `from __future__ import annotations` above keeps
+    # every signature below a string. Without it the return annotations name a
+    # symbol that exists nowhere in the module, which is invisible at runtime
+    # but leaves a type checker — and any doc generator that resolves
+    # annotations — with nothing to point at.
+    from matplotlib.figure import Figure
 
 # ---------------------------------------------------------------------------
 # Lazy matplotlib import — keeps the package importable without matplotlib
@@ -216,7 +225,7 @@ def vln_plot(
     ncol: Optional[int] = None,
     figsize: Optional[tuple] = None,
     palette: Optional[list] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Violin plot of feature expression per cluster/identity.
 
     Mirrors R's ``VlnPlot(pbmc, features = c("LYZ", "CD3D"))``.
@@ -297,7 +306,7 @@ def feature_plot(
     colormap: str = "YlOrRd",
     pt_size: float = 3.0,
     figsize: Optional[tuple] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Visualise feature expression on a dimensionality reduction embedding.
 
     Mirrors R's ``FeaturePlot(pbmc, features = c("MS4A1", "LYZ"))``.
@@ -383,7 +392,7 @@ def dim_plot(
     figsize: tuple = (7, 6),
     palette: Optional[list] = None,
     title: Optional[str] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Plot cells in a reduced-dimension embedding coloured by identity.
 
     Mirrors R's ``DimPlot(pbmc, reduction = "umap", label = TRUE)``.
@@ -443,7 +452,7 @@ def elbow_plot(
     reduction: str = "pca",
     ndims: int = 20,
     figsize: tuple = (7, 4),
-) -> "plt.Figure":
+) -> "Figure":
     """Rank principal components by standard deviation.
 
     Mirrors R's ``ElbowPlot(pbmc)``.
@@ -487,7 +496,7 @@ def feature_scatter(
     alpha: float = 0.6,
     figsize: tuple = (6, 5),
     palette: Optional[list] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Scatter plot of two features coloured by identity.
 
     Mirrors R's ``FeatureScatter(pbmc, feature1 = "nCount_RNA", feature2 = "percent.mt")``.
@@ -530,7 +539,7 @@ def variable_feature_plot(
     label: bool = True,
     n_label: int = 10,
     figsize: tuple = (9, 5),
-) -> "plt.Figure":
+) -> "Figure":
     """Plot mean expression vs dispersion and highlight variable features.
 
     Mirrors R's ``VariableFeaturePlot(pbmc)``.
@@ -615,7 +624,7 @@ def viz_dim_loadings(
     n_features: int = 15,
     ncol: Optional[int] = None,
     figsize: Optional[tuple] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Horizontal bar charts of top positive and negative loading genes per PC.
 
     Mirrors R's ``VizDimLoadings(pbmc, dims = 1:2, reduction = "pca")``.
@@ -687,7 +696,7 @@ def dim_heatmap(
     balanced: bool = True,
     ncol: Optional[int] = None,
     figsize: Optional[tuple] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Heatmap of gene loadings for selected principal components.
 
     Shows the most extreme cells (highest / lowest scores) and the top
@@ -801,7 +810,7 @@ def do_heatmap(
     cells: Optional[list[str]] = None,
     figsize: Optional[tuple] = None,
     palette: Optional[list] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Expression heatmap of selected genes across cells, sorted by cluster.
 
     Mirrors R's ``DoHeatmap(pbmc, features = top10$gene)``.
@@ -914,7 +923,7 @@ def ridge_plot(
     ncol: Optional[int] = None,
     figsize: Optional[tuple] = None,
     palette: Optional[list] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Ridgeline (joy) plots of feature expression per group.
 
     Mirrors R's ``RidgePlot(pbmc, features = c("LYZ", "CD3D"))``.
@@ -986,7 +995,7 @@ def dot_plot(
     dot_scale: float = 6.0,
     scale: bool = True,
     figsize: Optional[tuple] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Dot plot of feature expression across groups.
 
     Mirrors R's ``DotPlot(pbmc, features = c("LYZ", "CD3D"))``. For each
@@ -1095,7 +1104,7 @@ def image_dim_plot(
     ncol: Optional[int] = None,
     flip_y: bool = True,
     figsize: Optional[tuple] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Plot cell centroids in physical space, coloured by a grouping variable.
 
     Matplotlib equivalent of Seurat's ``ImageDimPlot`` — drawn directly from
@@ -1161,7 +1170,7 @@ def image_feature_plot(
     ncol: Optional[int] = None,
     flip_y: bool = True,
     figsize: Optional[tuple] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Plot cell centroids in physical space, coloured by a feature's expression.
 
     Matplotlib equivalent of Seurat's ``ImageFeaturePlot``. One panel per image.
@@ -1297,7 +1306,7 @@ def spatial_dim_plot(
     crop: bool = True,
     ncol: Optional[int] = None,
     figsize: Optional[tuple] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Plot spots on the tissue image, coloured by a grouping variable.
 
     Matplotlib equivalent of Seurat's ``SpatialDimPlot``. Each panel draws the
@@ -1388,7 +1397,7 @@ def spatial_feature_plot(
     crop: bool = True,
     ncol: Optional[int] = None,
     figsize: Optional[tuple] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Plot spots on the tissue image, coloured by a feature's expression.
 
     Matplotlib equivalent of Seurat's ``SpatialFeaturePlot``. Behaves exactly
@@ -1495,7 +1504,7 @@ def plot_perturb_score(
     assay: str = "PRTB",
     seed: int = 0,
     figsize: Optional[tuple] = None,
-) -> "plt.Figure":
+) -> "Figure":
     """Density of one target gene's perturbation scores (Seurat's ``PlotPerturbScore``).
 
     Mirrors ``PlotPerturbScore(object, target.gene.ident = "IFNGR2",
@@ -1652,7 +1661,7 @@ def mixscape_heatmap(
     pval_cutoff: float = 0.05,
     seed: int = 0,
     **kwargs,
-) -> "plt.Figure":
+) -> "Figure":
     """DE heatmap with cells ordered by knockout probability (``MixscapeHeatmap``).
 
     Mirrors ``MixscapeHeatmap(object, ident.1 = "NT", ident.2 = "IFNGR2 KO",

--- a/tests/test_annotations_resolve.py
+++ b/tests/test_annotations_resolve.py
@@ -1,0 +1,220 @@
+"""Every annotation in `shanuz/` must name something the module actually binds.
+
+`from __future__ import annotations` turns every signature into a string that is
+never evaluated, so an annotation may name a symbol that exists nowhere and
+nothing complains — the module imports, the function runs, the tests pass. What
+breaks is anything that *reads* the types: a checker, an IDE, or a documentation
+generator resolving `-> "plt.Figure"` when no `plt` exists at module scope.
+
+That is not hypothetical. Twenty-one annotations across four modules named
+symbols bound only inside function bodies (`plt = _mpl()`) or imported only at
+call time to dodge a circular import (`Graph`/`Neighbor`/`Shanuz`). The fix is a
+`if TYPE_CHECKING:` block, which type checkers and static doc tools read and the
+interpreter never executes — and which is easy to delete later while every other
+test stays green. This module is the thing that would notice.
+"""
+import ast
+import builtins
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PKG = Path(__file__).resolve().parent.parent / "shanuz"
+
+# Modules whose annotations depend on a `TYPE_CHECKING` block, and the symbol
+# each one defers. Listed explicitly so deleting a block is a failure with a
+# name attached rather than a silent loss of coverage.
+DEFERRED = {
+    "plotting.py": "Figure",
+    "graph.py": "Neighbor",
+    "neighbor.py": "Graph",
+    "compat/anndata.py": "Shanuz",
+}
+
+
+def _module_scope_names(tree: ast.Module) -> set:
+    """Names bound at module scope — the only scope an annotation can see.
+
+    Deliberately does *not* recurse into function or class bodies. An earlier
+    draft of this check walked every scope, which counted the function-local
+    `plt = _mpl()` as a binding for the module-level annotation `plt.Figure`
+    and so reported a clean run against the very tree that had all 21 defects.
+    `if` and `try` bodies *are* followed, since that is where both
+    `TYPE_CHECKING` blocks and optional-dependency imports live.
+    """
+    names = set(dir(builtins))
+
+    def visit(body):
+        for node in body:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    names.add((alias.asname or alias.name).split(".")[0])
+            elif isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                names.add(node.name)
+            elif isinstance(node, ast.Assign):
+                for target in node.targets:
+                    for sub in ast.walk(target):
+                        if isinstance(sub, ast.Name):
+                            names.add(sub.id)
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                names.add(node.target.id)
+            elif isinstance(node, ast.If):
+                visit(node.body)
+                visit(node.orelse)
+            elif isinstance(node, ast.Try):
+                visit(node.body)
+                visit(node.orelse)
+                visit(node.finalbody)
+                for handler in node.handlers:
+                    visit(handler.body)
+
+    visit(tree.body)
+    return names
+
+
+def _roots(expr: ast.expr) -> list:
+    """Identifiers an annotation depends on, unwrapping strings and generics.
+
+    `Optional[Graph]` depends on both `Optional` and `Graph`; `plt.Figure`
+    depends on `plt`, not on `Figure`; `"Shanuz"` is parsed and then treated
+    like the expression it spells.
+    """
+    if isinstance(expr, ast.Constant):
+        if isinstance(expr.value, str):
+            try:
+                return _roots(ast.parse(expr.value, mode="eval").body)
+            except SyntaxError:
+                return []
+        return []                                   # None, literal ints in Literal[...]
+    if isinstance(expr, ast.Name):
+        return [expr.id]
+    if isinstance(expr, ast.Attribute):
+        return _roots(expr.value)                   # np.ndarray -> np
+    if isinstance(expr, ast.Subscript):
+        return _roots(expr.value) + _roots(expr.slice)
+    if isinstance(expr, ast.BinOp):                 # int | None
+        return _roots(expr.left) + _roots(expr.right)
+    if isinstance(expr, (ast.Tuple, ast.List)):
+        return [r for elt in expr.elts for r in _roots(elt)]
+    return []
+
+
+def _annotations(tree: ast.Module):
+    """Yield (root_name, owner, lineno) for every annotation in the module."""
+    for node in ast.walk(tree):
+        found = []
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.returns is not None:
+                found.append(node.returns)
+            args = node.args
+            for arg in [*args.posonlyargs, *args.args, *args.kwonlyargs,
+                        args.vararg, args.kwarg]:
+                if arg is not None and arg.annotation is not None:
+                    found.append(arg.annotation)
+            owner = node.name
+        elif isinstance(node, ast.AnnAssign) and node.annotation is not None:
+            found.append(node.annotation)
+            owner = ast.unparse(node.target)
+        else:
+            continue
+        for expr in found:
+            for root in _roots(expr):
+                yield root, owner, expr.lineno
+
+
+def _sources():
+    # utf-8-sig: shanuz/command.py carries a UTF-8 BOM, which ast.parse rejects
+    # outright. Reading it away here keeps this check from being the thing that
+    # reports it; the BOM itself is tracked separately.
+    return [(p, ast.parse(p.read_text(encoding="utf-8-sig"), filename=str(p)))
+            for p in sorted(PKG.rglob("*.py"))]
+
+
+def test_every_annotation_names_a_module_scope_binding():
+    """The whole package, not a sampled subset — the defect was spread over four files."""
+    sources = _sources()
+    assert len(sources) > 40, f"only {len(sources)} modules found; is PKG right?"
+
+    unresolved = [
+        f"{path.relative_to(PKG.parent)}:{line} in {owner}() -> {root!r}"
+        for path, tree in sources
+        for root, owner, line in _annotations(tree)
+        if root not in _module_scope_names(tree)
+    ]
+    assert not unresolved, (
+        "annotations naming symbols bound nowhere at module scope — a type "
+        "checker and any doc generator both resolve these to nothing:\n  "
+        + "\n  ".join(unresolved)
+    )
+
+
+@pytest.mark.parametrize("relpath,symbol", sorted(DEFERRED.items()))
+def test_deferred_symbols_stay_inside_type_checking(relpath, symbol):
+    """The import must be in a `TYPE_CHECKING` block, not merely present.
+
+    Hoisting it to module scope silences the checker just as well, so this
+    asserts the placement rather than the resolution. For `plotting.py` the
+    difference is a hard matplotlib dependency; for the other three it is an
+    import cycle at interpreter start.
+    """
+    tree = ast.parse((PKG / relpath).read_text(encoding="utf-8-sig"))
+
+    guarded, unguarded = False, False
+    for node in tree.body:
+        if isinstance(node, ast.If) and "TYPE_CHECKING" in ast.unparse(node.test):
+            for sub in ast.walk(node):
+                if isinstance(sub, (ast.Import, ast.ImportFrom)):
+                    if any(a.asname == symbol or a.name == symbol for a in sub.names):
+                        guarded = True
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            if any(a.asname == symbol or a.name == symbol for a in node.names):
+                unguarded = True
+
+    assert guarded, f"{relpath} no longer defers {symbol!r} under TYPE_CHECKING"
+    assert not unguarded, (
+        f"{relpath} imports {symbol!r} at module scope; the TYPE_CHECKING block "
+        f"exists precisely so this import never runs"
+    )
+
+
+def test_importing_shanuz_still_does_not_import_matplotlib():
+    """`shanuz/__init__.py` imports `plotting` eagerly, so this is load-bearing.
+
+    matplotlib is optional — `_mpl()` raises a pip-install message when it is
+    absent. Moving `from matplotlib.figure import Figure` out of the
+    `TYPE_CHECKING` block would turn `import shanuz` into a hard requirement for
+    it on every install, and no other test in the suite would notice, because
+    CI has matplotlib installed.
+
+    Run in a subprocess: by the time this file executes, the rest of the suite
+    has long since put matplotlib in `sys.modules`.
+    """
+    code = (
+        "import sys; import shanuz; "
+        "assert 'shanuz.plotting' in sys.modules, 'plotting no longer imported eagerly'; "
+        "sys.exit(1 if 'matplotlib' in sys.modules else 0)"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0, (
+        "importing shanuz now pulls in matplotlib, making an optional "
+        f"dependency mandatory.\n{proc.stdout}{proc.stderr}"
+    )
+
+
+@pytest.mark.parametrize("relpath,symbol", sorted(DEFERRED.items()))
+def test_deferred_symbols_are_absent_at_runtime(relpath, symbol):
+    """The complement of the AST check: confirm the block really does not execute.
+
+    If `TYPE_CHECKING` were ever truthy — or the block were replaced with a
+    plain `try: import ... except ImportError:` — these names would appear in
+    the module namespace and the runtime deferral would be gone.
+    """
+    import importlib
+
+    name = "shanuz." + relpath[:-3].replace("/", ".")
+    module = importlib.import_module(name)
+    assert not hasattr(module, symbol), (
+        f"{name}.{symbol} exists at runtime; the TYPE_CHECKING block is executing"
+    )


### PR DESCRIPTION
## What

Twenty-one annotations across four modules named symbols that exist nowhere at module scope:

| Module | Count | Annotation | Where the name really lived |
|---|---|---|---|
| `shanuz/plotting.py` | 17 | `-> "plt.Figure"` | `plt = _mpl()`, a local inside each body |
| `shanuz/graph.py` | 2 | `-> "Neighbor"` | `from .neighbor import Neighbor`, inside the function |
| `shanuz/neighbor.py` | 1 | `-> "Graph"` | `from .graph import Graph`, inside the function |
| `shanuz/compat/anndata.py` | 1 | `-> "Shanuz"` | `from ..shanuz import Shanuz`, inside the function |

`from __future__ import annotations` makes every signature an unevaluated string, so this cost nothing at runtime and no test noticed. It is precisely what a type checker, an IDE, or a documentation generator reads.

Each is now a `if TYPE_CHECKING:` import — read statically, never executed. The plotting signatures name `Figure` from `matplotlib.figure`, which is the class the functions actually return (verified: `type(dim_plot(...))` is `matplotlib.figure.Figure`).

## It was two tools, not one

This was carried as a mypy item, but ruff's `F821` had been flagging the identical 21:

| | before | after |
|---|---|---|
| `mypy shanuz` | 81 | **60** |
| `ruff check shanuz` | 72 | **51** |
| `ruff check .` | 222 | **201** |
| `ruff check shanuz --select F821` | 21 | **0** |
| `mypy ... name-defined` | 21 | **0** |

Both baselines drop by exactly 21, so any figure recorded before this is 21 high on *both* tools. No new diagnostic appeared in either: 81 − 21 = 60 exactly.

## Guard

`tests/test_annotations_resolve.py` (10 tests) walks the AST of all 53 modules and fails on any annotation whose root name is not bound at module scope. Run against the pre-fix tree it reports mypy's exact 21, file and line; after, 0.

The first draft of that check was vacuous — it collected `Store` names at every scope, so the function-local `plt = _mpl()` counted as a binding and it passed cleanly on the broken tree. Module scope only is the whole point, and the docstring says so.

Two guards cover what the resolution check cannot:

- **Placement.** Hoisting `from matplotlib.figure import Figure` to module scope satisfies mypy, ruff *and* the AST check — and makes matplotlib mandatory, since `shanuz/__init__.py` imports `plotting` eagerly. A subprocess asserts `import shanuz` still leaves `matplotlib` out of `sys.modules`.
- **Runtime absence.** If a block were ever replaced with a plain `try: import`, the deferral would be gone; the deferred names are asserted absent from each module namespace.

Six mutations, one per guard, each caught by the intended test and only that test:

| Mutation | Caught by |
|---|---|
| `plotting.py` back to `plt.Figure`, block deleted | annotation resolution |
| matplotlib import hoisted out of the block | placement + optionality (resolution **passes**) |
| `graph.py` block deleted | annotation resolution + placement |
| `neighbor.py` block forced to execute | runtime absence |
| `compat/anndata.py` block deleted | annotation resolution |
| unmutated | all 10 pass |

## Verification

- Full suite **834 passed, 25 skipped** (824 before, +10 new).
- Behaviour unchanged: `get_type_hints()` on these functions raised `NameError` before this change too — on `plt` instead of `Figure`. Nothing in the repo calls it.
- `dim_plot` / `vln_plot` / `elbow_plot` smoke-tested end to end; all return `matplotlib.figure.Figure`.

## Scope

No docs site exists in the repo yet — this removes a blocker for building one, it does not build one. The remaining 60 mypy errors are real typing work (`assignment`, `attr-defined`, `arg-type`), not missing names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)