### PR TITLE
fix(hvf): write the column names HVFInfo() returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,51 @@ on `main`; none of it is on PyPI.
 
 ### Changed
 
+- **BREAKING: `find_variable_features` now writes the column names
+  `HVFInfo()` returns.** On an Assay5 the per-feature statistics land in
+  `assay.meta_data`, which — unlike SeuratObject, where they sit behind a
+  `vf_vst_counts_` prefix that `HVFInfo()` strips — *is* the user-facing table.
+  It spelled them `means` / `variances` / `variances.standardized` against
+  Seurat's `mean` / `variance` / `variance.standardized`, so the same quantity
+  read differently in the two languages and the PBMC 3k handoff had to rename
+  all three on the way out for the join to work. Now:
+
+  | method | columns |
+  |---|---|
+  | `"vst"` | `mean`, `variance`, `variance.expected`, `variance.standardized` |
+  | `"mvp"` / `"dispersion"` / `"mean.var.plot"` | `mvp.mean`, `mvp.dispersion`, `mvp.dispersion.scaled` |
+
+  Code reading `meta_data["means"]` and friends must be updated; the old names
+  are gone rather than aliased, since keeping both is what let the divergence
+  live in the object unnoticed. `highly_variable` is unchanged — it is shanuz's
+  own flag, and `HVFInfo(status = TRUE)`'s `variable` has no other counterpart.
+
+  Two things fall out of the rename. **`variance.expected` is new**: the vst
+  LOESS fit was computed, used to standardize, and then discarded, so nothing
+  downstream could tell a genuinely variable gene from one sitting where the fit
+  was poor. On PBMC 3k it agrees with Seurat to **2.50e-2 relative** against
+  `variance.standardized`'s **2.56e-2** — the two carry the same disagreement,
+  as they must, since the standardization is proportional to its reciprocal.
+  That is the whole of the VST gap, now attributable: the mean and the observed
+  variance match to 1.5e-14 and 5.1e-14, so what the two tools disagree about is
+  the LOESS fit and nothing else. And **the mvp path no
+  longer writes vst's names**: it had been storing scaled dispersions in a
+  column called `variances.standardized` and the raw variance in one called
+  `variances`, neither of which is a quantity `HVFInfo(method = "mvp")` reports.
+  Those values differ from Seurat's in definition as well as in name — shanuz
+  computes them on log-normalized data where Seurat round-trips through
+  `expm1` — so this fixes the labels, not the numbers.
+
+  `variable_feature_plot` reads the stored statistics and silently falls back to
+  recomputing a raw dispersion when it cannot find them, so a consumer left on
+  the old spelling would have kept drawing a plot — a different one, on a
+  different axis, with no error. `tests/test_hvf_column_names.py` pins the
+  column names against a recorded Seurat 5.5.1 probe, pins `variance.expected`'s
+  *contents* through the identity `variance.standardized = variance /
+  variance.expected` (exact wherever the clip does not bite), and asserts the
+  plot takes the stored-statistics branch. The PBMC 3k handoff now carries
+  `var.expected` on both sides, which is what separates "the standardization
+  drifted" from "the LOESS fit did".
 - **The SCTransform vignette's ±1 cluster gap is closed and its docstring
   corrected.** The vignette described shanuz resolving 13 clusters against
   Seurat's 12, blamed on the RNG and the differing clustering libraries. Both

--- a/shanuz/plotting.py
+++ b/shanuz/plotting.py
@@ -562,12 +562,12 @@ def variable_feature_plot(
     # Prefer pre-computed VST stats stored by find_variable_features
     md = getattr(assay_obj, "meta_data", None)
     use_std_var = (md is not None
-                   and "variances.standardized" in md.columns
-                   and "means" in md.columns)
+                   and "variance.standardized" in md.columns
+                   and "mean" in md.columns)
 
     if use_std_var:
-        means = md["means"].values
-        y_vals = md["variances.standardized"].values
+        means = md["mean"].values
+        y_vals = md["variance.standardized"].values
         y_label = "Standardized Variance"
         # clip extreme standardized values for readability
         y_vals = np.clip(y_vals, 0, np.percentile(y_vals[y_vals > 0], 99.5))

--- a/shanuz/preprocessing.py
+++ b/shanuz/preprocessing.py
@@ -314,6 +314,18 @@ def find_variable_features(
     Mirrors R's FindVariableFeatures(pbmc, selection.method = "vst",
     nfeatures = 2000). Modifies the assay in-place by setting
     var_features (Assay) or highly_variable in meta_data (Assay5).
