### PR TITLE
fix(object-model): clear all 14 mypy errors, two of them real bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,50 @@ on `main`; none of it is on PyPI.
 
 ### Fixed
 
+- **`run_pca` on an Assay5 that had not been scaled raised "the truth value of
+  an array … is ambiguous".** `_get_scaled_data` chose its fallback layer with
+  `layers.get("data") or layers.get("counts")`. `or` evaluates `bool()` on its
+  left operand, and scipy refuses to answer for any matrix with more than one
+  entry — so the fallback raised on **every call that reached it**, which is
+  every `run_pca` or `run_ica` on a v5 object that had not been through
+  `scale_data()`. The v3 path never had it: it reads `assay_obj.data`
+  directly, so the two architectures silently disagreed about whether an
+  unscaled object could be reduced at all. Selected with an explicit `is None`
+  now, and if neither layer exists the error says which ones it looked for.
+  The v5 fallback returns **bit-identical** embeddings to the v3 one it mirrors.
+- **Merging a v3-backed and a v5-backed object died with an
+  `AttributeError` about a private slot.** `Assay` keeps its cells in
+  `_cell_names` and `Assay5` in `_all_cell_names`, so `Shanuz.merge` reached
+  for whichever the other did not have and failed partway through — after the
+  cell names and metadata had already been concatenated, from inside a method
+  the caller never named. It now raises a `TypeError` naming the assay and both
+  classes, and pointing at `create_shanuz_object(..., use_v5=)` as the way to
+  make the two sides match. Merging assays of the same class is unaffected.
+- **`StdAssay`'s methods returned the abstract base rather than the caller's
+  own class.** `join_layers`, `split_layers`, `cast_assay`, `subset`,
+  `rename_cells`, `merge` and `_copy` were annotated `-> "StdAssay"` while every
+  one of them builds its result from `self.__class__`, so an `Assay5` went in
+  and something typed as an ABC came out. Every caller downstream then had to
+  widen, which is what put `dict[str, Assay | StdAssay]` where `Shanuz` wanted
+  `dict[str, Assay | Assay5]`. Annotated `Self`, which is both accurate and what
+  the code already did. `tests/test_object_model_typing.py` pins the runtime
+  property that makes it true — a subclass gets its own class back from all
+  seven — since hardcoding `Assay5(...)` in any of them would leave the
+  annotation a promise the code does not keep and no other test would notice.
+- **An unreachable second implementation of the object's count columns is
+  gone.** `create_shanuz_object` dispatched on `hasattr(assay_obj, "calc_n")`,
+  which both assay classes satisfy, so the `_calc_n_for_assay5` fallback could
+  never run. It derived the `nCount_<ASSAY>` suffix from the assay's *key*
+  rather than from the `assay` argument and hardcoded `nCount_RNA` for an assay
+  with no default layer — agreeing with the live path for an ordinary RNA
+  object, which is why nothing had reason to look at it.
+
+  Together these clear **all 14 mypy errors** in the object-model modules
+  (`shanuz.py`, `assay5.py`, `reduction.py`, `spatial/fov.py`), taking the
+  advisory total from **60 to 46**. The remaining 46 are elsewhere: 40 in
+  `datasets.py` (one repeated idiom — a `cache_dir: Optional[str]` parameter
+  reassigned to a `Path`), and six spread over plotting, mixscape, multiseq,
+  sctransform, preprocessing, module_score and integration.
 - **`shanuz/command.py` began with a UTF-8 BOM.** CPython decodes source as
   `utf-8-sig`, so the file imported, introspected, linted and type-checked
   without complaint — which is how three bytes survived unnoticed. What they

--- a/shanuz/assay5.py
+++ b/shanuz/assay5.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import os
 import re
 from abc import ABC, abstractmethod
-from typing import Optional, Type, Union
+from typing import Optional, Self, Type, Union
 
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
 
-from ._sparse import as_sparse, empty_sparse, is_matrix_empty
+from ._sparse import as_dense, as_sparse, empty_sparse, is_matrix_empty
 from ._utils import validate_cell_names, validate_feature_names
 from .lazy import is_lazy
 from .logmap import LogMap
