### PR TITLE
fix(reduction): label loadings with the features actually used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,44 @@ on `main`; none of it is on PyPI.
 
 ### Fixed
 
+- **A reduction that could not use every feature you asked for labelled its
+  loadings with the features you asked for anyway.** `_get_scaled_data` filtered
+  the request down to what the layer carried and returned only the matrix, so
+  `run_pca` stored *n* names against fewer than *n* rows and every row below the
+  first dropped feature answered to the wrong gene. `viz_dim_loadings` and
+  `dim_heatmap` read those names straight onto the axis, and `jack_straw` handed
+  each per-feature p-value to its neighbour. Nothing raised; every number was
+  individually correct. Seurat's `PrepDR5` drops the same features but **warns
+  naming them**, and takes its rownames from the subset matrix so the labels
+  cannot drift from the rows. Both halves are ported: the drop now warns with the
+  gene names (`RuntimeWarning`, first 20 named then a count), requesting nothing
+  the layer holds is an error rather than an empty matrix, and `run_pca`,
+  `run_spca`, `run_ica` and `jack_straw` all take back the list that labels the
+  rows they got. On the ordinary path — PBMC 3k, 2,000 variable features, nothing
+  dropped — embeddings and loadings are **bit-identical** to before.
+- **`run_pca` on a v3 `Assay` that had been through `scale_data()` read the
+  wrong genes, or crashed.** `Assay.scale_data` is a bare ndarray holding only
+  the scaled subset — the variable features, by default — with no record of
+  *which* subset; R's slot is a matrix and carries its own rownames. Four places
+  invented the missing labels, differently: `_get_scaled_data` indexed the layer
+  by each gene's position in the *assay*, `features("scale_data")` returned the
+  assay's leading *n* features, `subset()` discarded the layer whenever it was
+  not full height (i.e. always), and `mapping._scaled_feature_names` returned the
+  full feature list. The first either raised `IndexError` or returned another
+  gene's row, deterministically, on the standard workflow. `Assay` now carries
+  `_scaled_features` alongside `scale_data`, mirroring `Assay5`; the constructor
+  refuses to guess labels for a subset rather than inventing them, `subset()`
+  subsets the layer by name, and the v3 and v5 paths now return **identical**
+  scaled matrices.
+- **Integration anchors intersected the feature set against the wrong list.**
+  `_integration_features` filtered against the assay's full feature list — while
+  its own comment claimed it checked "scale/data" — and `_anchor_feature_matrix`
+  filtered against the scaled layer, so a feature one object had never scaled
+  survived the first filter and was dropped by the second, **in that object
+  alone**. The reference and query matrices are multiplied row-for-row, so that
+  is either a shape crash or two matrices describing different genes. The
+  intersection is now taken against the layer the anchors are built from, and
+  `_anchor_feature_matrix` raises rather than warns if anything is still missing.
 - **`run_pca` on an Assay5 that had not been scaled raised "the truth value of
   an array … is ambiguous".** `_get_scaled_data` chose its fallback layer with
   `layers.get("data") or layers.get("counts")`. `or` evaluates `bool()` on its