+
+    On an Assay5 the per-feature statistics land in ``assay.meta_data`` under
+    the names `HVFInfo()` uses, so a column reads the same in either language:
+
+    * ``selection_method="vst"`` — ``mean``, ``variance``,
+      ``variance.expected``, ``variance.standardized``
+    * ``"mvp"`` / ``"dispersion"`` / ``"mean.var.plot"`` — ``mvp.mean``,
+      ``mvp.dispersion``, ``mvp.dispersion.scaled``
+
+    plus ``highly_variable``, a boolean flag that has no Seurat counterpart of
+    its own (`HVFInfo(status = TRUE)` spells it ``variable``); it is the
+    fallback `Assay5.variable_features` reads when the ordered list is empty.
     """
     assay_name = assay or seurat.active_assay
     assay_obj = seurat.assays[assay_name]
@@ -342,16 +354,34 @@ def find_variable_features(
             else:
                 data = assay_obj.data if not is_matrix_empty(assay_obj.data) else assay_obj.counts
 
+    # `stats` becomes the per-feature columns written to meta_data below. The
+    # keys are Seurat's, taken from `HVFInfo()` rather than from the raw slot:
+    # SeuratObject stores these prefixed by method and layer
+    # (`vf_vst_counts_mean`), and strips the prefix on the way out. `HVFInfo()`
+    # is the name a Seurat user actually types, so it is the one to match.
     if selection_method == "vst":
-        hvg_indices, means, variances, var_std = _vst_hvg(data, nfeatures)
-    elif selection_method == "dispersion" or selection_method == "mvp":
-        hvg_indices, means, variances, var_std = _dispersion_hvg(
+        hvg_indices, means, variances, expected_var, var_std = _vst_hvg(data, nfeatures)
+        stats = {
+            "mean": means,
+            "variance": variances,
+            "variance.expected": expected_var,
+            "variance.standardized": var_std,
+        }
+    elif selection_method in ("dispersion", "mvp", "mean.var.plot"):
+        hvg_indices, means, dispersion, dispersion_scaled = _dispersion_hvg(
             data, nfeatures, mean_cutoff, dispersion_cutoff
         )
-    elif selection_method == "mean.var.plot":
-        hvg_indices, means, variances, var_std = _dispersion_hvg(
-            data, nfeatures, mean_cutoff, dispersion_cutoff
-        )
+        # A different method produces different quantities, and Seurat names
+        # them so: `HVFInfo(method = "mvp")` returns mvp.mean / mvp.dispersion /
+        # mvp.dispersion.scaled, never `variance.standardized`. Writing scaled
+        # dispersions into a column called `variance.standardized` — which is
+        # what sharing one set of column names across both methods amounts to —
+        # is a mislabelling that no downstream reader can detect.
+        stats = {
+            "mvp.mean": means,
+            "mvp.dispersion": dispersion,
+            "mvp.dispersion.scaled": dispersion_scaled,
+        }
     else:
         raise ValueError(f"Unknown selection_method: {selection_method!r}")
 
@@ -368,12 +398,7 @@ def find_variable_features(
     if isinstance(assay_obj, Assay5):
         # Store HVF info in assay meta_data
         hvf_df = pd.DataFrame(
-            {
-                "means": means,
-                "variances": variances,
-                "variances.standardized": var_std,
-                "highly_variable": np.zeros(len(feature_names), dtype=bool),
-            },
+            {**stats, "highly_variable": np.zeros(len(feature_names), dtype=bool)},
             index=feature_names,
         )
         hvf_df.loc[hvg_names, "highly_variable"] = True
@@ -393,8 +418,15 @@ def _vst_hvg(
     nfeatures: int = 2000,
     loess_span: float = 0.3,
     clip_max: Optional[float] = None,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Variance-stabilizing transformation HVG selection (Seurat's 'vst').
+
+    Returns ``(top_idx, mean, variance, variance.expected, variance.standardized)``
+    — the four per-gene quantities `HVFInfo(method = "vst")` reports, in its
+    order. The expected variance is the LOESS fit that step 2 computes anyway;
+    it is what tells a reader whether a gene's standardized variance is high
+    because the gene is variable or because the fit was poor there, which is the
+    whole point of plotting it against the observed variance.
 
     Faithfully reproduces Seurat's algorithm on the raw counts:
       1. Per-gene mean and *sample* (N-1) variance of the counts.
@@ -493,7 +525,7 @@ def _vst_hvg(
     # selected at all.
     top_idx = np.argsort(-var_standardized, kind="stable")[:nfeatures]
 
-    return top_idx, means, variances, var_standardized
+    return top_idx, means, variances, expected_var, var_standardized
 
 
 def _loess_fit(x: np.ndarray, y: np.ndarray, frac: float = 0.3) -> np.ndarray:
@@ -605,6 +637,12 @@ def _dispersion_hvg(
 
     Bins genes by mean expression, normalizes dispersion within each bin.
     Mirrors Seurat v2's FindVariableGenes.
+
+    Returns ``(top_idx, mean, dispersion, dispersion.scaled)`` — the three
+    quantities `HVFInfo(method = "mvp")` reports, in its order. The raw variance
+    is an intermediate here and is deliberately not returned: it has no column
+    in Seurat's mvp output, and returning it in the slot the caller labels
+    ``mvp.dispersion`` is how it came to be stored under a name it did not hold.
     """
     if sp.issparse(data):
         n_cells = data.shape[1]
