### PR TITLE
fix: strip the UTF-8 BOM from shanuz/command.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,17 @@ on `main`; none of it is on PyPI.
 
 ### Fixed
 
+- **`shanuz/command.py` began with a UTF-8 BOM.** CPython decodes source as
+  `utf-8-sig`, so the file imported, introspected, linted and type-checked
+  without complaint — which is how three bytes survived unnoticed. What they
+  broke is reading the source back as text: `Path.read_text()` defaults to plain
+  utf-8, keeps the U+FEFF, and `ast.parse` then rejects the file outright with
+  `invalid non-printable character`. The AST walk added alongside this had to
+  decode around it, and any codemod, doc generator or source-level lint would
+  hit the same wall on a file that looks fine. The BOM is gone, and
+  `test_no_source_file_starts_with_a_byte_order_mark` scans the whole repo — not
+  just the package — so another cannot arrive quietly.
+
 - **Twenty-one annotations named symbols that existed nowhere at module scope.**
   Seventeen plotting functions were declared `-> "plt.Figure"` while `plt` was
   only ever a local inside each body (`plt = _mpl()`); `Graph.as_neighbor`,

--- a/shanuz/command.py
+++ b/shanuz/command.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import inspect
 from datetime import datetime

--- a/tests/test_annotations_resolve.py
+++ b/tests/test_annotations_resolve.py
@@ -21,7 +21,8 @@ from pathlib import Path
 
 import pytest
 
-PKG = Path(__file__).resolve().parent.parent / "shanuz"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG = REPO_ROOT / "shanuz"
 
 # Modules whose annotations depend on a `TYPE_CHECKING` block, and the symbol
 # each one defers. Listed explicitly so deleting a block is a failure with a
@@ -125,11 +126,44 @@ def _annotations(tree: ast.Module):
 
 
 def _sources():
-    # utf-8-sig: shanuz/command.py carries a UTF-8 BOM, which ast.parse rejects
-    # outright. Reading it away here keeps this check from being the thing that
-    # reports it; the BOM itself is tracked separately.
+    # utf-8-sig rather than utf-8: no source carries a BOM any more (see
+    # `test_no_source_file_starts_with_a_byte_order_mark`), but decoding one
+    # away here keeps a stray BOM from surfacing as a confusing SyntaxError
+    # inside an annotation test. The dedicated guard below is what names it.
     return [(p, ast.parse(p.read_text(encoding="utf-8-sig"), filename=str(p)))
             for p in sorted(PKG.rglob("*.py"))]
+
+
+def test_no_source_file_starts_with_a_byte_order_mark():
+    """A UTF-8 BOM is legal Python and breaks every tool that reads the text.
+
+    CPython's import machinery decodes source as `utf-8-sig`, so a BOM never
+    shows up as a runtime failure — `import`, `inspect.getsource`, ruff and mypy
+    all handle `shanuz/command.py` without complaint, which is why one survived
+    in it unnoticed. What breaks is the ordinary idiom for reading source back:
+
+        ast.parse(Path(mod.__file__).read_text())
+
+    `Path.read_text()` defaults to plain utf-8 and keeps the U+FEFF, and
+    `ast.parse` then rejects the file with `invalid non-printable character`.
+    That is not hypothetical — the AST walk in this very module had to decode
+    around it, and any future contributor writing a codemod, a doc generator or
+    a source-level lint hits the same wall on a file that looks fine.
+
+    Scans the whole repo rather than just the package: the reason the BOM is
+    worth removing has nothing to do with which directory it lives in.
+    """
+    offenders = [
+        p.relative_to(REPO_ROOT)
+        for p in sorted(REPO_ROOT.rglob("*.py"))
+        if ".venv" not in p.parts and "build" not in p.parts
+        and p.read_bytes().startswith(b"\xef\xbb\xbf")
+    ]
+    assert not offenders, (
+        "Python sources beginning with a UTF-8 BOM — these import fine but "
+        "cannot be read with Path.read_text() and parsed:\n  "
+        + "\n  ".join(str(p) for p in offenders)
+    )
 
 
 def test_every_annotation_names_a_module_scope_binding():


### PR DESCRIPTION
## What

`shanuz/command.py` started with `ef bb bf`. It was the only file in the repo that did.

## Why nothing caught it

CPython's import machinery decodes source as `utf-8-sig`, so the BOM is invisible to essentially every check the repo runs. Measured on `main` before the fix:

| | result |
|---|---|
| `import shanuz.command` | ok |
| `inspect.getsource` | ok — first char `'f'` |
| `ruff check shanuz/command.py` | ok |
| `mypy shanuz/command.py` | `Success: no issues found` |
| `ast.parse(Path(...).read_text())` | **`SyntaxError: invalid non-printable character U+FEFF`** |

That last row is the whole defect. `Path.read_text()` defaults to plain utf-8 and keeps the U+FEFF, so the ordinary idiom for reading a module's own source back and parsing it fails on a file that looks perfectly normal. This is not hypothetical — the AST walk added in #62 had to decode around it, and any codemod, documentation generator or source-level lint hits the same wall.

## Guard

`test_no_source_file_starts_with_a_byte_order_mark` checks the raw bytes of every `.py` in the repo, not just the package — the reason a BOM is worth removing has nothing to do with which directory it sits in. Mutation-verified: re-adding the BOM fails that test, and only that test.

`_sources()` in the same module keeps reading with `utf-8-sig`, deliberately. That is not belt-and-braces — it keeps a stray BOM from surfacing as a baffling `SyntaxError` inside a test about *annotations*, and leaves the dedicated guard to name the actual problem. The stale comment there (which asserted the BOM still existed) is updated.

## Verification

- Suite **835 passed, 25 skipped** (834 before, +1).
- `ruff check shanuz` **51**, `ruff check .` **201**, `mypy shanuz` **60** — all unchanged, which is exactly the point: neither tool ever saw this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)