### PR TITLE
Clear the last 11 mypy errors — two of them were real defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,27 @@ on `main`; none of it is on PyPI.
 
 ### Fixed
 
+- **Any plot with more than 36 groups raised `AttributeError` on matplotlib
+  3.9 or newer.** `_palette` fills the first 36 colours from a fixed list and
+  falls back to a colormap past that, and the fallback called
+  `plt.cm.get_cmap(name, lut)` — deprecated in 3.7 and **removed in 3.9**. The
+  project has supported `matplotlib>=3.7` throughout, so on any current install
+  the branch was dead code that crashed the moment it was reached. Nine plotting
+  functions route through it; no test had ever asked for that many groups. It
+  now uses `.resampled`, the documented replacement, which reaches back to 3.6
+  and so works across the whole supported range.
+- **A layerless v5 assay came back as `KeyError: None`.** `Assay5.default_layer`
+  is `None` when the assay holds no layers, and the two layer getters — in
+  `preprocessing` and in `plotting` — indexed the layer dict with it directly.
+  Both now raise `ValueError("No layers available.")`, matching what
+  `Assay5.layer_data` has always said for the same condition.
+- **`multiseq_demux` and `_integrate_anchor_reduction` rebound their own
+  parameters**, the same idiom as the dataset loaders below; both use a local
+  now. No behaviour change, but neither `multiseq_demux`'s `qrange` nor
+  `integrate_layers`' single-element `group_by` list had any test coverage, so
+  both are now pinned. This clears the last of the package's type-checker
+  errors: **`mypy shanuz` reports none**, down from 44.
+
 - **`cbmc_citeseq` reported an unrelated error when the species filter matched
   nothing.** A `species_prefix` that no gene starts with — the wrong one, or a
   file whose row labels are not prefixed — left every chunk empty and surfaced