@@ -643,7 +681,7 @@ def _dispersion_hvg(
     n = min(nfeatures, len(dispersion_scaled))
     # Stable, and on the negated values -- see the note in `_vst_hvg`.
     top_idx = np.argsort(-dispersion_scaled, kind="stable")[:n]
-    return top_idx, means, variances, dispersion_scaled
+    return top_idx, means, dispersion, dispersion_scaled
 
 
 # ------------------------------------------------------------------

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -148,8 +148,8 @@ def test_vst_clipping_suppresses_single_cell_outliers():
     base[0, 0] = 50.0
     mat = sp.csc_matrix(base)
 
-    _, _, _, vs_clipped = _vst_hvg(mat, nfeatures=n_genes)            # clip = sqrt(N)
-    _, _, _, vs_unclipped = _vst_hvg(mat, nfeatures=n_genes, clip_max=1e12)
+    _, _, _, _, vs_clipped = _vst_hvg(mat, nfeatures=n_genes)         # clip = sqrt(N)
+    _, _, _, _, vs_unclipped = _vst_hvg(mat, nfeatures=n_genes, clip_max=1e12)
 
     assert vs_clipped[0] < 0.5 * vs_unclipped[0]
 

--- a/tests/test_hvf_column_names.py
+++ b/tests/test_hvf_column_names.py
@@ -1,0 +1,156 @@
+"""`find_variable_features` must write the columns `HVFInfo()` returns.
+
+SeuratObject keeps per-feature HVF statistics in the assay's meta.data behind a
+method-and-layer prefix (`vf_vst_counts_mean`) and strips it on the way out, so
+the names a Seurat user actually sees are `HVFInfo()`'s. shanuz has no prefix
+layer — `assay.meta_data` *is* the user-facing table — which makes matching
+`HVFInfo()` the only way a column can read the same in either language.
+
+It did not. shanuz wrote `means` / `variances` / `variances.standardized`
+against Seurat's `mean` / `variance` / `variance.standardized`, dropped
+`variance.expected` entirely, and wrote scaled *dispersions* from the mvp path
+into a column named `variances.standardized`. Nothing failed: every consumer was
+in-tree and used shanuz's spelling, so the divergence only surfaced where the
+two tools met — the pbmc3k handoff renamed all three columns on the way out to
+make the join work, and carried a comment saying the divergence was real.
+
+Measured against Seurat 5.5.1 / SeuratObject 5.4.0 on an Assay5:
+
+    HVFInfo(o[["RNA"]])                 mean, variance, variance.expected,
+                                        variance.standardized
+    HVFInfo(o[["RNA"]], status = TRUE)  ... plus variable, rank
+    HVFInfo(o2[["RNA"]], "mvp")         mvp.mean, mvp.dispersion,
+                                        mvp.dispersion.scaled
+
+`variable`/`rank` are deliberately not mirrored: shanuz spells the first
+`highly_variable` and keeps rank as the order of `assay.variable_features`.
+"""
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from shanuz.preprocessing import find_variable_features, normalize_data
+
+# Verbatim from `HVFInfo()` under Seurat 5.5.1 — see the module docstring.
+VST_COLUMNS = ["mean", "variance", "variance.expected", "variance.standardized"]
+MVP_COLUMNS = ["mvp.mean", "mvp.dispersion", "mvp.dispersion.scaled"]
+
+# The spellings shanuz used before. Listed so a partial revert fails loudly
+# rather than leaving one method writing the old names beside the new ones.
+RETIRED_COLUMNS = ["means", "variances", "variances.standardized"]
+
+
+def _fitted(small_seurat, method):
+    normalize_data(small_seurat)
+    find_variable_features(small_seurat, selection_method=method, nfeatures=5)
+    return small_seurat.assays["RNA"].meta_data
+
+
+def test_vst_writes_the_hvfinfo_column_names(small_seurat):
+    md = _fitted(small_seurat, "vst")
+    missing = [c for c in VST_COLUMNS if c not in md.columns]
+    assert not missing, (
+        f"vst is missing {missing}; `HVFInfo()` returns exactly {VST_COLUMNS}"
+    )
+
+
+def test_mvp_writes_the_hvfinfo_column_names(small_seurat):
+    """A different method reports different quantities, under different names.
+
+    `HVFInfo(method = "mvp")` never returns a `variance.standardized`. Sharing
+    one set of column names across both methods put scaled dispersions in a
+    column claiming to hold standardized variances, which no reader downstream
+    could detect.
+    """
+    md = _fitted(small_seurat, "mvp")
+    missing = [c for c in MVP_COLUMNS if c not in md.columns]
+    assert not missing, f"mvp is missing {missing}"
+    leaked = [c for c in VST_COLUMNS if c in md.columns]
+    assert not leaked, (
+        f"mvp wrote vst column(s) {leaked}; those names promise a LOESS "
+        f"variance fit that the dispersion path never computes"
+    )
+
+
+@pytest.mark.parametrize("method", ["vst", "mvp", "dispersion", "mean.var.plot"])
+def test_no_method_writes_the_retired_column_names(small_seurat, method):
+    md = _fitted(small_seurat, method)
+    survivors = [c for c in RETIRED_COLUMNS if c in md.columns]
+    assert not survivors, (
+        f"{method} still writes {survivors}; these are shanuz's old spellings "
+        f"and have no counterpart in Seurat's HVFInfo()"
+    )
+
+
+def test_variance_expected_column_holds_the_loess_fit_not_a_placeholder():
+    """Pins the column's *contents*, not just its presence.
+
+    Where no value is clipped, the definitions collapse into an exact identity:
+
+        variance.standardized = Σ((x-μ)/σ̂)² / (n-1) = variance / variance.expected
+
+    so a `variance.expected` holding the observed variance, its square root, or
+    a copy of some neighbouring column fails here even though a
+    column-names-only check would pass. Genes that clip are excluded — for them
+    the identity legitimately does not hold, and that is the point of the clip.
+
+    Deliberately routed through `find_variable_features` and read back off
+    `meta_data` rather than unpacked from `_vst_hvg`. Both mutations that swap
+    the column's contents live at the *storage* site, and a test that calls the
+    computation directly passes through every one of them: it would be checking
+    that `_vst_hvg` returns the right five arrays while the wrong one gets
+    written to the column.
+    """
+    from shanuz import create_shanuz_object
+
+    rng = np.random.default_rng(0)
+    n_genes, n_cells = 60, 40
+    counts = sp.csc_matrix(rng.poisson(4.0, size=(n_genes, n_cells)).astype(float))
+    obj = create_shanuz_object(
+        counts=counts,
+        assay="RNA",
+        feature_names=[f"gene{i}" for i in range(n_genes)],
+        cell_names=[f"cell{j}" for j in range(n_cells)],
+    )
+    find_variable_features(obj, selection_method="vst", nfeatures=10)
+    md = obj.assays["RNA"].meta_data
+
+    mean = md["mean"].to_numpy()
+    variance = md["variance"].to_numpy()
+    expected = md["variance.expected"].to_numpy()
+    var_std = md["variance.standardized"].to_numpy()
+
+    dense = counts.toarray()
+    sd = np.sqrt(np.where(expected > 0, expected, 1.0))
+    z = (dense - mean[:, None]) / sd[:, None]
+    unclipped = (z.max(axis=1) <= np.sqrt(n_cells)) & (expected > 0)
+    assert unclipped.sum() > 10, "fixture clips too much to test the identity"
+
+    np.testing.assert_allclose(
+        var_std[unclipped], (variance / expected)[unclipped], rtol=1e-12,
+        err_msg="variance.expected is not the LOESS fit the standardization used",
+    )
+
+
+def test_variable_feature_plot_reads_the_stored_stats(small_seurat):
+    """The rename has to reach the consumers, or they degrade in silence.
+
+    `variable_feature_plot` prefers the stored VST statistics and falls back to
+    recomputing a raw dispersion from the data matrix when it cannot find them.
+    A consumer left looking for `means` therefore keeps drawing a plot — a
+    different, wrong plot, on a different y axis, with no error anywhere. The
+    axis label is what distinguishes the two branches.
+    """
+    pytest.importorskip("matplotlib")
+    from shanuz.plotting import variable_feature_plot
+
+    _fitted(small_seurat, "vst")
+    fig = variable_feature_plot(small_seurat, label=False)
+    try:
+        assert fig.axes[0].get_ylabel() == "Standardized Variance", (
+            "variable_feature_plot fell back to recomputing dispersions; it no "
+            "longer finds the VST statistics find_variable_features stored"
+        )
+    finally:
+        import matplotlib.pyplot as plt
+        plt.close(fig)

--- a/tests/test_lazy_bpcells_parity.py
+++ b/tests/test_lazy_bpcells_parity.py
@@ -85,7 +85,8 @@ def test_shanuz_on_disk_and_in_memory_paths_are_bit_identical(tmp_path):
 
     h_mem = mem.assays["RNA"].meta_data
     h_lazy = lazy.assays["RNA"].meta_data
-    for column in ("means", "variances", "variances.standardized"):
+    for column in ("mean", "variance", "variance.expected",
+                   "variance.standardized"):
         np.testing.assert_array_equal(h_mem[column].to_numpy(),
                                       h_lazy[column].to_numpy())
 

--- a/tests/test_lazy_pipeline.py
+++ b/tests/test_lazy_pipeline.py
@@ -343,8 +343,8 @@ def test_variable_features_are_bit_identical_between_lazy_and_sparse(tmp_path):
     counts = _counts()
     lazy = write_lazy_matrix(counts, tmp_path / "m", overwrite=True)
 
-    idx_sparse, mean_s, var_s, vst_s = _vst_hvg(counts, nfeatures=20)
-    idx_lazy, mean_l, var_l, vst_l = _vst_hvg(lazy, nfeatures=20)
+    idx_sparse, mean_s, var_s, exp_s, vst_s = _vst_hvg(counts, nfeatures=20)
+    idx_lazy, mean_l, var_l, exp_l, vst_l = _vst_hvg(lazy, nfeatures=20)
 
     np.testing.assert_array_equal(idx_sparse, idx_lazy)
     np.testing.assert_array_equal(mean_s, mean_l)
@@ -457,7 +457,7 @@ def test_hvg_ties_break_by_ascending_index_like_r_order():
     """`head(order(x, decreasing = TRUE), n)` breaks ties by ascending original
     index; `argsort(x)[::-1]` breaks them descending, and unstably."""
     counts = _counts()
-    idx, _, _, var_standardized = _vst_hvg(counts, nfeatures=len(counts.toarray()))
+    idx, _, _, _, var_standardized = _vst_hvg(counts, nfeatures=len(counts.toarray()))
 
     ranked = var_standardized[idx]
     assert np.all(np.diff(ranked) <= 0), "must be ordered by descending score"

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -127,7 +127,7 @@ pipeline from the same 10x bytes; nothing is pinned across them.
 | Step | shanuz vs Seurat |
 |------|------------------|
 | Cells surviving QC | **the same 2,638 barcodes**, nCount/nFeature exact, percent.mt to 5.3e-15 |
-| VST per gene, all 13,714 | mean 4.8e-14, variance 1.6e-11, `variance.standardized` to 2.6e-2 relative |
+| VST per gene, all 13,714 | mean 4.8e-14, variance 1.6e-11, `variance.expected` 2.5e-2 and `variance.standardized` 2.6e-2 relative — the whole gap is the LOESS fit |
 | The 2,000 variable features | **1,998 shared**; the two swaps are genes 0.03 apart in a LOESS fit, at ranks 1,982–2,000 |
 | PCA, the 10 dims clustering uses | matched \|r\| mean **0.9988**, min 0.9946, no reordering |
 | kNN graph | **52,760 = 2,638 × 20 on both** |
@@ -655,6 +655,7 @@ same "don't chase the RNG" residual as `clara` (hashing) and the MULTI-seq KDE.
 | Switch assay | `DefaultAssay(cbmc) <- "ADT"` | `feature_plot(..., assay="ADT")` |
 | Access metadata | `pbmc@meta.data` | `pbmc.meta_data` |
 | Access assay | `pbmc[["RNA"]]` | `pbmc.assays["RNA"]` |
+| HVF statistics | `HVFInfo(pbmc[["RNA"]])` | `pbmc.assays["RNA"].meta_data` |
 | Active idents | `Idents(pbmc)` | `pbmc.idents` |
 
 ### Beyond PCA — supervised PCA and GLM-PCA

--- a/tutorials/lazy_bpcells_tutorial.py
+++ b/tutorials/lazy_bpcells_tutorial.py
@@ -214,11 +214,11 @@ def collect_anchors(obj_mem, obj_lazy, store, counts):
         scaled = np.asarray(_layer(obj, "scale.data").todense())
         anchors[f"{tag}.normalize_head"] = data.data[:HEAD].tolist()
         anchors[f"{tag}.normalize_sum"] = float(data.data.sum())
-        anchors[f"{tag}.vst_mean_head"] = hvf["means"].to_numpy()[:HEAD].tolist()
+        anchors[f"{tag}.vst_mean_head"] = hvf["mean"].to_numpy()[:HEAD].tolist()
         anchors[f"{tag}.vst_variance_head"] = (
-            hvf["variances"].to_numpy()[:HEAD].tolist())
+            hvf["variance"].to_numpy()[:HEAD].tolist())
         anchors[f"{tag}.vst_var_std_head"] = (
-            hvf["variances.standardized"].to_numpy()[:HEAD].tolist())
+            hvf["variance.standardized"].to_numpy()[:HEAD].tolist())
         anchors[f"{tag}.vst_selected_head"] = list(assay.variable_features[:HEAD])
         anchors[f"{tag}.scale_head"] = scaled[0, :HEAD].tolist()
         anchors[f"{tag}.scale_abs_sum"] = float(np.abs(scaled).sum())