--- a/shanuz/anchors.py
+++ b/shanuz/anchors.py
@@ -404,11 +404,26 @@ def _filter_anchors(
 
 
 def _anchor_feature_matrix(obj, features: list[str], layer: str) -> np.ndarray:
-    """Scaled (features × cells) matrix for the shared anchor features."""
-    from .reduction import _get_scaled_data
+    """Scaled (features × cells) matrix for the shared anchor features.
+
+    Every object must return the *same* rows in the same order — the reference
+    and query matrices are compared row-for-row — so a per-object drop here is
+    an error rather than a warning. `_integration_features` intersects against
+    the layer precisely so this cannot fire.
+    """
+    from .reduction import _prep_dr
 
     assay = obj.get_assay()
-    return _get_scaled_data(assay, features, layer)
+    mat, used = _prep_dr(assay, features, layer)
+    if used != list(features):
+        missing = [f for f in features if f not in set(used)]
+        raise ValueError(
+            f"Object is missing {len(missing)} of the {len(features)} anchor "
+            f"features in layer {layer!r} ({', '.join(missing[:10])}"
+            f"{', ...' if len(missing) > 10 else ''}); the per-object matrices "
+            f"would no longer describe the same genes row-for-row."
+        )
+    return mat
 
 
 def _data_matrix(obj, features: list[str]) -> np.ndarray:
@@ -425,7 +440,9 @@ def _data_matrix(obj, features: list[str]) -> np.ndarray:
     return np.asarray(mat).astype(float)
 
 
-def _integration_features(objects, anchor_features: Optional[list[str]]) -> list[str]:
+def _integration_features(
+    objects, anchor_features: Optional[list[str]], layer: str = "scale.data"
+) -> list[str]:
     """The features anchors run on: the caller's, else shared variable features."""
     from .reduction import _default_features
 
@@ -441,12 +458,22 @@ def _integration_features(objects, anchor_features: Optional[list[str]]) -> list
             feat_sets = [set(obj.get_assay().features()) for obj in objects]
             shared_all = set.intersection(*feat_sets)
             common = [f for f in objects[0].get_assay().features() if f in shared_all]
-    # Keep only features present (with scale/data) in every object.
+    # Keep only features every object carries *in the layer the anchors are
+    # built from*. Checking `features()` instead — the assay's full list, which
+    # is what stood here despite the comment — lets a feature through that one
+    # object never scaled. `_anchor_feature_matrix` then drops it from that
+    # object alone, and the reference and query matrices, which are multiplied
+    # together row-for-row, come back describing different genes.
+    from .reduction import _layer_feature_names
+
     for obj in objects:
-        present = set(obj.get_assay().features())
+        present = set(_layer_feature_names(obj.get_assay(), layer))
         common = [f for f in common if f in present]
     if not common:
-        raise ValueError("No shared anchor features across the objects.")
+        raise ValueError(
+            f"No shared anchor features across the objects in layer {layer!r}. "
+            f"Run scale_data() over a common feature set first."
+        )
     return list(common)
 
 
@@ -505,7 +532,7 @@ def find_integration_anchors(
     if not 0 <= reference < len(objects):
         raise IndexError(f"reference index {reference} out of range.")
 
-    features = _integration_features(objects, anchor_features)
+    features = _integration_features(objects, anchor_features, layer)
 
     # Both reductions start from the per-object scale.data. CCA standardizes it
     # per cell inside _cca; reciprocal PCA runs straight on it (Seurat's

--- a/shanuz/assay.py
+++ b/shanuz/assay.py
@@ -25,7 +25,12 @@ class Assay(KeyMixin):
     -----
     counts        : raw counts / TPMs  (features × cells)
     data          : normalised expression (features × cells)
-    scale_data    : scaled expression  (features × cells, dense)
+    scale_data    : scaled expression  (features × cells, dense) — a *subset*
+                    of the features, since ScaleData defaults to the variable
+                    ones. R's slot is a matrix and carries its own rownames;
+                    a bare ndarray does not, so the labels live alongside it in
+                    `_scaled_features` and every read of the layer goes through
+                    `features("scale_data")`.
     assay_orig    : name of original assay this was derived from
     var_features  : list of highly variable feature names
     meta_features : per-feature metadata DataFrame (features × cols)
@@ -44,6 +49,7 @@ class Assay(KeyMixin):
         "_key",
         "_feature_names",
         "_cell_names",
+        "_scaled_features",
     )
 
     def __init__(
@@ -51,6 +57,7 @@ class Assay(KeyMixin):
         counts: Optional[Union[np.ndarray, sp.spmatrix]] = None,
         data: Optional[Union[np.ndarray, sp.spmatrix]] = None,
         scale_data: Optional[np.ndarray] = None,
+        scaled_features: Optional[list[str]] = None,
         feature_names: Optional[list[str]] = None,
         cell_names: Optional[list[str]] = None,
         assay_orig: Optional[str] = None,
@@ -97,6 +104,7 @@ class Assay(KeyMixin):
         self.counts = counts if counts is not None else empty_sparse(n_features, n_cells)
         self.data = data if data is not None else self.counts
         self.scale_data = scale_data if scale_data is not None else empty_dense(0, n_cells)
+        self._scaled_features = self._resolve_scaled_features(scaled_features)
         self.assay_orig = assay_orig
         self.var_features = list(var_features) if var_features else []
         self.meta_features = (
@@ -113,10 +121,38 @@ class Assay(KeyMixin):
     def cells(self) -> list[str]:
         return list(self._cell_names)
 
+    def _resolve_scaled_features(
+        self, scaled_features: Optional[list[str]]
+    ) -> list[str]:
+        """Labels for `scale_data`'s rows, checked against its height.
+
+        Only a full-height (or empty) `scale_data` can be labelled without being
+        told: any other height is a subset, and which subset is not recoverable
+        from the matrix. Refusing to guess is the whole point — the guess that
+        used to stand here took the *first* n features, and ScaleData's subset is
+        the variable ones, which are scattered through the assay.
+        """
+        n_rows = self.scale_data.shape[0]
+        if scaled_features is not None:
+            if len(scaled_features) != n_rows:
+                raise ValueError(
+                    f"scaled_features has {len(scaled_features)} names for "
+                    f"{n_rows} rows of scale_data."
+                )
+            return list(scaled_features)
+        if n_rows == 0:
+            return []
+        if n_rows == len(self._feature_names):
+            return list(self._feature_names)
+        raise ValueError(
+            f"scale_data has {n_rows} rows but the assay has "
+            f"{len(self._feature_names)} features, so it holds a subset — pass "
+            f"`scaled_features=` naming those rows. They cannot be inferred."
+        )
+
     def features(self, layer: Optional[str] = None) -> list[str]:
-        if layer == "scale_data":
-            n = self.scale_data.shape[0]
-            return self._feature_names[:n]
+        if layer in ("scale_data", "scale.data"):
+            return list(self._scaled_features)
         return list(self._feature_names)
 
     # ------------------------------------------------------------------
@@ -126,8 +162,8 @@ class Assay(KeyMixin):
     def get_assay_data(self, layer: str = "data"):
         return self.layer_data(layer)
 
-    def set_assay_data(self, layer: str, new_data) -> None:
-        self._set_layer(layer, new_data)
+    def set_assay_data(self, layer: str, new_data, features: Optional[list[str]] = None) -> None:
+        self._set_layer(layer, new_data, features)
 
     def layer_data(
         self,
@@ -156,13 +192,16 @@ class Assay(KeyMixin):
             raise KeyError(f"Layer '{layer}' not found. Choose from {list(layers)}.")
         return layers[layer]
 
-    def _set_layer(self, layer: str, value) -> None:
+    def _set_layer(self, layer: str, value, features: Optional[list[str]] = None) -> None:
         if layer == "counts":
             self.counts = value
         elif layer == "data":
             self.data = value
-        elif layer == "scale_data":
+        elif layer in ("scale_data", "scale.data"):
             self.scale_data = np.asarray(value)
+            # Relabel with the new matrix, never leave the old names behind: a
+            # stale label list is worse than none, because every reader trusts it.
+            self._scaled_features = self._resolve_scaled_features(features)
         else:
             raise KeyError(f"Unknown layer '{layer}'. Must be counts, data, or scale_data.")
 
@@ -207,6 +246,7 @@ class Assay(KeyMixin):
             counts=self.counts,
             data=self.data,
             scale_data=self.scale_data.copy() if self.scale_data is not None else None,
+            scaled_features=list(self._scaled_features),
             feature_names=list(self._feature_names),
             cell_names=list(self._cell_names),
             assay_orig=self.assay_orig,
@@ -246,16 +286,26 @@ class Assay(KeyMixin):
         new_meta = self.meta_features.iloc[row_idx].copy()
         new_var = [f for f in self.var_features if f in set(new_features)]
 
+        # Subset scale_data by *name*, not by the assay's row indices: it holds
+        # its own subset of features, so `row_idx` addresses a different matrix.
+        # Dropping the layer whenever it was not full-height — which is what
+        # stood here, and which is every assay ScaleData has touched — silently
+        # cost the subset its scaled values.
         sd = self.scale_data
-        if not is_matrix_empty(sd) and sd.shape[0] == len(self._feature_names):
-            new_sd = sd[row_idx, :][:, col_idx]
-        else:
+        if is_matrix_empty(sd):
             new_sd = empty_dense(0, len(new_cells))
+            new_scaled = []
+        else:
+            keep = set(new_features)
+            sd_rows = [i for i, f in enumerate(self._scaled_features) if f in keep]
+            new_sd = sd[sd_rows, :][:, col_idx]
+            new_scaled = [self._scaled_features[i] for i in sd_rows]
 
         return Assay(
             counts=_sub(self.counts),
             data=_sub(self.data),
             scale_data=new_sd,
+            scaled_features=new_scaled,
             feature_names=new_features,
             cell_names=new_cells,
             assay_orig=self.assay_orig,

--- a/shanuz/jackstraw.py
+++ b/shanuz/jackstraw.py
@@ -50,7 +50,7 @@ class JackStrawData:
 def _scaled_matrix_for_reduction(seurat, dr, layer: str):
     """Return (features_used × cells) scaled matrix in the reduction's feature
     order, plus the feature-name list. Falls back to the assay's scale.data."""
-    from .reduction import _get_scaled_data
+    from .reduction import _prep_dr
 
     assay_obj = seurat.assays[dr.assay_used or seurat.active_assay]
     features = list(dr.features())
@@ -61,7 +61,10 @@ def _scaled_matrix_for_reduction(seurat, dr, layer: str):
             assay_obj.variable_features if isinstance(assay_obj, Assay5)
             else assay_obj.var_features
         ) or assay_obj.features()
-    mat = _get_scaled_data(assay_obj, features, layer)
+    # Take back the list `_prep_dr` actually filled: returning the *requested*
+    # names against a shorter matrix hands every per-feature p-value below the
+    # first dropped gene to the wrong gene.
+    mat, features = _prep_dr(assay_obj, features, layer)
     # Own the buffer: jack_straw scrambles rows in place while building the null,
     # and must never disturb the layer it read them from.
     return np.array(mat, dtype=float, copy=True), features

--- a/shanuz/mapping.py
+++ b/shanuz/mapping.py
@@ -280,5 +280,10 @@ def _scaled_feature_names(assay, layer: str) -> list[str]:
 
     if isinstance(assay, Assay5):
         return list(assay._layer_features.get(layer, assay._all_feature_names))
-    # Classic Assay v3 stores scale_data over the assay's feature list.
+    # Classic Assay v3 keeps one scaled matrix, labelled by `_scaled_features`.
+    # Returning the assay's full feature list — which is what stood here — claims
+    # the query carries every reference feature scaled, so nothing is ever
+    # dropped and the loadings are subset against the wrong rows.
+    if layer in ("scale_data", "scale.data"):
+        return assay.features("scale_data")
     return list(assay._feature_names)

--- a/shanuz/preprocessing.py
+++ b/shanuz/preprocessing.py
@@ -68,20 +68,19 @@ def _get_layer(assay_obj, layer: Optional[str]):
             return assay_obj.data
 
 
-def _set_layer(assay_obj, layer: str, value) -> None:
+def _set_layer(assay_obj, layer: str, value, features: Optional[list[str]] = None) -> None:
     """Store a data matrix in an assay."""
     from .assay import Assay
     from .assay5 import Assay5
 
     if isinstance(assay_obj, Assay5):
-        assay_obj.set_layer_data(layer, value)
+        assay_obj.set_layer_data(layer, value, feature_names=features)
+    elif layer == "counts":
+        assay_obj.counts = value
+    elif layer in ("scale_data", "scale.data"):
+        assay_obj._set_layer("scale_data", value, features)
     else:
-        if layer == "counts":
-            assay_obj.counts = value
-        elif layer in ("scale_data", "scale.data"):
-            assay_obj.scale_data = np.asarray(value)
-        else:
-            assay_obj.data = value
+        assay_obj.data = value
 
 
 # ------------------------------------------------------------------
@@ -769,7 +768,10 @@ def scale_data(
         # Store which features are scaled (needed for PCA)
         assay_obj._scaled_features = features_present
     else:
-        assay_obj.scale_data = sub
+        # Through `_set_layer` so the row labels are written with the matrix.
+        # Assigning `assay_obj.scale_data` directly leaves `_scaled_features`
+        # describing whatever was there before.
+        assay_obj._set_layer("scale_data", sub, features_present)
     log_shanuz_command(
         seurat, "ScaleData", assay=assay or seurat.active_assay,
         params={"do_center": do_center, "do_scale": do_scale,

--- a/shanuz/reduction.py
+++ b/shanuz/reduction.py
@@ -4,6 +4,7 @@ Mirrors Seurat's RunPCA() / RunSPCA() / RunICA() / RunTSNE().
 """
 from __future__ import annotations
 
+import warnings
 from typing import Optional
 
 import numpy as np
@@ -11,6 +12,12 @@ import scipy.sparse as sp
 
 from .command import log_shanuz_command
 from .dimreduc import DimReduc
+
+# How many dropped features the warning spells out before summarising the rest.
+# Seurat names every one; on a query missing a few thousand of a reference's
+# variable features that is a wall of text nobody reads, and the count is the
+# part that tells you whether to worry.
+_MAX_NAMED_FEATURES = 20
 
 
 def _truncated_svd(mat, n_components: int, seed: int):
@@ -90,8 +97,10 @@ def run_pca(
 
     features = _default_features(assay_obj, features)
 
-    # Get scale.data for the selected features
-    scaled = _get_scaled_data(assay_obj, features, layer)
+    # Get scale.data for the selected features. `used` is what the layer
+    # actually carried; it is what labels the loadings below, because a feature
+    # the layer does not have has no row to be labelled.
+    scaled, used = _prep_dr(assay_obj, features, layer)
     # scaled shape: (n_features_selected × n_cells)
     # irlba is handed t(scale.data), so transpose to (n_cells × n_features)
     data_t = scaled.T  # (cells × features)
@@ -116,7 +125,7 @@ def run_pca(
         stdev=stdev,
         key=reduction_key,
         cell_names=cells,
-        feature_names=list(features),
+        feature_names=used,
     )
 
     seurat.reductions[reduction_name] = dr
@@ -184,10 +193,11 @@ def run_spca(
 
     features = _default_features(assay_obj, features)
 
-    # `_get_scaled_data` densifies on the way out, so there is nothing left to
-    # convert here — the `sp.issparse` branch that used to stand between these
-    # two lines could not run.
-    X = np.asarray(_get_scaled_data(assay_obj, features, layer).T, dtype=float)
+    # `_prep_dr` densifies on the way out, so there is nothing left to convert
+    # here — the `sp.issparse` branch that used to stand between these two lines
+    # could not run.
+    scaled, used = _prep_dr(assay_obj, features, layer)
+    X = np.asarray(scaled.T, dtype=float)
     n_cells, n_features = X.shape
 
     G = seurat.graphs[graph].tocsr()
@@ -222,7 +232,7 @@ def run_spca(
         stdev=stdev,
         key=reduction_key,
         cell_names=seurat.cell_names(),
-        feature_names=list(features),
+        feature_names=used,
         misc={"spca_graph": graph, "eigenvalues": eigenvalues},
     )
 
@@ -251,7 +261,7 @@ def run_ica(
 
     features = _default_features(assay_obj, features)
 
-    scaled = _get_scaled_data(assay_obj, features, layer)  # (features × cells)
+    scaled, used = _prep_dr(assay_obj, features, layer)  # (features × cells)
     data_t = scaled.T  # (cells × features) — already dense, see run_pca
 
     nics = min(nics, min(data_t.shape))
@@ -267,7 +277,7 @@ def run_ica(
         assay_used=assay_name,
         key=reduction_key,
         cell_names=cells,
-        feature_names=list(features),
+        feature_names=used,
     )
 
 
@@ -350,51 +360,119 @@ def _flip_signs(vectors: np.ndarray) -> np.ndarray:
     return vectors * signs
 
 
-def _get_scaled_data(assay_obj, features: list[str], layer: str) -> np.ndarray:
-    """Extract scaled data for the given features as a (features × cells) array."""
+def _layer_matrix_and_features(assay_obj, layer: str):
+    """``(matrix, row labels, centre?)`` for ``layer``, or the fallback if absent.
+
+    Each layer is labelled by its *own* feature list. Only ``scale.data`` holds a
+    subset — ScaleData defaults to the variable features — so reading any other
+    layer's rows through the scaled names, which is what a single shared name
+    list amounts to, returns the wrong genes without raising.
+
+    The third element says whether the caller must centre: ``scale.data`` is
+    already centred, and the ``data``/``counts`` fallback is not.
+    """
     from .assay5 import Assay5
-    from ._sparse import as_dense, is_matrix_empty
+    from ._sparse import is_matrix_empty
 
     if isinstance(assay_obj, Assay5):
         if layer in assay_obj.layers:
-            mat = assay_obj.layers[layer]
-            # scale.data may be stored for a subset of features
-            scaled_features = getattr(assay_obj, "_scaled_features", assay_obj._all_feature_names)
-            feat_idx_map = {f: i for i, f in enumerate(scaled_features)}
-            valid = [f for f in features if f in feat_idx_map]
-            idx = [feat_idx_map[f] for f in valid]
-            return as_dense(mat[idx, :]).astype(float)
-        else:
-            # Fall back to log-normalized data. Selected with an explicit
-            # `is None` rather than `a or b`: `or` evaluates `bool(a)`, and
-            # scipy raises "truth value of an array ... is ambiguous" for any
-            # matrix with more than one entry — so this fallback raised on
-            # every call that reached it, which is every `run_pca` on an
-            # Assay5 that had not been through `scale_data()`.
-            data = assay_obj.layers.get("data")
-            if data is None:
-                data = assay_obj.layers.get("counts")
-            if data is None:
-                raise ValueError(
-                    f"assay has no {layer!r}, 'data' or 'counts' layer to draw "
-                    f"from; run normalize_data() and scale_data() first."
-                )
-            all_feats = assay_obj._all_feature_names
-            feat_idx = [all_feats.index(f) for f in features if f in all_feats]
-            sub = as_dense(data[feat_idx, :]).astype(float)
-            # Center in-place
-            sub -= sub.mean(axis=1, keepdims=True)
-            return sub
-    else:
-        if not is_matrix_empty(assay_obj.scale_data):
-            sd = assay_obj.scale_data
-            all_feats = assay_obj._feature_names
-            feat_idx = [all_feats.index(f) for f in features if f in all_feats]
-            return as_dense(sd[feat_idx, :]).astype(float)
-        else:
-            # Fall back to data
-            all_feats = assay_obj._feature_names
-            feat_idx = [all_feats.index(f) for f in features if f in all_feats]
-            sub = as_dense(assay_obj.data[feat_idx, :]).astype(float)
-            sub -= sub.mean(axis=1, keepdims=True)
-            return sub
+            names = assay_obj._layer_features.get(layer, assay_obj._all_feature_names)
+            return assay_obj.layers[layer], list(names), False
+        # Fall back to log-normalized data. Selected with an explicit `is None`
+        # rather than `a or b`: `or` evaluates `bool(a)`, and scipy raises
+        # "truth value of an array ... is ambiguous" for any matrix with more
+        # than one entry — so this fallback raised on every call that reached
+        # it, which is every `run_pca` on an Assay5 that had not been through
+        # `scale_data()`.
+        for name in ("data", "counts"):
+            mat = assay_obj.layers.get(name)
+            if mat is not None:
+                names = assay_obj._layer_features.get(name, assay_obj._all_feature_names)
+                return mat, list(names), True
+        raise ValueError(
+            f"assay has no {layer!r}, 'data' or 'counts' layer to draw from; "
+            f"run normalize_data() and scale_data() first."
+        )
+
+    if not is_matrix_empty(assay_obj.scale_data):
+        # `features("scale_data")` — not the assay's full feature list, which is
+        # what stood here. scale_data holds only the scaled subset, so indexing
+        # it by a gene's position in the *assay* reads a different gene's row,
+        # or runs off the end of a matrix a fraction of the height.
+        return assay_obj.scale_data, assay_obj.features("scale_data"), False
+    return assay_obj.data, list(assay_obj._feature_names), True
+
+
+def _layer_feature_names(assay_obj, layer: str) -> list[str]:
+    """The features a reduction on ``layer`` could actually draw on."""
+    return _layer_matrix_and_features(assay_obj, layer)[1]
+
+
+def _select_features(
+    names: list[str],
+    features: list[str],
+    layer: str,
+    action: str = "reduction",
+    stacklevel: int = 3,
+) -> tuple[list[int], list[str]]:
+    """``(row indices, labels)`` for ``features`` within ``names``.
+
+    Mirrors Seurat's ``PrepDR5``: a feature the layer does not carry is dropped
+    *with a warning that names it*, and none at all is an error. Both halves are
+    the point — a caller that gets back a shorter matrix and no signal has no way
+    to tell, and every row below the first drop then answers to the wrong gene.
+
+    ``stacklevel`` counts out to the *user's* call. It is a parameter rather than
+    a constant because the two callers sit at different depths, and a warning
+    that points at a line inside this module tells the reader nothing.
+    """
+    pos = {f: i for i, f in enumerate(names)}
+    kept = [f for f in features if f in pos]
+    if not kept:
+        raise ValueError(
+            f"None of the {len(features)} requested features are present in "
+            f"{layer!r}; nothing to {action}. Run scale_data() over them first."
+        )
+    if len(kept) < len(features):
+        missing = [f for f in features if f not in pos]
+        shown = ", ".join(missing[:_MAX_NAMED_FEATURES])
+        if len(missing) > _MAX_NAMED_FEATURES:
+            shown += f", ... ({len(missing) - _MAX_NAMED_FEATURES} more)"
+        warnings.warn(
+            f"The following {len(missing)} features are not present in "
+            f"{layer!r}; running the {action} without them: {shown}",
+            RuntimeWarning,
+            stacklevel=stacklevel,
+        )
+    return [pos[f] for f in kept], kept
+
+
+def _prep_dr(
+    assay_obj, features: list[str], layer: str
+) -> tuple[np.ndarray, list[str]]:
+    """``(features × cells matrix, the features it actually holds)``.
+
+    The caller is handed back the list that labels the rows it got. Returning
+    only the matrix — which is what :func:`_get_scaled_data` did — leaves every
+    caller to assume its own *request* labels the result, so a dropped feature
+    shifts every row below it onto the wrong gene name in the stored loadings.
+    """
+    from ._sparse import as_dense
+
+    mat, names, needs_centering = _layer_matrix_and_features(assay_obj, layer)
+    idx, kept = _select_features(names, features, layer, stacklevel=4)
+
+    sub = as_dense(mat[idx, :]).astype(float)
+    if needs_centering:
+        sub -= sub.mean(axis=1, keepdims=True)
+    return sub, kept
+
+
+def _get_scaled_data(assay_obj, features: list[str], layer: str) -> np.ndarray:
+    """Extract scaled data for the given features as a (features × cells) array.
+
+    Thin wrapper over :func:`_prep_dr` for callers that genuinely only want the
+    numbers. Anything that goes on to *label* the rows must use `_prep_dr` and
+    take the feature list with them.
+    """
+    return _prep_dr(assay_obj, features, layer)[0]

--- a/shanuz/sketch.py
+++ b/shanuz/sketch.py
@@ -62,7 +62,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from .dimreduc import DimReduc
-from .reduction import _default_features, _get_scaled_data
+from .reduction import _default_features, _get_scaled_data, _layer_feature_names
 
 
 # ----------------------------------------------------------------------
@@ -351,31 +351,25 @@ _EXACT_NDIMS = 50
 def _leverage_matrix(assay_obj, features: list[str], layer: str):
     """The ``(features × cells)`` matrix to score, sparse if the layer is sparse."""
     from .assay5 import Assay5
+    from .reduction import _select_features
 
+    # Which names label the layer's rows is `_layer_feature_names`'s business —
+    # only `scale.data` holds a subset, and this function used to carry its own
+    # copy of that rule. The filtering and the dropped-feature warning come from
+    # `_select_features` for the same reason: two implementations of one rule
+    # drift, and the drift is silent by construction.
     if isinstance(assay_obj, Assay5) and layer in assay_obj.layers:
         mat = assay_obj.layers[layer]
-        # Only scale.data is stored against a feature subset; every other layer is
-        # indexed by the assay's full feature list. Mixing the two silently reads
-        # the wrong rows.
-        stored = assay_obj._all_feature_names
-        if layer == "scale.data":
-            stored = getattr(assay_obj, "_scaled_features", None) or stored
-        pos = {f: i for i, f in enumerate(stored)}
-        idx = [pos[f] for f in features if f in pos]
+        stored = _layer_feature_names(assay_obj, layer)
     elif not isinstance(assay_obj, Assay5) and layer in ("data", "counts"):
         mat = assay_obj.data if layer == "data" else assay_obj.counts
-        pos = {f: i for i, f in enumerate(assay_obj._feature_names)}
-        idx = [pos[f] for f in features if f in pos]
+        stored = list(assay_obj._feature_names)
     else:
         # Anything else (notably "scale.data") goes through the shared accessor,
         # which handles the fallbacks and returns dense.
         return np.asarray(_get_scaled_data(assay_obj, features, layer), dtype=float)
 
-    if not idx:
-        raise ValueError(
-            f"None of the {len(features)} requested features are present in layer "
-            f"{layer!r}; nothing to score."
-        )
+    idx, _ = _select_features(stored, features, layer, action="score")
     if sp.issparse(mat):
         return sp.csr_matrix(mat)[idx, :].astype(float)
     return np.asarray(mat, dtype=float)[idx, :]

--- a/tests/test_reduction_feature_selection.py
+++ b/tests/test_reduction_feature_selection.py
@@ -1,0 +1,323 @@
+"""Which features a reduction ran on, and which names label its rows.
+
+`_get_scaled_data` filtered the requested features down to the ones the layer
+carried and returned only the matrix. Every caller then labelled that matrix with
+its own *request*, so a dropped feature shifted every row below it onto the wrong
+gene: `run_pca` stored 2,000 names against 1,980 loadings, `viz_dim_loadings`
+drew the wrong gene on every bar, and `jack_straw` handed each p-value to its
+neighbour. Nothing raised, and the numbers were all individually correct.
+
+Seurat's `PrepDR5` does the same subsetting but warns naming the excluded
+features, and its loadings take their rownames from the subset matrix, so the
+labels cannot drift from the rows.
+
+The v3 path had a second problem underneath: `Assay.scale_data` is a bare ndarray
+holding only the scaled subset, with no record of which subset. Four places
+guessed differently — `features("scale_data")` took the first n features,
+`subset()` threw the layer away, `_scaled_feature_names` returned the full list,
+and `_get_scaled_data` indexed it by position in the assay. The last one either
+raised `IndexError` or read whichever gene happened to sit at that row.
+"""
+import warnings
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from shanuz import (
+    create_shanuz_object,
+    find_variable_features,
+    normalize_data,
+    run_ica,
+    run_pca,
+    scale_data,
+)
+from shanuz.assay import Assay
+from shanuz.jackstraw import _scaled_matrix_for_reduction
+
+N_GENES, N_CELLS, N_VAR = 60, 40, 20
+
+
+def _obj(use_v5=True, seed=0, tag="c"):
+    rng = np.random.default_rng(seed)
+    counts = sp.csc_matrix(rng.poisson(3.0, size=(N_GENES, N_CELLS)).astype(float))
+    obj = create_shanuz_object(
+        counts=counts,
+        assay="RNA",
+        feature_names=[f"g{i}" for i in range(N_GENES)],
+        cell_names=[f"{tag}{j}" for j in range(N_CELLS)],
+        use_v5=use_v5,
+    )
+    normalize_data(obj)
+    find_variable_features(obj, nfeatures=N_VAR)
+    scale_data(obj)
+    return obj
+
+
+def _interleaved(obj):
+    """(requested, present) where the absent features sit *between* the present ones.
+
+    Interleaving is the point. A run that appends the dropped features to the end
+    of the list would still label row 0 correctly; scattering them means the first
+    wrong label lands on the very first row.
+
+    `present` is reversed out of the layer's own order so that "the features the
+    caller asked for" and "the order the layer stores them in" are different
+    lists. A filter that walks the layer instead of the request returns the same
+    genes and the same count, and only the ordering gives it away.
+    """
+    assay = obj.assays["RNA"]
+    scaled = list(assay.features("scale_data")) if isinstance(assay, Assay) else list(
+        assay._scaled_features
+    )
+    absent = [f for f in assay.features() if f not in set(scaled)]
+    present = scaled[:10][::-1]
+    asked = [x for pair in zip(absent[:10], present) for x in pair]
+    return asked, present
+
+
+# ---------------------------------------------------------------------------
+# 1. The drop is announced, and it names what it dropped
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("use_v5", [True, False])
+def test_run_pca_warns_and_names_the_features_it_could_not_use(use_v5):
+    obj = _obj(use_v5=use_v5)
+    asked, _ = _interleaved(obj)
+
+    with pytest.warns(RuntimeWarning) as record:
+        run_pca(obj, n_pcs=3, features=asked)
+
+    message = str(record[0].message)
+    assert "10 features" in message, "the count is the part that says whether to worry"
+    assert "scale.data" in message, "the layer names where to look"
+    dropped = [f for f in asked if f not in set(obj.reductions["pca"].features())]
+    assert all(f in message for f in dropped), (
+        "a warning that does not name the genes leaves the user to diff two "
+        "lists by hand, which is exactly the work the warning exists to save"
+    )
+
+
+def test_no_warning_when_every_requested_feature_is_present():
+    """The guard must not cry wolf on the ordinary path."""
+    obj = _obj()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        run_pca(obj, n_pcs=3)
+
+
+def test_requesting_nothing_the_layer_has_is_an_error_not_an_empty_matrix():
+    obj = _obj()
+    absent = [f for f in obj.assays["RNA"].features()
+              if f not in set(obj.assays["RNA"]._scaled_features)]
+    with pytest.raises(ValueError, match="None of the"):
+        run_pca(obj, n_pcs=3, features=absent)
+
+
+# ---------------------------------------------------------------------------
+# 2. The labels match the rows — the defect that produced wrong answers
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("use_v5", [True, False])
+def test_pca_loadings_are_labelled_with_the_features_actually_used(use_v5):
+    """Row *i* of the loadings must be the gene `features()[i]` says it is.
+
+    Checked two ways, because they fail to different mutations: the name list
+    must equal the surviving features (a stored `list(features)` fails this),
+    and the matrix must equal a run that asked only for those (a filter that
+    keeps the right count in the wrong order fails this one).
+    """
+    obj = _obj(use_v5=use_v5)
+    asked, present = _interleaved(obj)
+
+    with pytest.warns(RuntimeWarning):
+        run_pca(obj, n_pcs=3, features=asked)
+    dr = obj.reductions["pca"]
+
+    assert dr.features() == present
+    assert dr.feature_loadings.shape[0] == len(dr.features()), (
+        "names and rows must be the same length — DimReduc does not check this, "
+        "which is how the mismatch survived"
+    )
+
+    clean = _obj(use_v5=use_v5)
+    run_pca(clean, n_pcs=3, features=present)
+    np.testing.assert_allclose(
+        dr.feature_loadings,
+        clean.reductions["pca"].feature_loadings,
+        rtol=1e-12,
+        atol=1e-12,
+        err_msg="asking for extra absent features changed which rows were used",
+    )
+
+
+def test_ica_labels_its_loadings_too():
+    """`run_ica` stored `list(features)` from the same copied line."""
+    obj = _obj()
+    asked, present = _interleaved(obj)
+    with pytest.warns(RuntimeWarning):
+        run_ica(obj, nics=3, features=asked)
+    dr = obj.reductions["ica"]
+    assert dr.features() == present
+    assert dr.feature_loadings.shape[0] == len(dr.features())
+
+
+def test_jackstraw_gets_back_the_features_the_matrix_holds():
+    """The p-value for gene *i* is only about gene *i* if these agree.
+
+    `_scaled_matrix_for_reduction` returned `dr.features()` unchanged next to a
+    matrix `_get_scaled_data` had already filtered, so the two disagreed exactly
+    when the reduction's feature list held something the layer did not.
+    """
+    obj = _obj()
+    asked, present = _interleaved(obj)
+    with pytest.warns(RuntimeWarning):
+        run_pca(obj, n_pcs=3, features=asked)
+    dr = obj.reductions["pca"]
+    # Put the absent features back on the reduction, as a hand-built or
+    # round-tripped DimReduc may carry them.
+    dr._feature_names = list(asked)
+
+    with pytest.warns(RuntimeWarning):
+        mat, features = _scaled_matrix_for_reduction(obj, dr, "scale.data")
+    assert features == present
+    assert mat.shape[0] == len(features)
+
+
+# ---------------------------------------------------------------------------
+# 3. The v3 Assay's scale_data now knows its own rows
+# ---------------------------------------------------------------------------
+
+def test_v3_scale_data_reports_the_features_it_holds():
+    """Not the assay's first n features, which is what stood here.
+
+    ScaleData's subset is the *variable* features, scattered through the assay,
+    so `_feature_names[:n]` was right only when the variable features happened to
+    be the leading ones — never, on real data.
+    """
+    obj = _obj(use_v5=False)
+    assay = obj.assays["RNA"]
+    labels = assay.features("scale_data")
+
+    assert len(labels) == assay.scale_data.shape[0]
+    assert set(labels) == set(assay.var_features)
+    assert labels != assay.features()[: len(labels)], (
+        "fixture is degenerate: the variable features are the leading ones, so "
+        "the old guess would pass"
+    )
+
+
+def test_v3_and_v5_read_identical_rows_out_of_scale_data():
+    """The v3 path indexed a 20-row matrix by positions in a 60-gene list.
+
+    Depending on where the variable features landed that either raised
+    `IndexError` or returned another gene's row. Checked against the v5 path
+    rather than a recorded matrix: the two architectures scale the same numbers,
+    so agreement is the property, and v5 was the one that already worked.
+    """
+    from shanuz.reduction import _get_scaled_data
+
+    v5, v3 = _obj(use_v5=True), _obj(use_v5=False)
+    feats = list(v5.assays["RNA"]._scaled_features)
+
+    m5 = _get_scaled_data(v5.assays["RNA"], feats, "scale.data")
+    m3 = _get_scaled_data(v3.assays["RNA"], feats, "scale.data")
+    np.testing.assert_allclose(m3, m5, rtol=1e-12, atol=1e-12)
+
+
+def test_v3_subset_keeps_the_scaled_layer():
+    """`subset` dropped scale_data unless it was full height — i.e. always.
+
+    It subset every other layer by the assay's row indices, which address a
+    different matrix than scale_data's, so throwing it away was the only safe
+    thing to do without labels. With labels it can be subset by name.
+    """
+    obj = _obj(use_v5=False)
+    assay = obj.assays["RNA"]
+    scaled = list(assay.features("scale_data"))
+    keep = scaled[:5] + [f for f in assay.features() if f not in set(scaled)][:5]
+
+    sub = assay.subset(features=keep)
+    assert sub.features("scale_data") == scaled[:5]
+    assert sub.scale_data.shape[0] == 5
+    rows = [scaled.index(f) for f in scaled[:5]]
+    np.testing.assert_allclose(sub.scale_data, assay.scale_data[rows, :])
+
+
+def test_v3_assay_refuses_to_invent_labels_for_a_subset_scale_data():
+    """A subset scale_data with no names is unrecoverable — say so, don't guess."""
+    names = [f"g{i}" for i in range(10)]
+    cells = [f"c{j}" for j in range(4)]
+    with pytest.raises(ValueError, match="holds a subset"):
+        Assay(
+            counts=sp.csc_matrix(np.ones((10, 4))),
+            scale_data=np.zeros((3, 4)),
+            feature_names=names,
+            cell_names=cells,
+        )
+
+    with pytest.raises(ValueError, match="3 names for 2 rows"):
+        Assay(
+            counts=sp.csc_matrix(np.ones((10, 4))),
+            scale_data=np.zeros((2, 4)),
+            scaled_features=names[:3],
+            feature_names=names,
+            cell_names=cells,
+        )
+
+
+def test_v3_relabels_scale_data_when_the_layer_is_replaced():
+    """Stale labels are worse than none: every reader trusts them."""
+    obj = _obj(use_v5=False)
+    assay = obj.assays["RNA"]
+    assert len(assay.features("scale_data")) == N_VAR
+
+    new_feats = assay.features()[:5]
+    assay.set_assay_data("scale_data", np.zeros((5, N_CELLS)), new_feats)
+    assert assay.features("scale_data") == new_feats
+
+
+# ---------------------------------------------------------------------------
+# 4. Anchors: a per-object drop would misalign the matrices, so it cannot happen
+# ---------------------------------------------------------------------------
+
+def test_integration_features_intersects_against_the_layer_not_the_assay():
+    """The reference and query matrices are multiplied row-for-row.
+
+    `_integration_features` filtered against `features()` — the assay's full
+    list — while `_anchor_feature_matrix` filtered against the scaled layer, so a
+    feature one object had never scaled survived the first filter and was dropped
+    by the second, in that object alone. The two matrices then had different
+    heights (a crash) or, with a compensating drop elsewhere, the same height and
+    different genes.
+    """
+    from shanuz.anchors import _anchor_feature_matrix, _integration_features
+
+    a, b = _obj(seed=1, tag="a"), _obj(seed=2, tag="b")
+    # Force the objects to disagree: rescale `b` on a different feature set.
+    b_feats = list(b.assays["RNA"]._scaled_features)[:12]
+    scale_data(b, features=b_feats)
+
+    shared = _integration_features([a, b], None, "scale.data")
+    assert shared, "the two objects do share scaled features"
+    a_scaled = set(a.assays["RNA"]._scaled_features)
+    b_scaled = set(b.assays["RNA"]._scaled_features)
+    assert set(shared) <= a_scaled & b_scaled
+
+    # Nothing is dropped downstream, so the two matrices line up row-for-row.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        ma = _anchor_feature_matrix(a, shared, "scale.data")
+        mb = _anchor_feature_matrix(b, shared, "scale.data")
+    assert ma.shape[0] == mb.shape[0] == len(shared)
+
+
+def test_anchor_matrix_refuses_a_partial_feature_set():
+    """Where a reduction warns, anchors must raise — the rows are paired."""
+    from shanuz.anchors import _anchor_feature_matrix
+
+    a = _obj(seed=1, tag="a")
+    scaled = list(a.assays["RNA"]._scaled_features)
+    absent = [f for f in a.assays["RNA"].features() if f not in set(scaled)][:3]
+    with pytest.raises(ValueError, match="row-for-row"):
+        _anchor_feature_matrix(a, scaled[:5] + absent, "scale.data")


### PR DESCRIPTION
## The defect

`_get_scaled_data` filtered the requested features down to the ones the layer carried and returned **only the matrix**. Every caller then labelled that matrix with its own *request*:

```python
scaled = _get_scaled_data(assay_obj, features, layer)   # possibly fewer rows
...
DimReduc(feature_loadings=loadings, feature_names=list(features))   # full list
```

So `run_pca` stored *n* names against fewer than *n* loadings, and every row below the first dropped feature answered to the wrong gene. `viz_dim_loadings` indexes those names straight onto the bar labels; `dim_heatmap` reads them the same way; `jack_straw` handed each per-feature p-value to its neighbour. Nothing raised, and every number was individually correct — `DimReduc` validates `cell_names` against the embedding rows but has never checked `feature_names` against the loading rows.

Reproduced by asking for 30 genes when only 20 were scaled: `feature_loadings` came back 20 rows, `dr.features()` 30 names.

## What Seurat does

`Seurat:::PrepDR5` drops the same features, but **warns naming them**, and `data.use <- data.use[features.use, ]` means `RunPCA`'s rownames come from the subset matrix — the labels cannot drift from the rows. Verified against Seurat 5.5.1: `Loadings(pca)` is 20 × 5 with rownames from the requested list, never the full one.

Both halves are ported. The drop warns (`RuntimeWarning`, first 20 genes named then a count), requesting nothing the layer holds is now an error, and `run_pca` / `run_spca` / `run_ica` / `jack_straw` all take back the list that labels the rows they got.

## Two more found while reproducing it

**The v3 `Assay`'s `scale_data` had no row identity at all.** It is a bare ndarray holding only the scaled subset — the variable features, by default — where R's slot is a matrix carrying its own rownames. Four places invented the missing labels, differently:

| site | what it assumed |
|---|---|
| `_get_scaled_data` | each gene's position in the **assay** indexes the layer |
| `features("scale_data")` | the layer holds the assay's **leading n** features |
| `subset()` | discard the layer unless full height — i.e. always |
| `mapping._scaled_feature_names` | the layer holds **every** assay feature |

The first is a wrong answer on the standard workflow: `run_pca` after `scale_data()` on a v3 object raised `IndexError: index 55 is out of bounds for axis 0 with size 20`, or, when the variable features happened to sit low enough, returned other genes' rows. `Assay` now carries `_scaled_features` alongside `scale_data`, mirroring `Assay5`, and the constructor **refuses to guess** labels for a subset rather than inventing them. The v3 and v5 paths now return identical scaled matrices (max |diff| 0.0).

**Integration anchors intersected against the wrong list.** `_integration_features` filtered against `obj.get_assay().features()` — despite a comment claiming it checked "scale/data" — while `_anchor_feature_matrix` filtered against the scaled layer. A feature one object had never scaled survived the first filter and was dropped by the second, in that object alone; the reference and query matrices are multiplied row-for-row. The intersection now runs against the layer, and `_anchor_feature_matrix` **raises** rather than warns if anything is still missing, because a per-object drop there is not recoverable.

Also folded `sketch._leverage_matrix`'s private copy of the layer-labelling rule into the shared helper — two implementations of one rule drift, and the drift is silent by construction.

## Verification

- **PBMC 3k, 2,000 variable features, nothing dropped**: embeddings and loadings **bit-identical** to `main` (max |diff| 0.0), same 2,000 feature names in the same order. The ordinary path is untouched; only the broken ones changed.
- **v3 vs v5 scaled matrices**: identical, where v3 previously raised.
- Suite **869 passed, 25 skipped** (was 854 — 15 new tests, no regressions).
- `ruff check shanuz` **51**, `ruff check .` **201**, `mypy shanuz` **46** — all unchanged from `main`; lint findings in the seven touched files are byte-identical before and after.

## Mutation testing

All 12 mutations caught, each by its intended guard:

| mutation | tests failed |
|---|---|
| `run_pca` stores `list(features)` | 2 |
| warning removed entirely | 6 |
| warning drops the gene names | 2 |
| v3 branch labels with the full feature list | 3 |
| `features("scale_data")` guesses the leading *n* | 3 |
| `subset()` discards `scale_data` | 1 |
| constructor guesses labels instead of raising | 1 |
| anchors intersect on the assay again | 1 |
| anchors tolerate a partial set | 1 |
| `run_ica` stores `list(features)` | 1 |
| jackstraw keeps the unfiltered names | 1 |
| filter walks the layer, not the request | 5 |

The last one is why the fixture asks for its features **reversed** out of the layer's order and **interleaved** with absent ones: a filter that walks the layer returns the same genes and the same count, and only the ordering gives it away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)