@@ -297,7 +297,7 @@ class StdAssay(KeyMixin, ABC):
         """
         return self._split_stems.get(name)
 
-    def join_layers(self, layers: Optional[list[str]] = None) -> "StdAssay":
+    def join_layers(self, layers: Optional[list[str]] = None) -> Self:
         """Rejoin split layers, restoring the name, order and contents.
 
         Mirrors R's ``JoinLayers``. Each split *stem* is rejoined separately —
@@ -360,7 +360,7 @@ class StdAssay(KeyMixin, ABC):
                                feature_names=features, cell_names=ordered)
         return new_obj
 
-    def split_layers(self, f: list[str], layer: Optional[str] = None) -> "StdAssay":
+    def split_layers(self, f: list[str], layer: Optional[str] = None) -> Self:
         """Split one layer into per-group layers, as R's ``split()`` does.
 
         The parts are named ``<layer>.<group>`` — Seurat's spelling, which users
@@ -397,13 +397,13 @@ class StdAssay(KeyMixin, ABC):
     # Cast assay layer types
     # ------------------------------------------------------------------
 
-    def cast_assay(self, to_sparse: bool = True) -> "StdAssay":
+    def cast_assay(self, to_sparse: bool = True) -> Self:
         new_obj = self._copy()
         for name, mat in new_obj.layers.items():
             if to_sparse and not sp.issparse(mat):
                 new_obj.layers[name] = sp.csc_matrix(mat)
             elif not to_sparse and sp.issparse(mat):
-                new_obj.layers[name] = mat.toarray()
+                new_obj.layers[name] = as_dense(mat)
         return new_obj
 
     # ------------------------------------------------------------------
@@ -414,7 +414,7 @@ class StdAssay(KeyMixin, ABC):
         self,
         cells: Optional[list[str]] = None,
         features: Optional[list[str]] = None,
-    ) -> "StdAssay":
+    ) -> Self:
         all_feat = self._all_feature_names
         all_cells = self._all_cell_names
         feat_set = set(all_feat)
@@ -472,7 +472,7 @@ class StdAssay(KeyMixin, ABC):
     # Cell renaming
     # ------------------------------------------------------------------
 
-    def rename_cells(self, new_names: list[str]) -> "StdAssay":
+    def rename_cells(self, new_names: list[str]) -> Self:
         if len(new_names) != len(self._all_cell_names):
             raise ValueError("new_names must match the number of cells.")
         obj = self._copy()
@@ -485,9 +485,9 @@ class StdAssay(KeyMixin, ABC):
 
     def merge(
         self,
-        y: Union["StdAssay", list["StdAssay"]],
+        y: Union[Self, list[Self]],
         add_cell_ids: Optional[list[str]] = None,
-    ) -> "StdAssay":
+    ) -> Self:
         others = [y] if isinstance(y, StdAssay) else y
         all_assays = [self] + others
 
@@ -574,7 +574,7 @@ class StdAssay(KeyMixin, ABC):
     # Copy helper
     # ------------------------------------------------------------------
 
-    def _copy(self) -> "StdAssay":
+    def _copy(self) -> Self:
         new = self.__class__(
             layers={k: v.copy() if hasattr(v, "copy") else v for k, v in self.layers.items()},
             feature_names=list(self._all_feature_names),

--- a/shanuz/reduction.py
+++ b/shanuz/reduction.py
@@ -184,10 +184,10 @@ def run_spca(
 
     features = _default_features(assay_obj, features)
 
-    X = _get_scaled_data(assay_obj, features, layer).T      # cells × features
-    if sp.issparse(X):
-        X = X.toarray()
-    X = np.asarray(X, dtype=float)
+    # `_get_scaled_data` densifies on the way out, so there is nothing left to
+    # convert here — the `sp.issparse` branch that used to stand between these
+    # two lines could not run.
+    X = np.asarray(_get_scaled_data(assay_obj, features, layer).T, dtype=float)
     n_cells, n_features = X.shape
 
     G = seurat.graphs[graph].tocsr()
@@ -252,9 +252,7 @@ def run_ica(
     features = _default_features(assay_obj, features)
 
     scaled = _get_scaled_data(assay_obj, features, layer)  # (features × cells)
-    data_t = scaled.T  # (cells × features)
-    if sp.issparse(data_t):
-        data_t = data_t.toarray()
+    data_t = scaled.T  # (cells × features) — already dense, see run_pca
 
     nics = min(nics, min(data_t.shape))
 
@@ -355,7 +353,7 @@ def _flip_signs(vectors: np.ndarray) -> np.ndarray:
 def _get_scaled_data(assay_obj, features: list[str], layer: str) -> np.ndarray:
     """Extract scaled data for the given features as a (features × cells) array."""
     from .assay5 import Assay5
-    from ._sparse import is_matrix_empty
+    from ._sparse import as_dense, is_matrix_empty
 
     if isinstance(assay_obj, Assay5):
         if layer in assay_obj.layers:
@@ -365,18 +363,25 @@ def _get_scaled_data(assay_obj, features: list[str], layer: str) -> np.ndarray:
             feat_idx_map = {f: i for i, f in enumerate(scaled_features)}
             valid = [f for f in features if f in feat_idx_map]
             idx = [feat_idx_map[f] for f in valid]
-            if sp.issparse(mat):
-                return mat[idx, :].toarray().astype(float)
-            return np.asarray(mat)[idx, :].astype(float)
+            return as_dense(mat[idx, :]).astype(float)
         else:
-            # Fall back to log-normalized data
-            data = assay_obj.layers.get("data") or assay_obj.layers.get("counts")
+            # Fall back to log-normalized data. Selected with an explicit
+            # `is None` rather than `a or b`: `or` evaluates `bool(a)`, and
+            # scipy raises "truth value of an array ... is ambiguous" for any
+            # matrix with more than one entry — so this fallback raised on
+            # every call that reached it, which is every `run_pca` on an
+            # Assay5 that had not been through `scale_data()`.
+            data = assay_obj.layers.get("data")
+            if data is None:
+                data = assay_obj.layers.get("counts")
+            if data is None:
+                raise ValueError(
+                    f"assay has no {layer!r}, 'data' or 'counts' layer to draw "
+                    f"from; run normalize_data() and scale_data() first."
+                )
             all_feats = assay_obj._all_feature_names
             feat_idx = [all_feats.index(f) for f in features if f in all_feats]
-            if sp.issparse(data):
-                sub = data[feat_idx, :].toarray().astype(float)
-            else:
-                sub = np.asarray(data)[feat_idx, :].astype(float)
+            sub = as_dense(data[feat_idx, :]).astype(float)
             # Center in-place
             sub -= sub.mean(axis=1, keepdims=True)
             return sub
@@ -385,17 +390,11 @@ def _get_scaled_data(assay_obj, features: list[str], layer: str) -> np.ndarray:
             sd = assay_obj.scale_data
             all_feats = assay_obj._feature_names
             feat_idx = [all_feats.index(f) for f in features if f in all_feats]
-            if sp.issparse(sd):
-                return sd[feat_idx, :].toarray().astype(float)
-            return np.asarray(sd)[feat_idx, :].astype(float)
+            return as_dense(sd[feat_idx, :]).astype(float)
         else:
             # Fall back to data
             all_feats = assay_obj._feature_names
             feat_idx = [all_feats.index(f) for f in features if f in all_feats]
-            mat = assay_obj.data
-            if sp.issparse(mat):
-                sub = mat[feat_idx, :].toarray().astype(float)
-            else:
-                sub = np.asarray(mat)[feat_idx, :].astype(float)
+            sub = as_dense(assay_obj.data[feat_idx, :]).astype(float)
             sub -= sub.mean(axis=1, keepdims=True)
             return sub

--- a/shanuz/shanuz.py
+++ b/shanuz/shanuz.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Optional, Union
+from typing import Any, Optional, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -499,8 +499,26 @@ class Shanuz:
         for aname in shared_assay_names:
             base = all_objects[0].assays[aname]
             rest = [obj.assays[aname] for obj in all_objects[1:]]
+            # A v3 Assay and a v5 Assay5 keep their cells in different slots
+            # (`_cell_names` vs `_all_cell_names`), so merging across the two
+            # reaches for a slot the other does not have and dies partway
+            # through with a bare AttributeError naming a private attribute.
+            # Refuse it here, where the assay and both classes can be named.
+            wrong = {type(a).__name__ for a in rest} - {type(base).__name__}
+            if wrong:
+                raise TypeError(
+                    f"cannot merge assay {aname!r}: it is a "
+                    f"{type(base).__name__} in the first object and a "
+                    f"{'/'.join(sorted(wrong))} in another. The two assay "
+                    f"classes store cells differently and cannot be combined. "
+                    f"Rebuild one side so both match — the `use_v5=` argument "
+                    f"to `create_shanuz_object` chooses the class."
+                )
+            # `rest` is now all `type(base)`, which only the check above makes
+            # true. mypy cannot carry that fact through a list, and filtering
+            # the list to prove it would read as a silent drop.
             new_assays[aname] = base.merge(
-                rest, add_cell_ids=add_cell_ids
+                cast(Any, rest), add_cell_ids=add_cell_ids
             )
 
         # Merged ident
@@ -603,8 +621,13 @@ def create_shanuz_object(
     """
     key = f"{assay.lower()}_"
 