@@ -236,10 +236,10 @@ def collect_anchors(obj_mem, obj_lazy, store, counts):
     anchors["selfcheck.normalize_identical"] = float(
         np.array_equal(d_mem.data, d_lazy.data))
     anchors["selfcheck.vst_mean_max_diff"] = float(
-        np.abs(h_mem["means"].to_numpy() - h_lazy["means"].to_numpy()).max())
+        np.abs(h_mem["mean"].to_numpy() - h_lazy["mean"].to_numpy()).max())
     anchors["selfcheck.vst_var_std_max_diff"] = float(np.abs(
-        h_mem["variances.standardized"].to_numpy()
-        - h_lazy["variances.standardized"].to_numpy()).max())
+        h_mem["variance.standardized"].to_numpy()
+        - h_lazy["variance.standardized"].to_numpy()).max())
     anchors["selfcheck.hvg_overlap"] = len(
         set(obj_mem.assays[ASSAY].variable_features)
         & set(obj_lazy.assays[ASSAY].variable_features))

--- a/tutorials/pbmc3k_tutorial.md
+++ b/tutorials/pbmc3k_tutorial.md
@@ -551,9 +551,10 @@ find_clusters(
 > scattered disagreement.
 >
 > Where it comes from is traceable: the two runs keep the **same 2,638
-> barcodes** and agree on the per-gene VST means to 4.8e-14, but
-> `variance.standardized` depends on a degree-2 LOESS fit that differs by up to
-> 2.6e-2 relative. That flips **2 of the 2,000** variable features (both at
+> barcodes** and agree on the per-gene VST means to 4.8e-14 and observed
+> variances to 5.1e-14, but `variance.standardized` depends on a degree-2 LOESS
+> fit that differs by up to 2.6e-2 relative — and `variance.expected`, the fit
+> itself, differs by 2.5e-2, so the disagreement is the fit and only the fit. That flips **2 of the 2,000** variable features (both at
 > ranks 1,982–2,000, and 0.03 apart in the fit), which moves the PCA slightly
 > — matched \|r\| 0.9988 over the 10 dims clustering uses — which moves 286 of
 > ~194,000 SNN edges, which moves this one boundary.
@@ -1032,7 +1033,7 @@ on this dataset:
 | | shanuz vs Seurat 5.5.1 |
 |---|---|
 | Cells surviving QC | **the same 2,638 barcodes**; nCount and nFeature exact, percent.mt to 5.3e-15 |
-| VST per gene (13,714) | mean 4.8e-14 · variance 1.6e-11 · `variance.standardized` 2.6e-2 relative |
+| VST per gene (13,714) | mean 4.8e-14 · variance 1.6e-11 · `variance.expected` 2.5e-2 · `variance.standardized` 2.6e-2, all relative |
 | Variable features | **1,998 of 2,000 shared**, rank Spearman 0.9999 |
 | PCA (10 dims) | matched \|r\| mean **0.9988**, min 0.9946, no reordering |
 | kNN graph | **52,760 on both** (2,638 × 20) |

--- a/tutorials/pbmc3k_tutorial.py
+++ b/tutorials/pbmc3k_tutorial.py
@@ -461,18 +461,18 @@ def write_anchors(pbmc, all_markers) -> None:
     cells.to_csv(FIGURES / "py_cell_meta.csv", index=False)
 
     rna = pbmc.assays["RNA"]
-    # shanuz stores the VST statistics on the assay's meta_data under `means` /
-    # `variances` / `variances.standardized`; Seurat's HVFInfo() spells the same
-    # three columns `mean` / `variance` / `variance.standardized`. Renamed here
-    # so the handoff joins, but the divergence is real and lives in the object.
+    # shanuz stores the VST statistics on the assay's meta_data under the names
+    # HVFInfo() uses, so these columns carry straight through to the R side of
+    # the handoff without being renamed on the way out.
     hvf = rna.meta_data
     selected = list(rna.variable_features)
     rank = {g: i + 1 for i, g in enumerate(selected)}
     pd.DataFrame({
         "gene": _r_symbols(hvf.index),
-        "mean": hvf["means"].to_numpy(),
-        "variance": hvf["variances"].to_numpy(),
-        "var.std": hvf["variances.standardized"].to_numpy(),
+        "mean": hvf["mean"].to_numpy(),
+        "variance": hvf["variance"].to_numpy(),
+        "var.expected": hvf["variance.expected"].to_numpy(),
+        "var.std": hvf["variance.standardized"].to_numpy(),
         "hvg_rank": [rank.get(g, np.nan) for g in hvf.index],
     }).to_csv(FIGURES / "py_hvg.csv", index=False)
 
@@ -547,11 +547,21 @@ def report() -> None:
     genes = ph.index.intersection(rh.index)
     print(f"\n  Variable features (VST) — {len(genes)} shared genes "
           f"of {len(ph)} / {len(rh)}")
-    print(f"  {'per-gene statistic':<20}{'max|diff|':>14}")
-    print(f"  {'-' * 34}")
-    for col in ("mean", "variance", "var.std"):
-        d = np.abs(ph.loc[genes, col].to_numpy() - rh.loc[genes, col].to_numpy()).max()
-        print(f"  {col:<20}{d:>14.3e}")
+    print(f"  {'per-gene statistic':<20}{'max|diff|':>14}{'max rel':>14}")
+    print(f"  {'-' * 48}")
+    # `var.expected` is the LOESS fit, and `var.std` is proportional to its
+    # reciprocal — so the two columns carry the same disagreement, and having
+    # both is what separates "the standardization drifted" from "the fit did".
+    #
+    # Relative as well as absolute, because these four live on wildly different
+    # scales: an expected variance runs into the hundreds for an abundant gene,
+    # so its absolute gap reads as enormous next to a mean's and says nothing.
+    for col in ("mean", "variance", "var.expected", "var.std"):
+        a = ph.loc[genes, col].to_numpy()
+        b = rh.loc[genes, col].to_numpy()
+        d = np.abs(a - b)
+        rel = d / np.maximum(np.abs(b), np.finfo(float).tiny)
+        print(f"  {col:<20}{d.max():>14.3e}{rel.max():>14.3e}")
     py_sel = set(ph.index[ph["hvg_rank"].notna()])
     r_sel = set(rh.index[rh["hvg_rank"].notna()])
     both = py_sel & r_sel

--- a/tutorials/pbmc3k_verify.R
+++ b/tutorials/pbmc3k_verify.R
@@ -129,6 +129,7 @@ write.csv(data.frame(
   gene        = rownames(hvf),
   mean        = hvf[["mean"]],
   variance    = hvf[["variance"]],
+  var.expected = hvf[["variance.expected"]],
   var.std     = hvf[["variance.standardized"]],
   # rank in the selection (1 = most variable), NA for the genes not selected
   hvg_rank    = match(rownames(hvf), selected)),

--- a/tutorials/visium_tutorial.py
+++ b/tutorials/visium_tutorial.py
@@ -243,9 +243,9 @@ def collect_anchors(obj, fov):
     a["qc.nfeature_head"] = obj.meta_data[f"nFeature_{ASSAY}"].to_numpy(float)[:HEAD].tolist()
 
     md = assay.meta_data
-    a["vst.mean_head"] = md["means"].to_numpy(float)[:HEAD].tolist()
-    a["vst.variance_head"] = md["variances"].to_numpy(float)[:HEAD].tolist()
-    a["vst.var_std_head"] = md["variances.standardized"].to_numpy(float)[:HEAD].tolist()
+    a["vst.mean_head"] = md["mean"].to_numpy(float)[:HEAD].tolist()
+    a["vst.variance_head"] = md["variance"].to_numpy(float)[:HEAD].tolist()
+    a["vst.var_std_head"] = md["variance.standardized"].to_numpy(float)[:HEAD].tolist()
 
     a["pca.stdev_head"] = list(map(float, obj.reductions["pca"].stdev[:HEAD]))
     a.update(spot_geometry(fov))


### PR DESCRIPTION
`find_variable_features` stored per-feature statistics on an Assay5's `meta_data` as `means` / `variances` / `variances.standardized`. Seurat's `HVFInfo()` spells the same three `mean` / `variance` / `variance.standardized`.

SeuratObject can afford its own internal spelling because the raw slot carries a `vf_vst_counts_` prefix that `HVFInfo()` strips on the way out. shanuz has no such layer — `meta_data` *is* the user-facing table — so its names are the ones a reader sees, and matching `HVFInfo()` is the only way a column reads the same in either language.

Nothing failed. Every consumer was in-tree and used shanuz's spelling, so the divergence surfaced only where the two tools met: the PBMC 3k handoff renamed all three columns on the way out so the join would work, and carried a comment saying the divergence was real.

## What changed

| method | columns |
|---|---|
| `"vst"` | `mean`, `variance`, `variance.expected`, `variance.standardized` |
| `"mvp"` / `"dispersion"` / `"mean.var.plot"` | `mvp.mean`, `mvp.dispersion`, `mvp.dispersion.scaled` |

**BREAKING** — the old names are gone rather than aliased. Keeping both is what would let the divergence go on living in the object. `highly_variable` is unchanged: it is shanuz's own flag, and `HVFInfo(status = TRUE)`'s `variable` has no other counterpart.

Two things fall out of the rename.

**`variance.expected` is new.** The vst LOESS fit was computed, used to standardize, and then discarded — leaving nothing downstream able to tell a genuinely variable gene from one sitting where the fit was poor. Measured on PBMC 3k against Seurat 5.5.1, all 13,714 genes:

| statistic | max abs | max relative |
|---|---|---|
| `mean` | 4.796e-14 | 1.548e-14 |
| `variance` | 1.592e-11 | 5.131e-14 |
| `variance.expected` | 4.300e+00 | **2.498e-02** |
| `variance.standardized` | 2.088e-01 | **2.562e-02** |

The last two agree with each other, as they must — the standardization is proportional to the fit's reciprocal. That pins the whole of the VST gap on the LOESS fit and nothing else, which the handoff previously could not distinguish from a drifting standardization. The report table gained a relative column so those four numbers can be read side by side at all; an expected variance runs into the hundreds for an abundant gene, and its absolute gap says nothing next to a mean's.

**The mvp path no longer borrows vst's names.** It had been storing scaled dispersions under `variances.standardized` and the raw variance under `variances`, neither of which `HVFInfo(method = "mvp")` reports. Those values still differ from Seurat's in *definition* — shanuz computes them on log-normalized data where Seurat round-trips through `expm1` — so this fixes the labels, not the numbers. That numeric gap is pre-existing and untouched here.

## The guard

`variable_feature_plot` prefers the stored statistics and silently falls back to recomputing a raw dispersion when it cannot find them, so a consumer left on the old spelling keeps drawing a plot — a different one, on a different y axis, with no error anywhere. That is the failure mode `tests/test_hvf_column_names.py` exists for. It pins the names against a recorded Seurat 5.5.1 / SeuratObject 5.4.0 probe, pins `variance.expected`'s *contents* through the identity `variance.standardized = variance / variance.expected` (exact wherever the clip does not bite), and asserts the plot takes the stored-statistics branch.

Mutation-tested; each of six mutations is caught by the intended guard and no other:

| mutation | caught by |
|---|---|
| vst writes the old names | names · retired-names · contents · plot |
| `variance.expected` dropped | names · contents |
| `variance.expected` holds the observed variance | contents |
| `variance.expected` holds the SD | contents |
| mvp writes vst's names | mvp names |
| plot still reads `means` | plot |

The two contents mutations sit at the *storage* site, so the identity check had to run through `find_variable_features` and read `meta_data` back. An earlier draft called `_vst_hvg` directly and passed through both — it verified the computation returned the right five arrays while the wrong one was written to the column.

## Verification

- Suite **843 passed, 25 skipped** (from 835 — the 8 new guards).
- `mypy` **60**, `ruff check shanuz` **51**, `ruff check .` **201** — all unmoved from `main`.
- PBMC 3k tutorial and `pbmc3k_verify.R` both re-run end to end under Seurat 5.5.1; the handoff joins on the new names with no rename, and the selection is unchanged at **1,998 of 2,000 shared**, rank Spearman 0.9999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)