--- a/shanuz/integration.py
+++ b/shanuz/integration.py
@@ -175,7 +175,7 @@ def integrate_layers(
 
 def _integrate_anchor_reduction(
     seurat,
-    group_by: str,
+    group_by: Union[str, list[str]],
     reduction: str,
     new_reduction: str,
     orig_reduction: str = "pca",
@@ -210,14 +210,18 @@ def _integrate_anchor_reduction(
     from .anchors import find_integration_anchors, integrate_embeddings
     from .preprocessing import scale_data
 
+    # `integrate_layers` accepts Harmony's list of covariates; the anchor path
+    # takes exactly one. A local, so `column` is a str from here down.
     if isinstance(group_by, (list, tuple)):
         if len(group_by) != 1:
             raise ValueError(
                 "CCA/RPCA integration supports a single group_by column."
             )
-        group_by = group_by[0]
-    if group_by not in seurat.meta_data.columns:
-        raise KeyError(f"group_by column {group_by!r} not found in meta_data.")
+        column = group_by[0]
+    else:
+        column = group_by
+    if column not in seurat.meta_data.columns:
+        raise KeyError(f"group_by column {column!r} not found in meta_data.")
 
     if orig_reduction not in seurat.reductions:
         raise KeyError(
@@ -232,14 +236,14 @@ def _integrate_anchor_reduction(
     # k.filter = NA. v4's default of 200 only applies to the object-list API.
     kwargs.setdefault("k_filter", None)
 
-    groups = list(pd.unique(seurat.meta_data[group_by]))
+    groups = list(pd.unique(seurat.meta_data[column]))
     if len(groups) < 2:
         raise ValueError(
-            f"group_by={group_by!r} has < 2 levels; nothing to integrate."
+            f"group_by={column!r} has < 2 levels; nothing to integrate."
         )
 
     all_cells = seurat.cell_names()
-    labels = seurat.meta_data[group_by]
+    labels = seurat.meta_data[column]
     objects = [
         seurat.subset(cells=[c for c in all_cells if labels.loc[c] == g])
         for g in groups

--- a/shanuz/mixscape.py
+++ b/shanuz/mixscape.py
@@ -77,7 +77,7 @@ Two deliberate, documented choices differ from a literal reading of R:
 """
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 import numpy as np
 import pandas as pd
@@ -293,7 +293,10 @@ def run_mixscape(
     try:
         for gene in genes:
             gene_local = np.where(labels_vec == gene)[0]
-            info = {"n_cells": int(gene_local.size), "n_de": 0, "n_iter": 0, "n_ko": 0}
+            # Counts plus a "scores" DataFrame-or-None, so not dict[str, int].
+            info: dict[str, Any] = {
+                "n_cells": int(gene_local.size), "n_de": 0, "n_iter": 0, "n_ko": 0,
+            }
 
             if gene_local.size < min_cells:
                 _assign(mixscape_class, global_class, gene_local, gene, "NP", prtb_type)

--- a/shanuz/module_score.py
+++ b/shanuz/module_score.py
@@ -164,8 +164,8 @@ def add_module_score(
     bins = pd.qcut(data_avg + jitter, q=min(nbin, len(pool)), labels=False, duplicates="drop")
     gene_to_bin = {g: int(b) for g, b in zip(pool, bins)}
     bin_to_genes: dict[int, list[str]] = {}
-    for g, b in gene_to_bin.items():
-        bin_to_genes.setdefault(b, []).append(g)
+    for gene_name, bin_idx in gene_to_bin.items():
+        bin_to_genes.setdefault(bin_idx, []).append(gene_name)
 
     n_cells = mat.shape[1]
     for label, genes in zip(labels, programs):

--- a/shanuz/multiseq.py
+++ b/shanuz/multiseq.py
@@ -113,14 +113,13 @@ def multiseq_demux(
             f"MULTIseqDemux needs at least 2 barcodes; assay {assay!r} has {n_bc}."
         )
 
-    if qrange is None:
-        qrange = np.round(np.arange(0.1, 0.9 + 1e-9, 0.05), 4)
-    else:
-        qrange = np.asarray(qrange, dtype=float)
+    # A local array rather than rebinding the Sequence[float]|None parameter.
+    qs = (np.round(np.arange(0.1, 0.9 + 1e-9, 0.05), 4) if qrange is None
+          else np.asarray(qrange, dtype=float))
 
     if autothresh:
         calls, thresholds, q_used = _auto_classify(
-            data, feats, qrange, maxiter, verbose
+            data, feats, qs, maxiter, verbose
         )
     else:
         calls, thresholds = _classify_cells(data, feats, quantile)

--- a/shanuz/plotting.py
+++ b/shanuz/plotting.py
@@ -100,7 +100,9 @@ def _palette(n: int) -> list[str]:
     if n <= len(_PALETTE_36):
         return _PALETTE_36[:n]
     import matplotlib.pyplot as plt
-    cmap = plt.cm.get_cmap("tab20", n)
+    # `plt.cm.get_cmap(name, lut)` was removed in matplotlib 3.9; `.resampled`
+    # is its documented replacement and reaches back to 3.6, under our >=3.7.
+    cmap = plt.get_cmap("tab20").resampled(n)
     return [f"#{int(r*255):02x}{int(g*255):02x}{int(b*255):02x}"
             for r, g, b, *_ in (cmap(i) for i in range(n))]
 
@@ -121,7 +123,10 @@ def _get_data_matrix(assay_obj, layer: Optional[str] = None):
         for candidate in ("data", "counts"):
             if candidate in assay_obj.layers:
                 return assay_obj.layers[candidate]
-        return assay_obj.layers[assay_obj.default_layer]
+        default = assay_obj.default_layer
+        if default is None:
+            raise ValueError("No layers available.")
+        return assay_obj.layers[default]
     else:
         if layer in ("counts",):
             return assay_obj.counts

--- a/shanuz/preprocessing.py
+++ b/shanuz/preprocessing.py
@@ -65,7 +65,10 @@ def _get_layer(assay_obj, layer: Optional[str]):
             for candidate in ("data", "counts"):
                 if candidate in assay_obj.layers:
                     return assay_obj.layers[candidate]
-            return assay_obj.layers[assay_obj.default_layer]
+            default = assay_obj.default_layer
+            if default is None:
+                raise ValueError("No layers available.")
+            return assay_obj.layers[default]
         return assay_obj.layers[layer]
     else:
         if layer == "counts":

--- a/shanuz/sctransform.py
+++ b/shanuz/sctransform.py
@@ -54,7 +54,7 @@ this model wrong once are pinned separately in
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
@@ -466,6 +466,9 @@ def sctransform(
         raise ValueError(f"vst_flavor must be 'v1' or 'v2', got {vst_flavor!r}")
 
     src = seurat.assays[assay or seurat.active_assay]
+    # A layer may be dense, sparse, or an on-disk LazyMatrix — `sp.csc_matrix`
+    # is what accepts all three, so keep `issparse` as the discriminator below.
+    counts: Any
     if isinstance(src, Assay5):
         counts = src.layers.get("counts")
         all_genes = src._all_feature_names

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -362,3 +362,24 @@ def test_integrate_layers_cca_requires_group_by():
     obj = _batched_object()
     with pytest.raises(ValueError):
         integrate_layers(obj, method="cca")
+
+
+def test_integrate_layers_cca_unwraps_a_one_element_group_by():
+    # `integrate_layers` takes str | list[str] because Harmony corrects on
+    # several covariates at once; the anchor path takes exactly one and unwraps
+    # a single-element list. Two objects, so this pins the unwrapped column
+    # actually reaching the split — a name that never arrives would raise.
+    plain, wrapped = _batched_object(), _batched_object()
+    integrate_layers(plain, method="cca", group_by="batch", new_reduction="int")
+    integrate_layers(wrapped, method="cca", group_by=["batch"], new_reduction="int")
+
+    assert np.allclose(
+        plain.reductions["int"].cell_embeddings,
+        wrapped.reductions["int"].cell_embeddings,
+    )
+
+
+def test_integrate_layers_cca_rejects_several_group_by_columns():
+    obj = _batched_object()
+    with pytest.raises(ValueError, match="single group_by column"):
+        integrate_layers(obj, method="cca", group_by=["batch", "celltype"])

--- a/tests/test_multiseq.py
+++ b/tests/test_multiseq.py
@@ -163,6 +163,19 @@ def test_autothresh_recovers_singlets():
     assert (call[singlet] == truth[singlet]).mean() >= 0.9
 
 
+def test_autothresh_sweeps_only_the_given_qrange():
+    # `qrange` had no coverage at all — the sweep quietly used its own default
+    # whatever you passed. The chosen quantile is reported in misc, so a
+    # deliberately off-default single-element range makes the wiring visible.
+    obj, _ = _hashing_object()
+    multiseq_demux(obj, autothresh=True, qrange=[0.42])
+    assert obj.misc["multiseq_demux"]["HTO"]["quantile"] == pytest.approx(0.42)
+
+    obj_two, _ = _hashing_object()
+    multiseq_demux(obj_two, autothresh=True, qrange=[0.11, 0.13])
+    assert obj_two.misc["multiseq_demux"]["HTO"]["quantile"] in (0.11, 0.13)
+
+
 def test_normalize_false_uses_data_layer():
     obj, truth = _hashing_object()
     normalize_data(obj, normalization_method="CLR", margin=1, assay="HTO")

--- a/tests/test_typing_behaviour.py
+++ b/tests/test_typing_behaviour.py
@@ -1,0 +1,93 @@
+"""Behaviour behind the last of the mypy fixes.
+
+Companion to `test_object_model_typing.py`. Most of the annotation work is
+advisory — CI runs mypy with `|| true` — but two of the sites it pointed at were
+doing something wrong at runtime, and those are what is pinned here:
+
+  * `_palette` reached for `plt.cm.get_cmap`, which matplotlib **removed** in
+    3.9. Every plot with more than 36 groups raised `AttributeError` on any
+    modern matplotlib, and no test ever asked for that many.
+  * `_get_layer` / `_get_data_matrix` indexed an Assay5's layers with
+    `default_layer`, which is `None` when the assay has none — so a layerless
+    assay came back as `KeyError: None` instead of a sentence.
+
+The annotations themselves are mypy's business and are not asserted.
+"""
+import re
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from shanuz.assay5 import Assay5
+from shanuz.plotting import _PALETTE_36, _get_data_matrix, _palette
+from shanuz.preprocessing import _get_layer
+
+_HEX = re.compile(r"^#[0-9a-f]{6}$")
+
+
+@pytest.mark.parametrize("n", [1, 36])
+def test_palette_serves_small_n_from_the_fixed_list(n):
+    assert _palette(n) == _PALETTE_36[:n]
+
+
+@pytest.mark.parametrize("n", [37, 40, 64])
+def test_palette_falls_back_to_a_colormap_past_the_fixed_list(n):
+    # The colormap branch — unreachable for n <= 36, which is why its removed
+    # matplotlib call went unnoticed. Only the length and format are asserted:
+    # tab20 resampled to n repeats hues, so distinctness is not a property here.
+    colors = _palette(n)
+    assert len(colors) == n
+    assert all(_HEX.match(c) for c in colors)
+
+
+def test_vln_plot_survives_more_groups_than_the_fixed_palette():
+    # `_palette` is private; this is the public path that used to crash. 40
+    # groups, one over the point where the colormap branch takes over.
+    plt = pytest.importorskip("matplotlib.pyplot")
+    import pandas as pd
+
+    from shanuz.plotting import vln_plot
+    from shanuz.shanuz import create_shanuz_object
+
+    n_groups, per = 40, 3
+    n_cells = n_groups * per
+    rng = np.random.default_rng(0)
+    counts = sp.csc_matrix(rng.poisson(5, size=(6, n_cells)).astype(np.float64))
+    cells = [f"c{i}" for i in range(n_cells)]
+    meta = pd.DataFrame({"grp": [f"g{i // per}" for i in range(n_cells)]}, index=cells)
+    obj = create_shanuz_object(
+        counts=counts, feature_names=[f"gene{i}" for i in range(6)],
+        cell_names=cells, meta_data=meta, min_cells=0, min_features=0,
+    )
+
+    fig = vln_plot(obj, features="gene0", group_by="grp")
+    plt.close("all")
+    assert fig is not None
+
+
+@pytest.mark.parametrize("getter", [_get_layer, _get_data_matrix])
+def test_a_layerless_assay5_says_so(getter):
+    # `default_layer` is None for an assay with no layers, so both getters used
+    # to index the dict with None. The message matches Assay5.layer_data's.
+    empty = Assay5(layers={}, feature_names=["g1"], cell_names=["c1"])
+    assert empty.default_layer is None
+    with pytest.raises(ValueError, match="No layers available"):
+        getter(empty, None)
+
+
+@pytest.mark.parametrize("getter", [_get_layer, _get_data_matrix])
+def test_a_populated_assay5_still_resolves_without_a_named_layer(getter):
+    # The guard sits after the data/counts search, so it must not intercept the
+    # ordinary path — nor the third case, a layer under neither of those names.
+    mat = sp.csc_matrix(np.array([[1.0, 2.0]]))
+    both = Assay5(
+        layers={"counts": mat, "data": mat * 2},
+        feature_names=["g1"], cell_names=["c1", "c2"],
+    )
+    assert (getter(both, None).toarray() == (mat * 2).toarray()).all()
+
+    odd = Assay5(
+        layers={"scale.data": mat}, feature_names=["g1"], cell_names=["c1", "c2"],
+    )
+    assert (getter(odd, None).toarray() == mat.toarray()).all()


### PR DESCRIPTION
Follow-on to #69. `mypy shanuz` now reports **no errors**, down from 44 before #69 and 11 after it.

Where #69 was one repeated idiom in one file, these 11 were a mixed bag across seven files — and two of the sites the checker pointed at were wrong at runtime, not just loosely annotated.

## Two real defects

**`_palette` crashed on any plot with more than 36 groups.** It fills the first 36 colours from a fixed list and falls back to a colormap past that; the fallback called `plt.cm.get_cmap(name, lut)`, deprecated in matplotlib 3.7 and **removed in 3.9**. The project has declared `matplotlib>=3.7` throughout, so on the installed 3.11 — and on anything since mid-2024 — that branch was dead code that raised the moment it was reached:

```
>>> _palette(40)
AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'
```

Nine plotting functions route through `_palette`. No test had ever asked for more than 36 groups, which is why it survived a full-matrix fresh-install audit. Now uses `.resampled`, the documented replacement — verified colour-for-colour identical to `mpl.colormaps["tab20"].resampled(n)`, and available since 3.6, so it works across the whole supported range rather than only above it.

**A layerless v5 assay came back as `KeyError: None`.** `Assay5.default_layer` returns `None` when the assay holds no layers, and both layer getters — `preprocessing._get_layer` and `plotting._get_data_matrix` — indexed the layer dict with it directly. `Assay5.layer_data` already raises `ValueError("No layers available.")` for exactly this condition; the two getters now say the same thing.

## The other five

Annotation-level, no behaviour change:

- `multiseq_demux` and `_integrate_anchor_reduction` **rebound their own parameters** — the #69 idiom again. Both use a local now.
- `mixscape`'s per-gene `info` dict holds a DataFrame-or-None beside its counts, so it isn't `dict[str, int]`.
- `sctransform`'s counts layer can be dense, sparse, **or an on-disk `LazyMatrix`**. My first pass narrowed on `isinstance(counts, np.ndarray)` and inverted the branches, which would have broken the lazy path — `sp.csc_matrix(lazy)` works, `lazy.tocsc()` does not. Reverted to `issparse` as the discriminator with an `Any` declaration and a comment saying why.
- `add_module_score` reused one loop variable for an `int` and an `int | None`.

## Coverage

Two of the parameters this touched turned out to have **no test coverage at all** — `multiseq_demux`'s `qrange` (never referenced by any test or tutorial) and `integrate_layers`' single-element `group_by` list. A silent regression there was exactly what a local-variable refactor risks, so both are now pinned: `qrange=[0.42]` must be the quantile that comes back in `misc`, and `group_by=["batch"]` must produce the same embedding as `group_by="batch"`.

New `tests/test_typing_behaviour.py` covers the two real defects, companion to `test_object_model_typing.py` from #65. The palette test drives `vln_plot` with 40 groups, not just the private helper.

## Verification

| | before | after |
|---|---|---|
| `mypy shanuz` | 11 | **0** |
| suite | 902 passed / 25 skipped | **915 passed / 25 skipped** |
| `ruff check shanuz` | 51 | 51 |
| `ruff check .` | 201 | 201 |

The 109 R-fidelity tests over SCTransform, mixscape, cell cycle and hashing all pass unskipped — that's the integration-level evidence that the five annotation-only changes are neutral.

**Mutation testing: 13 mutations, 13 killed, 0 bad anchors.** Including reinstating the removed matplotlib call, deleting each None guard, moving a guard ahead of the data/counts search, dropping the `group_by` unwrap, and ignoring `qrange` in both places it is threaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)