### PR TITLE
fix(datasets): stop rebinding the data_dir parameter to a Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,21 @@ on `main`; none of it is on PyPI.
 
 ### Fixed
 
+- **`cbmc_citeseq` reported an unrelated error when the species filter matched
+  nothing.** A `species_prefix` that no gene starts with — the wrong one, or a
+  file whose row labels are not prefixed — left every chunk empty and surfaced
+  as scipy's `blocks must be 2-D, and some must be sparse` from `sp.vstack`,
+  which names neither the file nor the prefix that caused it. It now raises a
+  `ValueError` naming both.
+- **The four oldest dataset loaders rebound their `data_dir` parameter to a
+  `Path`.** `pbmc3k`, `pbmc8k`, `cbmc_citeseq` and `xenium_mouse_brain` assigned
+  a `Path` back over a parameter declared `Optional[str]`, which was most of the
+  package's remaining type-checker noise (33 of 44 errors, now 11). They use a
+  local `Path` like the newer loaders alongside them. No behaviour change — but
+  nothing had ever checked that an explicit `data_dir` was honoured at all, so
+  that is now covered, along with the RNA chunk stitching every real
+  `cbmc_citeseq` load depends on and none of the tests reached.
+
 - **The `mvp` statistics were three different quantities under Seurat's
   names.** PR #64 renamed the dispersion path's columns to `mvp.mean`,
   `mvp.dispersion` and `mvp.dispersion.scaled`; the numbers underneath were not