+    # Each branch keeps its own narrowly-typed name and widens once, at the
+    # end: the two classes hold their cells in differently-named slots, so a
+    # single `assay_obj` reused across both branches has no type under which
+    # both reads are valid.
+    assay_obj: AnyAssay
     if use_v5:
-        assay_obj = create_assay5_object(
+        v5 = create_assay5_object(
             counts=counts,
             min_cells=min_cells,
             min_features=min_features,
@@ -612,9 +635,10 @@ def create_shanuz_object(
             cell_names=cell_names,
             key=key,
         )
-        cells = assay_obj._all_cell_names
+        cells = v5._all_cell_names
+        assay_obj = v5
     else:
-        assay_obj = create_assay_object(
+        v3 = create_assay_object(
             counts=counts,
             min_cells=min_cells,
             min_features=min_features,
@@ -622,10 +646,17 @@ def create_shanuz_object(
             cell_names=cell_names,
             key=key,
         )
-        cells = assay_obj._cell_names
+        cells = v3._cell_names
+        assay_obj = v3
 
-    # Build metadata
-    raw_meta = assay_obj.calc_n() if hasattr(assay_obj, "calc_n") else _calc_n_for_assay5(assay_obj)
+    # Build metadata. Both assay classes define `calc_n`, so the
+    # `hasattr(assay_obj, "calc_n")` fallback that used to stand here was
+    # unreachable — a second implementation of the same naming that nothing
+    # exercised, deriving the suffix from the assay's *key* rather than from
+    # the `assay` argument, and hardcoding `nCount_RNA` when the assay had no
+    # default layer. The two agree for an ordinary RNA object, which is why
+    # neither the tests nor the type checker had reason to look at it.
+    raw_meta = assay_obj.calc_n()
     base_meta = raw_meta.rename(columns={"nCount": f"nCount_{assay}", "nFeature": f"nFeature_{assay}"})
     # `orig.ident` is the first column of every Seurat object's metadata and the
     # default identity class; scripts group and split on it. Seeded with the
@@ -650,21 +681,3 @@ def create_shanuz_object(
     )
     return obj
 
-
-def _calc_n_for_assay5(assay: Assay5) -> pd.DataFrame:
-    from ._utils import calc_n as _calc_n
-
-    default_layer = assay.default_layer
-    if default_layer is None:
-        n = len(assay._all_cell_names)
-        return pd.DataFrame(
-            {"nCount_RNA": np.zeros(n), "nFeature_RNA": np.zeros(n)},
-            index=assay._all_cell_names,
-        )
-    mat = assay.layers[default_layer]
-    ncount, nfeature = _calc_n(mat)
-    key_base = assay._key.rstrip("_").upper()
-    return pd.DataFrame(
-        {f"nCount_{key_base}": ncount, f"nFeature_{key_base}": nfeature},
-        index=assay._all_cell_names,
-    )

--- a/shanuz/spatial/fov.py
+++ b/shanuz/spatial/fov.py
@@ -220,6 +220,7 @@ def create_fov(
 
     type_ : 'centroids' | 'segmentation' | 'molecules'
     """
+    boundary: BoundaryType
     if type_ == "centroids":
         boundary = create_centroids(coords, nsides=nsides, radius=radius, theta=theta, assay=assay)
         return FOV(boundaries={"centroids": boundary}, assay=assay, key=key)

--- a/tests/test_object_model_typing.py
+++ b/tests/test_object_model_typing.py
@@ -1,0 +1,160 @@
+"""Behaviour behind the object model's type annotations.
+
+Two of the fixes that cleared mypy from `shanuz.py` / `assay5.py` /
+`reduction.py` / `spatial/fov.py` changed what the code does, not just what it
+claims — a merge across assay classes, and `run_pca` on an unscaled Assay5. Both
+are pinned here, because a type checker is advisory in this repo (`|| true` in
+CI) and a count that drifts across matrix legs cannot be the only thing standing
+between the object model and a regression.
+
+The annotations themselves — `StdAssay`'s methods returning `Self` rather than
+the abstract base — are mypy's business and are not asserted here. What *is*
+asserted is the runtime property `Self` promises: that those methods build their
+result from `self.__class__`, so a subclass gets its own class back. Hardcoding
+`Assay5(...)` anywhere in them would keep every other test green and quietly make
+the annotation a lie.
+"""
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from shanuz import (
+    create_shanuz_object,
+    find_variable_features,
+    normalize_data,
+    run_pca,
+)
+from shanuz.assay import Assay
+from shanuz.assay5 import Assay5
+
+
+def _obj(use_v5=True, tag="c", n_genes=80, n_cells=40, seed=0):
+    rng = np.random.default_rng(seed)
+    counts = sp.csc_matrix(rng.poisson(3.0, size=(n_genes, n_cells)).astype(float))
+    return create_shanuz_object(
+        counts=counts,
+        assay="RNA",
+        feature_names=[f"g{i}" for i in range(n_genes)],
+        cell_names=[f"{tag}{j}" for j in range(n_cells)],
+        use_v5=use_v5,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Merging across assay classes
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("first_is_v5", [True, False])
+def test_merging_across_assay_classes_names_the_mismatch(first_is_v5):
+    """A v3 Assay and a v5 Assay5 cannot be merged, and now say so.
+
+    They keep their cells in differently-named private slots, so the merge used
+    to reach for one the other does not have and die partway through with
+    `AttributeError: 'Assay' object has no attribute '_all_cell_names'` — a
+    message about a private attribute, from inside a method the caller never
+    named, after the cell names and metadata had already been concatenated.
+    """
+    a = _obj(use_v5=first_is_v5, tag="a")
+    b = _obj(use_v5=not first_is_v5, tag="b")
+
+    with pytest.raises(TypeError) as excinfo:
+        a.merge(b)
+
+    message = str(excinfo.value)
+    assert "RNA" in message, "the message must name the assay that clashed"
+    assert "Assay5" in message and "Assay" in message, (
+        "the message must name both classes — knowing which two collided is "
+        "the difference between a fix and a guess"
+    )
+
+
+def test_merging_matching_assay_classes_still_works():
+    """The guard must not cost the ordinary case."""
+    a, b = _obj(tag="a"), _obj(tag="b")
+    merged = a.merge(b)
+    assert len(merged.cell_names()) == 80
+    assert type(merged.assays["RNA"]) is Assay5
+
+    a3, b3 = _obj(use_v5=False, tag="a"), _obj(use_v5=False, tag="b")
+    merged3 = a3.merge(b3)
+    assert len(merged3.cell_names()) == 80
+    assert type(merged3.assays["RNA"]) is Assay
+
+
+# ---------------------------------------------------------------------------
+# 2. run_pca's fallback when scale.data is absent
+# ---------------------------------------------------------------------------
+
+def test_run_pca_falls_back_to_data_on_an_unscaled_assay5():
+    """`X or Y` calls `bool(X)`, and scipy refuses to answer for a matrix.
+
+    `_get_scaled_data` picked its fallback layer with
+    `layers.get("data") or layers.get("counts")`. Any sparse matrix with more
+    than one entry raises `ValueError: The truth value of an array with more
+    than one element is ambiguous` from `__bool__`, so the fallback raised on
+    every call that reached it — which is every `run_pca` on an Assay5 that had
+    not been through `scale_data()`.
+
+    The v3 path never had the bug (it reads `assay_obj.data` directly), so the
+    two architectures disagreed about whether an unscaled object could be
+    reduced at all. They are checked against each other rather than against a
+    recorded number: identical embeddings is the property, and it makes the
+    v3 path the reference for what the v5 fallback was always meant to do.
+    """
+    v5, v3 = _obj(use_v5=True), _obj(use_v5=False)
+    for obj in (v5, v3):
+        normalize_data(obj)
+        find_variable_features(obj, nfeatures=30)
+        assert "scale.data" not in getattr(obj.assays["RNA"], "layers", {})
+        run_pca(obj, n_pcs=5)
+
+    np.testing.assert_array_equal(
+        v5.reductions["pca"].cell_embeddings,
+        v3.reductions["pca"].cell_embeddings,
+        err_msg="the v5 fallback no longer agrees with the v3 one it mirrors",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. The runtime property `Self` promises
+# ---------------------------------------------------------------------------
+
+class _DerivedAssay(Assay5):
+    """A stand-in for any future Assay5 specialization. Adds nothing."""
+
+
+def _derived_from(assay):
+    return _DerivedAssay(
+        layers={k: v.copy() for k, v in assay.layers.items()},
+        feature_names=list(assay._all_feature_names),
+        cell_names=list(assay._all_cell_names),
+        key=assay._key,
+    )
+
+
+@pytest.mark.parametrize("call", [
+    pytest.param(lambda a: a._copy(), id="_copy"),
+    pytest.param(lambda a: a.rename_cells([f"x{i}" for i in range(40)]), id="rename_cells"),
+    pytest.param(lambda a: a.subset(features=[f"g{i}" for i in range(10)]), id="subset"),
+    pytest.param(lambda a: a.cast_assay(to_sparse=False), id="cast_assay"),
+    pytest.param(lambda a: a.join_layers(), id="join_layers"),
+    pytest.param(lambda a: a.split_layers(["p"] * 20 + ["q"] * 20), id="split_layers"),
+])
+def test_stdassay_methods_return_the_callers_own_class(call):
+    """These are annotated `Self`; that is only true if they build via `self.__class__`.
+
+    They used to be annotated with the abstract `StdAssay`, which forced every
+    caller downstream to widen — that is what put `Assay | StdAssay` where
+    `Shanuz` wanted `Assay | Assay5` and produced four of the errors this change
+    cleared. `Self` is the accurate type *because* of the property asserted
+    here; hardcode `Assay5(...)` in any one of these and the annotation becomes
+    a promise the code does not keep, with nothing else in the suite noticing.
+    """
+    derived = _derived_from(_obj().assays["RNA"])
+    assert type(call(derived)) is _DerivedAssay
+
+
+def test_merge_also_returns_the_callers_own_class():
+    a, b = _obj(tag="a").assays["RNA"], _obj(tag="b").assays["RNA"]
+    merged = _derived_from(a).merge(_derived_from(b))
+    assert type(merged) is _DerivedAssay


### PR DESCRIPTION
The object-model modules — `shanuz.py`, `assay5.py`, `reduction.py`, `spatial/fov.py` — carried 14 of the repo's 60 advisory mypy errors. Two of them were pointing at code that could not work.

## The two real defects

**`run_pca` on an unscaled Assay5 always raised.** `_get_scaled_data` chose its fallback layer with

```python
data = assay_obj.layers.get("data") or assay_obj.layers.get("counts")
```

`or` evaluates `bool()` on its left operand, and scipy refuses to answer for any matrix with more than one entry. So the fallback raised `ValueError: The truth value of an array with more than one element is ambiguous` on **every call that reached it** — which is every `run_pca` or `run_ica` on a v5 object that had not been through `scale_data()`. The v3 path reads `assay_obj.data` directly and never had the bug, so the two architectures silently disagreed about whether an unscaled object could be reduced at all.

Reproduced before the fix, and after it the v5 fallback returns **bit-identical** embeddings to the v3 one it mirrors — which is the assertion, rather than a recorded number: the v3 path is the reference for what the v5 fallback was always meant to do.

**Merging across assay classes died mid-flight.** `Assay` keeps its cells in `_cell_names`, `Assay5` in `_all_cell_names`, so `Shanuz.merge` reached for whichever the other did not have:

```
AttributeError: 'Assay' object has no attribute '_all_cell_names'
```

— from inside a method the caller never named, after the cell names and metadata had already been concatenated. It now raises a `TypeError` naming the assay and both classes and pointing at `create_shanuz_object(..., use_v5=)`. Merging assays of the same class is unaffected, in both directions.

## The typing

`StdAssay`'s `join_layers`, `split_layers`, `cast_assay`, `subset`, `rename_cells`, `merge` and `_copy` were annotated `-> "StdAssay"` while every one of them builds its result from `self.__class__`. An `Assay5` went in and something typed as an ABC came out, so every caller downstream had to widen — that is what put `dict[str, Assay | StdAssay]` where `Shanuz` wanted `dict[str, Assay | Assay5]` and produced four of the 14. `Self` is both accurate and what the code already did.

The rest:

- `create_shanuz_object` keeps a narrowly-typed name per branch and widens once at the end — the two classes hold their cells in differently-named slots, so no single type makes both reads valid.
- `_get_scaled_data` and `cast_assay` route through the existing `_sparse.as_dense` rather than hand-branching on `sp.issparse`, four sites collapsing to one idiom.
- Two `sp.issparse` branches at the `run_pca` / `run_ica` call sites are gone: the function they guard is annotated `-> np.ndarray` and every branch of it returns dense, so they could not run.
- `create_fov` annotates its `boundary` as the `BoundaryType` union the FOV actually stores.
- `_calc_n_for_assay5` is removed. `create_shanuz_object` dispatched on `hasattr(assay_obj, "calc_n")`, which both classes satisfy, so it was unreachable — a second implementation of the same naming that derived the `nCount_<ASSAY>` suffix from the assay's *key* rather than the `assay` argument, and hardcoded `nCount_RNA` when there was no default layer. It agrees with the live path for an ordinary RNA object, which is why nothing had reason to look at it.

## The guard

`tests/test_object_model_typing.py` (11 tests). It does **not** assert a mypy count — mypy is advisory here (`|| true`) and its total drifts 81–85 across CI legs as each resolves its own dependency versions, so a count assertion would go red on an unrelated cause. What it pins is behaviour, including the runtime property that makes `Self` true: a subclass gets its own class back from all seven methods. Hardcode `Assay5(...)` in any of them and the annotation becomes a promise the code does not keep, with nothing else in the suite noticing.

Mutation-tested; each caught by the intended guard:

| mutation | caught by |
|---|---|
| merge guard removed | both mixed-class merge tests |
| `or` fallback restored | unscaled-Assay5 `run_pca` |
| fallback prefers `counts` over `data` | unscaled-Assay5 `run_pca` |
| `subset` hardcodes `Assay5(...)` | subclass test — `subset` |
| `_copy` hardcodes `Assay5(...)` | subclass tests — `_copy`, `rename_cells`, `cast_assay`, `split_layers` |

A sixth mutation modelling the removed `calc_n` fallback was **not** caught, and on investigation it should not have been: the fallback's column names coincide with the live path's for an ordinary RNA object, so there was nothing to discriminate. The test I had written for it asserted a property `tests/test_seurat.py` already covers, so it was dropped rather than kept as decoration — and the code comment claiming the fallback "would have been wrong" was corrected to say only what is demonstrable.

## Verification

| | before | after |
|---|---|---|
| `mypy shanuz` | 60 | **46** |
| … in `shanuz.py` / `assay5.py` / `reduction.py` / `spatial/fov.py` | 14 | **0** |
| `ruff check shanuz` | 51 | 51 |
| `ruff check .` | 201 | 201 |
| suite | 843 / 25 skipped | **854** / 25 skipped |

The 46 that remain are outside the object model: **40 in `datasets.py`**, all one repeated idiom (a `cache_dir: Optional[str]` parameter reassigned to a `Path`), and six spread over plotting, mixscape, multiseq, sctransform, preprocessing, module_score and integration. No new unused-import or unused-variable findings — the nine in these four files are identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)