--- a/shanuz/datasets.py
+++ b/shanuz/datasets.py
@@ -45,15 +45,12 @@ def pbmc3k(
     """
     from .io import read_10x
 
-    if data_dir is None:
-        data_dir = Path.home() / ".shanuz_data" / "pbmc3k"
-    else:
-        data_dir = Path(data_dir)
-
-    matrix_dir = data_dir / _PBMC3K_DIR
+    base = (Path(data_dir) if data_dir is not None
+            else Path.home() / ".shanuz_data" / "pbmc3k")
+    matrix_dir = base / _PBMC3K_DIR
 
     if force_download or not (matrix_dir / "matrix.mtx").exists():
-        _download_10x(_PBMC3K_URLS, data_dir, label="PBMC3k", size_mb=24)
+        _download_10x(_PBMC3K_URLS, base, label="PBMC3k", size_mb=24)
 
     mat, genes, cells = read_10x(matrix_dir, var_names="gene_symbols")
     return mat, genes, cells
@@ -79,15 +76,12 @@ def pbmc8k(
     """
     from .io import read_10x
 
-    if data_dir is None:
-        data_dir = Path.home() / ".shanuz_data" / "pbmc8k"
-    else:
-        data_dir = Path(data_dir)
-
-    matrix_dir = data_dir / _PBMC8K_DIR
+    base = (Path(data_dir) if data_dir is not None
+            else Path.home() / ".shanuz_data" / "pbmc8k")
+    matrix_dir = base / _PBMC8K_DIR
 
     if force_download or not (matrix_dir / "matrix.mtx").exists():
-        _download_10x(_PBMC8K_URLS, data_dir, label="PBMC8k", size_mb=38)
+        _download_10x(_PBMC8K_URLS, base, label="PBMC8k", size_mb=38)
 
     mat, genes, cells = read_10x(matrix_dir, var_names="gene_symbols")
     return mat, genes, cells
@@ -127,14 +121,12 @@ def cbmc_citeseq(
 
     from .io import _make_unique
 
-    if data_dir is None:
-        data_dir = Path.home() / ".shanuz_data" / "cbmc"
-    else:
-        data_dir = Path(data_dir)
-    data_dir.mkdir(parents=True, exist_ok=True)
+    base = (Path(data_dir) if data_dir is not None
+            else Path.home() / ".shanuz_data" / "cbmc")
+    base.mkdir(parents=True, exist_ok=True)
 
-    rna_path = data_dir / _CBMC_RNA
-    adt_path = data_dir / _CBMC_ADT
+    rna_path = base / _CBMC_RNA
+    adt_path = base / _CBMC_ADT
     for fname, path in ((_CBMC_RNA, rna_path), (_CBMC_ADT, adt_path)):
         if force_download or not path.exists():
             _download_file(_CBMC_BASE + fname, path, label=fname)
@@ -144,7 +136,9 @@ def cbmc_citeseq(
     adt_cells = list(adt_df.columns)
 
     # RNA is larger — read in row-chunks, keeping only human genes.
-    rna_blocks, rna_genes, rna_cells = [], [], None
+    rna_blocks: list[sp.csr_matrix] = []
+    rna_genes: list[str] = []
+    rna_cells: Optional[list[str]] = None
     for chunk in pd.read_csv(rna_path, index_col=0, chunksize=4000):
         if rna_cells is None:
             rna_cells = list(chunk.columns)
@@ -153,6 +147,12 @@ def cbmc_citeseq(
         if len(sub):
             rna_genes.extend(g[len(species_prefix):] for g in sub.index)
             rna_blocks.append(sp.csr_matrix(sub.values.astype(np.float32)))
+    if rna_cells is None or not rna_blocks:
+        # No rows at all, or none surviving the species filter — a wrong
+        # `species_prefix` used to surface as sp.vstack's "blocks must be 2-D".
+        raise ValueError(
+            f"{rna_path} yielded no rows starting with {species_prefix!r}"
+        )
     rna_mat = sp.vstack(rna_blocks, format="csc")
     rna_genes = _make_unique(rna_genes)
 
@@ -195,27 +195,25 @@ def xenium_mouse_brain(
     This is the public section featured in Seurat's Xenium spatial vignette, so
     the same analysis runs in R (``LoadXenium``) and Python (``load_xenium``).
     """
-    if data_dir is None:
-        data_dir = Path.home() / ".shanuz_data" / "xenium_mouse_brain"
-    else:
-        data_dir = Path(data_dir)
-    data_dir.mkdir(parents=True, exist_ok=True)
+    root = (Path(data_dir) if data_dir is not None
+            else Path.home() / ".shanuz_data" / "xenium_mouse_brain")
+    root.mkdir(parents=True, exist_ok=True)
 
-    mtx_dir = data_dir / "cell_feature_matrix"
+    mtx_dir = root / "cell_feature_matrix"
     need = force_download or not (mtx_dir / "matrix.mtx.gz").exists()
     if need:
-        tar_dest = data_dir / "cell_feature_matrix.tar.gz"
+        tar_dest = root / "cell_feature_matrix.tar.gz"
         _download_file(_XENIUM_MB_BASE + _XENIUM_MB_FILES["cell_feature_matrix.tar.gz"],
                        tar_dest, label="Xenium mouse brain matrix (~11 MB)")
         with tarfile.open(tar_dest, "r:gz") as tf:
-            tf.extractall(data_dir)
+            tf.extractall(root)
         os.unlink(tar_dest)
 
-    cells_dest = data_dir / "cells.csv.gz"
+    cells_dest = root / "cells.csv.gz"
     if force_download or not cells_dest.exists():
         _download_file(_XENIUM_MB_BASE + _XENIUM_MB_FILES["cells.csv.gz"],
                        cells_dest, label="Xenium mouse brain cells (~2 MB)")
-    return data_dir
+    return root
 
 
 # Visium mouse brain (sagittal anterior, section 1) — 10x Genomics public dataset,
@@ -249,8 +247,6 @@ def visium_mouse_brain(
     pass to :func:`shanuz.load_visium`, and to R's ``Read10X_Image`` /
     ``Load10X_Spatial``, so the same slide runs in both languages.
     """
-    # A local Path rather than rebinding the str|None parameter — the older
-    # loaders in this module do the latter and it is most of their mypy noise.
     root = (Path(data_dir) if data_dir is not None
             else Path.home() / ".shanuz_data" / "visium_mouse_brain")
     root.mkdir(parents=True, exist_ok=True)

--- a/tests/test_datasets_loaders.py
+++ b/tests/test_datasets_loaders.py
@@ -20,12 +20,17 @@ import numpy as np
 import pytest
 import scipy.sparse as sp
 
+from shanuz import datasets
 from shanuz.datasets import (
     _align_on_cells,
     _read_dense_table_sparse,
     _read_table_cached,
+    cbmc_citeseq,
     ifnb,
+    pbmc3k,
+    pbmc8k,
     pbmc_hashing,
+    xenium_mouse_brain,
 )
 
 
@@ -167,6 +172,139 @@ def test_pbmc_hashing_drops_qc_rows_and_aligns(tmp_path):
 def test_ifnb_errors_when_bridge_not_run(tmp_path):
     with pytest.raises(FileNotFoundError, match="export_seuratdata.R ifnb"):
         ifnb(data_dir=str(tmp_path))
+
+
+# --------------------------------------------------------------------------- #
+# data_dir is honoured (no network, and the default cache is made unreachable)
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def offline(monkeypatch, tmp_path):
+    """Point ``Path.home()`` at an empty dir and make any download fail loudly.
+
+    Both halves are load-bearing. Redirecting home means a loader that ignored
+    ``data_dir`` cannot quietly succeed off a developer's populated
+    ``~/.shanuz_data``; failing the download means it announces itself here
+    instead of reaching the network in CI.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    def _no_download(*args, **kwargs):
+        raise AssertionError("loader tried to download — it did not use data_dir")
+
+    monkeypatch.setattr(datasets, "_download_10x", _no_download)
+    monkeypatch.setattr(datasets, "_download_file", _no_download)
+    return fake_home
+
+
+def _write_10x_v2(directory: Path, mat: sp.csc_matrix, genes: list[str],
+                  cells: list[str]) -> None:
+    """Write a v2 (``genes.tsv``) 10x trio, the layout both PBMC bundles use."""
+    import scipy.io
+
+    directory.mkdir(parents=True, exist_ok=True)
+    with open(directory / "matrix.mtx", "wb") as fh:
+        scipy.io.mmwrite(fh, mat)
+    (directory / "genes.tsv").write_text(
+        "".join(f"ENSG{i:05d}\t{g}\n" for i, g in enumerate(genes))
+    )
+    (directory / "barcodes.tsv").write_text("".join(f"{c}\n" for c in cells))
+
+
+@pytest.mark.parametrize("loader, subdir", [
+    (pbmc3k, "filtered_gene_bc_matrices/hg19"),
+    (pbmc8k, "filtered_gene_bc_matrices/GRCh38"),
+])
+def test_pbmc_loaders_read_the_given_data_dir(loader, subdir, tmp_path, offline):
+    # The reference lives at data_dir/<bundle subdir>, so this pins the join as
+    # well as the directory: a loader reading data_dir itself finds nothing.
+    mat = sp.csc_matrix(np.array([[1, 0], [0, 2], [3, 4]], dtype=np.float32))
+    _write_10x_v2(tmp_path / subdir, mat, ["GeneA", "GeneB", "GeneC"], ["c1", "c2"])
+
+    counts, genes, cells = loader(data_dir=str(tmp_path))
+    assert genes == ["GeneA", "GeneB", "GeneC"]
+    assert cells == ["c1", "c2"]
+    assert counts.toarray().tolist() == [[1, 0], [0, 2], [3, 4]]
+    assert not list(offline.iterdir()), "loader wrote to the default cache"
+
+
+def test_xenium_returns_the_given_data_dir(tmp_path, offline):
+    # Both files present, so nothing is fetched and the folder is returned as is.
+    (tmp_path / "cell_feature_matrix").mkdir()
+    (tmp_path / "cell_feature_matrix" / "matrix.mtx.gz").write_bytes(b"")
+    (tmp_path / "cells.csv.gz").write_bytes(b"")
+
+    got = xenium_mouse_brain(data_dir=str(tmp_path))
+    assert got == tmp_path
+    assert isinstance(got, Path), "load_xenium is handed this path directly"
+    assert not list(offline.iterdir()), "loader wrote to the default cache"
+
+
+def test_cbmc_keeps_human_genes_and_aligns_to_shared_barcodes(tmp_path, offline):
+    # RNA over c1..c3 with one mouse spike-in; ADT over c3,c2,c9. Shared = c2,c3,
+    # which must come back in *RNA* order and drop MOUSE_Actb with its prefix.
+    _write_gzip_table(
+        tmp_path / "GSE100866_CBMC_8K_13AB_10X-RNA_umi.csv.gz",
+        header=["", "c1", "c2", "c3"],
+        rows=[["HUMAN_CD3E", 1, 5, 0], ["MOUSE_Actb", 9, 9, 9], ["HUMAN_MS4A1", 2, 0, 7]],
+        sep=",",
+    )
+    _write_gzip_table(
+        tmp_path / "GSE100866_CBMC_8K_13AB_10X-ADT_umi.csv.gz",
+        header=["", "c3", "c2", "c9"],
+        rows=[["CD3", 30, 20, 90], ["CD19", 33, 22, 99]],
+        sep=",",
+    )
+    rna, genes, adt, prots, cells = cbmc_citeseq(data_dir=str(tmp_path))
+    assert genes == ["CD3E", "MS4A1"], "mouse row kept, or prefix left on"
+    assert cells == ["c2", "c3"]
+    assert prots == ["CD3", "CD19"]
+    assert rna.toarray().tolist() == [[5, 0], [0, 7]]
+    assert adt.toarray().tolist() == [[20, 30], [22, 33]]  # reordered to the RNA
+    assert not list(offline.iterdir()), "loader wrote to the default cache"
+
+
+def test_cbmc_stitches_chunks_and_skips_an_all_mouse_one(tmp_path, offline):
+    # The loader reads the RNA table in 4,000-row chunks and the real file is
+    # ~36,000 rows, so every genuine load crosses several boundaries — the tests
+    # above all fit in one chunk and never exercise the accumulation at all.
+    # Three chunks, the middle one entirely mouse, so *two* human blocks have to
+    # be stitched across a skipped one. First column carries the source row
+    # number, which is what ties each matrix row back to its gene.
+    rows = [[f"HUMAN_G{i}", i + 1, 1] for i in range(4000)]          # chunk 1
+    rows += [[f"MOUSE_m{i}", 7, 7] for i in range(4000)]             # chunk 2, dropped
+    rows += [[f"HUMAN_G{4000 + i}", 8001 + i, 1] for i in range(500)]  # chunk 3
+    _write_gzip_table(tmp_path / "GSE100866_CBMC_8K_13AB_10X-RNA_umi.csv.gz",
+                      header=["", "c1", "c2"], rows=rows, sep=",")
+    _write_gzip_table(tmp_path / "GSE100866_CBMC_8K_13AB_10X-ADT_umi.csv.gz",
+                      header=["", "c1", "c2"], rows=[["CD3", 4, 5]], sep=",")
+
+    rna, genes, adt, prots, cells = cbmc_citeseq(data_dir=str(tmp_path))
+    assert rna.shape == (4500, 2), "chunks not concatenated, or mouse chunk kept"
+    assert genes[:2] == ["G0", "G1"] and genes[-1] == "G4499"  # source order held
+    assert cells == ["c1", "c2"]
+    # Rows must still line up with `genes` after the stitch: G0 came from source
+    # row 1 and G4499 from row 8500, so a reordered block shows up here.
+    assert rna[0, 0] == 1 and rna[4499, 0] == 8500
+    # Column 2 is all ones, so a dropped or duplicated block shows up here.
+    assert rna[:, 1].toarray().sum() == 4500
+
+
+@pytest.mark.parametrize("rna_rows", [
+    [],                              # header only
+    [["MOUSE_Actb", 1]],             # rows, none matching the prefix
+])
+def test_cbmc_names_the_species_prefix_when_nothing_survives(rna_rows, tmp_path, offline):
+    # Both cases used to reach sp.vstack([]) and report "blocks must be 2-D",
+    # which says nothing about the prefix that actually filtered everything out.
+    _write_gzip_table(tmp_path / "GSE100866_CBMC_8K_13AB_10X-RNA_umi.csv.gz",
+                      header=["", "c1"], rows=rna_rows, sep=",")
+    _write_gzip_table(tmp_path / "GSE100866_CBMC_8K_13AB_10X-ADT_umi.csv.gz",
+                      header=["", "c1"], rows=[["CD3", 1]], sep=",")
+    with pytest.raises(ValueError, match="HUMAN_"):
+        cbmc_citeseq(data_dir=str(tmp_path))
 
 
 def test_ifnb_reads_bridge_output(tmp_path):


### PR DESCRIPTION
## What

`pbmc3k`, `pbmc8k`, `cbmc_citeseq` and `xenium_mouse_brain` each assigned a `Path` back over a parameter declared `Optional[str]`:

```python
if data_dir is None:
    data_dir = Path.home() / ".shanuz_data" / "pbmc3k"
else:
    data_dir = Path(data_dir)
matrix_dir = data_dir / _PBMC3K_DIR
```

That one idiom accounted for **33 of the package's 44 mypy errors** — every `/` on it, every `.mkdir()`, and every call that passed it on. The newer loaders sitting next to them (`visium_mouse_brain`, `pbmc_hashing`, `thp1_eccite`, `_load_seuratdata_export`) already bind a local `Path` instead; this brings the older four into line, so the file now has a single convention rather than two.

**mypy `shanuz`: 44 → 11.** No behaviour change to any loader.

## Why the tests

The refactor has exactly one failure mode: reading or writing the default `~/.shanuz_data` instead of the caller's directory. Nothing checked that, and on a developer's machine the default cache is populated — so a loader that ignored `data_dir` entirely would still have returned the right data and passed.

The `offline` fixture makes that impossible: it points `Path.home()` at an empty directory *and* makes both download helpers raise. Both halves are load-bearing.

Two smaller things fell out of the work:

- **`cbmc_citeseq` misreported an empty species filter.** A `species_prefix` matching no gene left every chunk empty and surfaced as scipy's `blocks must be 2-D, and some must be sparse` from `sp.vstack([])` — naming neither the file nor the prefix. It now raises a `ValueError` naming both.
- **Its chunked RNA read had no coverage.** The real file is ~36,000 rows against a 4,000-row chunk, so every genuine load crosses several boundaries; every existing test fit in one chunk. The new test uses three chunks with the middle one entirely mouse, so two human blocks must be stitched across a skipped one.

## Verification

| | before | after |
|---|---|---|
| `mypy shanuz` | 44 | **11** |
| suite | 895 passed, 25 skipped | **902 passed, 25 skipped** |
| `ruff check shanuz` | 51 | 51 |
| `ruff check .` | 201 | 201 |

All four loaders were also run for real against the cached datasets, default-dir and explicit-dir, `str` and `Path` — identical matrices to the values on `main` (pbmc3k 32,738 × 2,700; pbmc8k 33,694 × 8,381; cbmc 20,400 × 8,617 with 13 proteins).

**Mutation testing: 15 mutations, 14 killed.** The survivor is a genuine no-op — `if rna_cells is None:` guards a capture that would produce the same list on every chunk anyway.

The first version of the chunk test survived two of them. It wrote 4,000 human rows followed by mouse, so every human gene landed in a single chunk and there was never more than one block to stitch — the test asserted a property its own fixture could not express. Rewritten with three chunks, both mutations die.

🤖 Generated with [Claude Code](https://claude.com/claude-code)