### PR TITLE
ruff is clean at both scopes — and three of the reports were real

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,35 @@ on `main`; none of it is on PyPI.
 
 ### Fixed
 
+- **One test had been shadowed by a same-named copy and never ran.**
+  `test_anchors_seurat_parity.py` defined
+  `test_pca_loadings_are_exact_not_randomized` twice; Python keeps the second,
+  so the earlier one — which additionally proves sklearn's *randomized* solver
+  disagrees on the trailing PCs, i.e. that the exact SVD matters at all — was
+  collected by nothing. Renamed and now runs (and passes).
+- **`sctransform(vars_to_regress=...)` was tested against no baseline.** The
+  guard asserted only that the residuals come back uncorrelated with the
+  covariate, which is equally true when there was never any covariate signal to
+  remove; it computed a `before` from a *different* object built from
+  un-injected counts and then never asserted on it. It now runs SCTransform
+  twice over the same injected counts and requires the unregressed residuals to
+  carry the signal (0.25) before requiring the regressed ones not to (0.00).
+- **`find_markers` named the missing ident in one error and not the other.** An
+  empty `ident_2` raised a constant `"No cells found for comparison group."`
+  while the `ident_1` branch named what it looked for. Both now name it, and
+  the `ident_2=None` case says there is nothing left outside `ident_1` rather
+  than reporting a parameter the caller never passed.
+- **`ruff check` is clean, at both scopes** — 51 → 0 in `shanuz`, 201 → 0 for
+  the repo. Mostly unused imports left behind by the Assay5 refactor, plus dead
+  locals and semicolon-joined statements. Two of the dead locals were computed
+  colour maps in `vln_plot` and `dim_plot` that nothing read, and one was a
+  `v3` layout flag in `read_10x` that no branch consumed. The 121 `E402`s in
+  `tests/` and `tutorials/` are the deliberate `sys.path` bootstrap those files
+  need to run from a clone, and are now ignored by scope in `pyproject.toml`
+  rather than by 121 scattered `# noqa`. Note CI resolves **ruff unpinned**,
+  which currently means 0.16.0 and a much larger default rule set (PEP 604
+  annotations, import sorting); this entry is measured against 0.15.20.
+
 - **Any plot with more than 36 groups raised `AttributeError` on matplotlib
   3.9 or newer.** `_palette` fills the first 36 colours from a fixed list and
   falls back to a colormap past that, and the fallback called

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,14 @@ addopts = "-v"
 line-length = 100
 target-version = "py312"
 
+[tool.ruff.lint.per-file-ignores]
+# Tests and tutorials are runnable straight from a clone, so each one bootstraps
+# `sys.path` before importing shanuz. That puts every subsequent import below a
+# statement, which is E402 by definition — 121 reports for one deliberate line
+# per file. Ignored by scope rather than by 121 scattered `# noqa: E402`.
+"tests/*" = ["E402"]
+"tutorials/*" = ["E402"]
+
 [tool.mypy]
 # Deliberately no `python_version`. Pinning it to our floor also makes mypy parse
 # every *followed* import at that version, third-party source included — and

--- a/shanuz/_sparse.py
+++ b/shanuz/_sparse.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Union
 
 import numpy as np
 import scipy.sparse as sp

--- a/shanuz/_utils.py
+++ b/shanuz/_utils.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from typing import Optional
 
 import numpy as np
-import pandas as pd
 import scipy.sparse as sp
 
-from ._sparse import is_sparse
 
 
 def calc_n(matrix, margin: int = 2) -> tuple[np.ndarray, np.ndarray]:

--- a/shanuz/assay.py
+++ b/shanuz/assay.py
@@ -7,7 +7,6 @@ import pandas as pd
 import scipy.sparse as sp
 
 from ._sparse import (
-    as_sparse,
     empty_dense,
     empty_sparse,
     is_matrix_empty,

--- a/shanuz/assay5.py
+++ b/shanuz/assay5.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import os
 import re
-from abc import ABC, abstractmethod
-from typing import Optional, Self, Type, Union
+from abc import ABC
+from typing import Optional, Self, Union
 
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
 
-from ._sparse import as_dense, as_sparse, empty_sparse, is_matrix_empty
+from ._sparse import as_dense
 from ._utils import validate_cell_names, validate_feature_names
 from .lazy import is_lazy
 from .logmap import LogMap

--- a/shanuz/clustering.py
+++ b/shanuz/clustering.py
@@ -258,4 +258,4 @@ def _renumber_by_size(labels: np.ndarray) -> np.ndarray:
     unique, counts = np.unique(labels, return_counts=True)
     order = unique[np.argsort(-counts)]
     mapping = {old: new for new, old in enumerate(order)}
-    return np.array([mapping[l] for l in labels])
+    return np.array([mapping[lab] for lab in labels])

--- a/shanuz/command.py
+++ b/shanuz/command.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import inspect
 from datetime import datetime
 from typing import Any, Optional
 
-import pandas as pd
 
 
 class ShanuzCommand:

--- a/shanuz/compat/anndata.py
+++ b/shanuz/compat/anndata.py
@@ -37,7 +37,6 @@ def as_anndata(seurat, assay: Optional[str] = None):
             "anndata is required. Install with: pip install 'seurat-object[anndata]'"
         )
 
-    from ..assay import Assay
     from ..assay5 import StdAssay
     from ..shanuz import Shanuz
 
@@ -150,7 +149,7 @@ def from_anndata(
     ``obs[fov_key]`` exists it splits the cells into one image per FOV.
     """
     try:
-        import anndata as _ann
+        import anndata  # noqa: F401  — probed for availability, not used here
     except ImportError:
         raise ImportError(
             "anndata is required. Install with: pip install 'seurat-object[anndata]'"

--- a/shanuz/generics.py
+++ b/shanuz/generics.py
@@ -7,7 +7,6 @@ unregistered types get a clear message.
 from __future__ import annotations
 
 import functools
-from typing import Any, Optional, Union
 
 
 def _not_implemented(func_name: str):
@@ -157,7 +156,7 @@ rename_cells = _generic("rename_cells")
 
 def _register_all() -> None:
     from .assay import Assay
-    from .assay5 import Assay5, StdAssay
+    from .assay5 import StdAssay
     from .dimreduc import DimReduc
     from .graph import Graph
     from .neighbor import Neighbor
@@ -165,7 +164,6 @@ def _register_all() -> None:
     from .spatial.base import SpatialImage
     from .spatial.centroids import Centroids
     from .spatial.fov import FOV
-    from .spatial.molecules import Molecules
     from .spatial.segmentation import Segmentation
     from ._sparse import is_matrix_empty as _ime
     import numpy as np
@@ -393,7 +391,6 @@ def _register_all() -> None:
     # --- as_sparse ---
     @as_sparse.register(np.ndarray)
     def _asp_nd(x, fmt="csc"):
-        import scipy.sparse as sp
         return sp.csc_matrix(x) if fmt == "csc" else sp.csr_matrix(x)
 
 

--- a/shanuz/io.py
+++ b/shanuz/io.py
@@ -7,10 +7,8 @@ from __future__ import annotations
 import gzip
 import os
 from pathlib import Path
-from typing import Optional, Union
+from typing import Union
 
-import numpy as np
-import pandas as pd
 import scipy.io
 import scipy.sparse as sp
 
@@ -43,17 +41,14 @@ def read_10x(
         matrix_file = data_dir / "matrix.mtx.gz"
         barcodes_file = data_dir / "barcodes.tsv.gz"
         features_file = data_dir / "features.tsv.gz"
-        v3 = True
     elif (data_dir / "genes.tsv").exists():
         matrix_file = data_dir / "matrix.mtx"
         barcodes_file = data_dir / "barcodes.tsv"
         features_file = data_dir / "genes.tsv"
-        v3 = False
     elif (data_dir / "features.tsv").exists():
         matrix_file = data_dir / "matrix.mtx"
         barcodes_file = data_dir / "barcodes.tsv"
         features_file = data_dir / "features.tsv"
-        v3 = True
     else:
         raise FileNotFoundError(
             f"No 10X matrix files found in {data_dir}. "
@@ -103,7 +98,8 @@ def _open_file(path: Path):
 def _read_mtx(path: Path) -> sp.coo_matrix:
     """Read a (possibly gzipped) Matrix Market file."""
     if str(path).endswith(".gz"):
-        import tempfile, shutil
+        import tempfile
+        import shutil
         with gzip.open(path, "rb") as src:
             with tempfile.NamedTemporaryFile(suffix=".mtx", delete=False) as dst:
                 shutil.copyfileobj(src, dst)

--- a/shanuz/markers.py
+++ b/shanuz/markers.py
@@ -297,7 +297,12 @@ def find_markers(
     if not cells_1:
         raise ValueError(f"No cells found with ident {ident_1}.")
     if not cells_2:
-        raise ValueError(f"No cells found for comparison group.")
+        # `ident_2=None` means "every other ident", so name what was searched
+        # rather than a parameter the caller never passed.
+        raise ValueError(
+            f"No cells found with ident {ident_2}." if ident_2 is not None
+            else f"No cells left outside ident {ident_1} to compare against."
+        )
 
     # Optional downsampling
     if max_cells_per_ident is not None:
@@ -790,7 +795,6 @@ def _deseq2_pseudobulk(
 def _get_expression_matrix(assay_obj, layer: Optional[str]):
     """Return (matrix features×cells, feature_names) using best available layer."""
     from .assay5 import Assay5
-    from .assay import Assay
 
     if isinstance(assay_obj, Assay5):
         feature_names = assay_obj._all_feature_names

--- a/shanuz/module_score.py
+++ b/shanuz/module_score.py
@@ -19,7 +19,6 @@ from .lazy import is_lazy
 
 def _assay_data(seurat, assay: Optional[str], layer: str = "data"):
     """Return (matrix features×cells, feature_names) from an assay layer."""
-    from .assay import Assay
     from .assay5 import Assay5
     from ._sparse import is_matrix_empty
 

--- a/shanuz/plotting.py
+++ b/shanuz/plotting.py
@@ -113,9 +113,7 @@ def _get_assay_obj(obj, assay: Optional[str]):
 
 def _get_data_matrix(assay_obj, layer: Optional[str] = None):
     """Return the gene-expression matrix (genes × cells) from an assay."""
-    from .assay import Assay
     from .assay5 import Assay5
-    import scipy.sparse as sp
 
     if isinstance(assay_obj, Assay5):
         if layer is not None and layer in assay_obj.layers:
@@ -252,7 +250,6 @@ def vln_plot(
     groups = _get_groups(obj, group_by)
     unique = sorted(set(groups), key=lambda x: (int(x) if x.isdigit() else x))
     colors = palette or _palette(len(unique))
-    cmap = dict(zip(unique, colors))
 
     nrow, nc = _subplot_grid(len(features), ncol)
     if figsize is None:
@@ -416,7 +413,6 @@ def dim_plot(
     groups = _get_groups(obj, group_by)
     unique = sorted(set(groups), key=lambda x: (int(x) if x.isdigit() else x))
     colors = palette or _palette(len(unique))
-    cmap = dict(zip(unique, colors))
 
     ax1_label = reduction.upper() + "_1"
     ax2_label = reduction.upper() + "_2"
@@ -436,7 +432,8 @@ def dim_plot(
                     bbox=dict(boxstyle="round,pad=0.25", fc="white",
                               alpha=0.75, ec="none"))
 
-    ax.set_xlabel(ax1_label); ax.set_ylabel(ax2_label)
+    ax.set_xlabel(ax1_label)
+    ax.set_ylabel(ax2_label)
     ax.set_title(title or f"{reduction.upper()} — coloured by "
                           f"{'ident' if group_by is None else group_by}",
                  fontsize=12)
@@ -524,7 +521,8 @@ def feature_scatter(
         ax.scatter(x[mask], y[mask], s=pt_size, alpha=alpha,
                    color=color, label=g, linewidths=0)
 
-    ax.set_xlabel(feature1); ax.set_ylabel(feature2)
+    ax.set_xlabel(feature1)
+    ax.set_ylabel(feature2)
     ax.set_title(f"{feature1} vs {feature2}", fontsize=12)
     ax.legend(markerscale=2.5, fontsize=8,
               bbox_to_anchor=(1.01, 1), loc="upper left", frameon=False)
@@ -616,7 +614,8 @@ def variable_feature_plot(
                             textcoords="offset points", color="#333333")
 
     if log and not use_std_var:
-        ax.set_xscale("log"); ax.set_yscale("log")
+        ax.set_xscale("log")
+        ax.set_yscale("log")
         ax.set_xlabel("Average Expression (log)")
     else:
         ax.set_xlabel("Average Expression")
@@ -887,7 +886,8 @@ def do_heatmap(
     axes[0].imshow(colour_row, aspect="auto",
                    cmap=plt.matplotlib.colors.ListedColormap(colors),
                    vmin=0, vmax=len(unique) - 1, interpolation="none")
-    axes[0].set_xticks([]); axes[0].set_yticks([])
+    axes[0].set_xticks([])
+    axes[0].set_yticks([])
     for spine in axes[0].spines.values():
         spine.set_visible(False)
 
@@ -1161,7 +1161,8 @@ def image_dim_plot(
             ax.scatter(dd["x"], dd["y"], s=size, c=[cols.get(g, "grey")],
                        label=g, linewidths=0)
         ax.set_title(str(img), fontsize=9, fontweight="bold")
-        ax.set_aspect("equal"); ax.axis("off")
+        ax.set_aspect("equal")
+        ax.axis("off")
         if flip_y:
             ax.invert_yaxis()
     for ax in axes_flat[len(images):]:
@@ -1215,7 +1216,8 @@ def image_feature_plot(
         sc = ax.scatter(d["x"], d["y"], s=size, c=d["val"], cmap=cmap,
                         vmin=0, vmax=vmax, linewidths=0)
         ax.set_title(str(img), fontsize=9, fontweight="bold")
-        ax.set_aspect("equal"); ax.axis("off")
+        ax.set_aspect("equal")
+        ax.axis("off")
         if flip_y:
             ax.invert_yaxis()
     for ax in axes_flat[len(images):]:

--- a/shanuz/preprocessing.py
+++ b/shanuz/preprocessing.py
@@ -6,7 +6,7 @@ ScaleData(), and PercentageFeatureSet().
 from __future__ import annotations
 
 import re
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -57,7 +57,6 @@ def _get_assay(seurat, assay: Optional[str]):
 
 def _get_layer(assay_obj, layer: Optional[str]):
     """Get a data matrix from an assay (Assay or Assay5)."""
-    from .assay import Assay
     from .assay5 import Assay5
 
     if isinstance(assay_obj, Assay5):
@@ -81,7 +80,6 @@ def _get_layer(assay_obj, layer: Optional[str]):
 
 def _set_layer(assay_obj, layer: str, value, features: Optional[list[str]] = None) -> None:
     """Store a data matrix in an assay."""
-    from .assay import Assay
     from .assay5 import Assay5
 
     if isinstance(assay_obj, Assay5):
@@ -113,7 +111,6 @@ def percentage_feature_set(
     assay_obj = _get_assay(seurat, assay)
     mat = _get_layer(assay_obj, layer)
 
-    from .assay import Assay
     from .assay5 import Assay5
     if isinstance(assay_obj, Assay5):
         feature_names = assay_obj._all_feature_names
@@ -408,7 +405,6 @@ def find_variable_features(
         raise ValueError(f"Unknown selection_method: {selection_method!r}")
 
     from .assay5 import Assay5
-    from .assay import Assay
     if isinstance(assay_obj, Assay5):
         feature_names = assay_obj._all_feature_names
     else:
@@ -876,7 +872,6 @@ def scale_data(
     assay_obj = seurat.assays[assay_name]
 
     from .assay5 import Assay5
-    from .assay import Assay
 
     if isinstance(assay_obj, Assay5):
         all_features = assay_obj._all_feature_names
@@ -948,7 +943,6 @@ def _regress_out(
     feature_names: list[str],
 ) -> np.ndarray:
     """Regress covariates out of each gene's expression using OLS."""
-    from sklearn.linear_model import LinearRegression
 
     covariates = meta_data[vars_to_regress].values.astype(float)
     # Add intercept

--- a/shanuz/shanuz.py
+++ b/shanuz/shanuz.py
@@ -10,7 +10,7 @@ from packaging.version import Version
 
 from .assay import Assay, create_assay_object
 from .assay5 import Assay5, create_assay5_object
-from .command import ShanuzCommand, log_shanuz_command
+from .command import ShanuzCommand
 from .dimreduc import DimReduc
 from .graph import Graph
 from .neighbor import Neighbor
@@ -371,7 +371,6 @@ class Shanuz:
         old_names = self.cell_names()
         if len(new_names) != len(old_names):
             raise ValueError("new_names must match number of cells.")
-        mapping = dict(zip(old_names, new_names))
 
         new_meta = self.meta_data.copy()
         new_meta.index = new_names

--- a/shanuz/spatial/fov.py
+++ b/shanuz/spatial/fov.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Optional, Sequence, Union
 
-import numpy as np
 import pandas as pd
 
 from .base import SpatialImage
@@ -110,7 +109,6 @@ class FOV(SpatialImage):
         )
 
     def subset(self, cells: list[str]) -> "FOV":
-        cell_set = set(cells)
         new_boundaries = {k: b.subset(cells) for k, b in self.boundaries.items()}
         new_molecules = {k: m.subset(cells) for k, m in self.molecules.items()}
         return FOV(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 """Shared fixtures for shanuz tests."""
 import numpy as np
-import pandas as pd
 import pytest
 import scipy.sparse as sp
 

--- a/tests/test_advanced_tutorial.py
+++ b/tests/test_advanced_tutorial.py
@@ -32,7 +32,7 @@ def _make_object(gene_levels, n_per_cluster=6, housekeeping=50):
     genes = sorted({g for lv in gene_levels.values() for g in lv} | {"MALAT1"})
     gidx = {g: i for i, g in enumerate(genes)}
 
-    cells, idents, cols = [], [], []
+    cells, idents = [], []
     mat = np.zeros((len(genes), len(clusters) * n_per_cluster))
     col = 0
     for cl in clusters:

--- a/tests/test_anchors_seurat_parity.py
+++ b/tests/test_anchors_seurat_parity.py
@@ -272,7 +272,7 @@ def test_the_filter_sees_the_data_layer_not_scale_data():
         assert a_min >= 0.0 and b_min >= 0.0
 
 
-def test_pca_loadings_are_exact_not_randomized():
+def test_randomized_svd_would_visibly_disagree_on_the_trailing_pcs():
     """The reciprocal-PCA anchors need every PC right, not just the leading ones.
 
     ``_pca_loadings`` must use an exact SVD. sklearn's default ``PCA`` picks a

--- a/tests/test_anndata_compat.py
+++ b/tests/test_anndata_compat.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 anndata = pytest.importorskip("anndata", reason="anndata not installed")

--- a/tests/test_assay.py
+++ b/tests/test_assay.py
@@ -1,8 +1,7 @@
 import numpy as np
-import pandas as pd
 import pytest
 import scipy.sparse as sp
-from shanuz import Assay, create_assay_object
+from shanuz import create_assay_object
 
 
 def test_create_from_counts(small_assay):

--- a/tests/test_assay5.py
+++ b/tests/test_assay5.py
@@ -1,7 +1,6 @@
 import numpy as np
-import pytest
 import scipy.sparse as sp
-from shanuz import Assay5, create_assay5_object
+from shanuz import create_assay5_object
 
 
 def test_create(small_assay5):
@@ -73,7 +72,6 @@ def test_repr(small_assay5):
 def _ordered_assay():
     """4 features x 6 cells whose values encode their position, so a permuted
     column is visible by inspection rather than only by a checksum."""
-    from shanuz import create_assay5_object
     mat = sp.csc_matrix(np.arange(1, 25, dtype=float).reshape(4, 6))
     return create_assay5_object(
         counts=mat,

--- a/tests/test_de_parity.py
+++ b/tests/test_de_parity.py
@@ -57,6 +57,24 @@ def two_group_object():
     return obj
 
 
+def test_an_empty_comparison_group_names_the_ident_that_was_empty(two_group_object):
+    # Both empty-group errors used to be reachable, but only the ident_1 one
+    # said which ident it had looked for; the ident_2 branch raised a constant
+    # string that named nothing.
+    with pytest.raises(ValueError, match="ident nope"):
+        find_markers(two_group_object, ident_1="nope")
+    with pytest.raises(ValueError, match="ident alsonope"):
+        find_markers(two_group_object, ident_1="A", ident_2="alsonope")
+
+
+def test_a_lone_ident_says_there_is_nothing_to_compare_against(two_group_object):
+    # `ident_2=None` means "every other ident", so when ident_1 is the only one
+    # present the message has to describe that, not a missing ident_2.
+    two_group_object.idents = ["A"] * len(two_group_object)
+    with pytest.raises(ValueError, match="No cells left outside ident A"):
+        find_markers(two_group_object, ident_1="A")
+
+
 def test_log2fc_matches_seurats_formula(two_group_object):
     obj = two_group_object
     res = find_markers(obj, "A", "B", test_use="wilcox",

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 import scipy.sparse as sp
 from shanuz import Graph, Neighbor

--- a/tests/test_logmap.py
+++ b/tests/test_logmap.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from shanuz import LogMap
 
 
@@ -55,7 +54,7 @@ def test_copy():
     lm = LogMap({"k": np.array([True])})
     lm2 = lm.copy()
     lm2["k"][0] = False
-    assert lm["k"][0] is np.bool_(True) or lm["k"][0] == True
+    assert bool(lm["k"][0]) is True, "copy() shared the underlying array"
 
 
 def test_repr():

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -84,23 +84,40 @@ def test_sctransform_vars_to_regress_removes_covariate_effect():
     covar = rng.standard_normal(N)
     obj.meta_data["percent.mt"] = covar
 
-    sctransform(obj, n_cells=300, n_features=40, seed=0)
-    before = obj.assays["SCT"].layers["scale.data"].toarray()
-    # Inject covariate structure, then regress it out.
-    obj2 = create_shanuz_object(
-        counts=sp.csc_matrix(counts + np.outer(np.ones(G), np.clip(covar, 0, None)) * 2),
-        assay="RNA", feature_names=[f"g{i}" for i in range(G)],
-        cell_names=[f"c{i}" for i in range(N)],
+    # Inject covariate structure into the counts, then run SCTransform twice over
+    # the *same* counts — once plain, once regressing the covariate out. The
+    # baseline has to be the unregressed run on the injected counts: a low
+    # `corr_after` on its own is also what you would see if there had been
+    # nothing to remove, so it does not distinguish a working regression from a
+    # no-op. (This test used to compute a `before` from a different object built
+    # from the *un-injected* counts, and then never assert on it at all.)
+    injected = sp.csc_matrix(
+        counts + np.outer(np.ones(G), np.clip(covar, 0, None)) * 2
     )
-    obj2.meta_data["percent.mt"] = covar
-    sctransform(obj2, vars_to_regress=["percent.mt"], n_cells=300, n_features=40, seed=0)
-    after = obj2.assays["SCT"].layers["scale.data"].toarray()
 
-    # After regression, each gene's residuals are ~uncorrelated with the covariate.
-    corr_after = np.array([
-        abs(np.corrcoef(after[i], covar)[0, 1]) for i in range(after.shape[0])
-    ])
-    assert np.nanmean(corr_after) < 0.05
+    def _residuals(vars_to_regress):
+        o = create_shanuz_object(
+            counts=injected, assay="RNA",
+            feature_names=[f"g{i}" for i in range(G)],
+            cell_names=[f"c{i}" for i in range(N)],
+        )
+        o.meta_data["percent.mt"] = covar
+        sctransform(o, vars_to_regress=vars_to_regress,
+                    n_cells=300, n_features=40, seed=0)
+        return o.assays["SCT"].layers["scale.data"].toarray()
+
+    def _mean_abs_corr(res):
+        return np.nanmean([
+            abs(np.corrcoef(res[i], covar)[0, 1]) for i in range(res.shape[0])
+        ])
+
+    corr_before = _mean_abs_corr(_residuals(None))
+    corr_after = _mean_abs_corr(_residuals(["percent.mt"]))
+
+    # The covariate must be visible in the unregressed residuals in the first
+    # place — otherwise the assertion below is vacuous.
+    assert corr_before > 0.2, f"fixture carries no covariate signal ({corr_before})"
+    assert corr_after < 0.05, f"regression left covariate structure ({corr_after})"
 
 
 def test_sctransform_drops_low_detection_genes():

--- a/tests/test_pseudobulk_conserved.py
+++ b/tests/test_pseudobulk_conserved.py
@@ -1,6 +1,5 @@
 """Tests for AggregateExpression (pseudobulk) and FindConservedMarkers."""
 import numpy as np
-import pandas as pd
 import scipy.sparse as sp
 import pytest
 

--- a/tests/test_seurat.py
+++ b/tests/test_seurat.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as sp
-from shanuz import DimReduc, Shanuz, create_shanuz_object
+from shanuz import DimReduc, create_shanuz_object
 
 
 def test_create(small_seurat):

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -3,8 +3,6 @@ import pandas as pd
 import pytest
 from shanuz import (
     Centroids,
-    FOV,
-    Molecules,
     Segmentation,
     create_centroids,
     create_fov,

--- a/tutorials/generate_dimreduc_plots.py
+++ b/tutorials/generate_dimreduc_plots.py
@@ -34,7 +34,7 @@ if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
 from tutorials.pbmc3k_dimreduc_tutorial import (
-    run_full, FIGURES, JS_DIMS, ALPHA, SCORE_THRESH, TSNE_DIMS,
+    run_full, FIGURES, ALPHA, SCORE_THRESH, TSNE_DIMS,
 )
 from shanuz.plotting import _palette
 

--- a/tutorials/generate_plots.py
+++ b/tutorials/generate_plots.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import matplotlib
 matplotlib.use("Agg")
-import numpy as np
 
 _ROOT = Path(__file__).parent.parent
 if str(_ROOT) not in sys.path:
@@ -32,7 +31,7 @@ from shanuz.umap import run_umap
 from shanuz.markers import find_all_markers
 from shanuz.plotting import (
     vln_plot, feature_plot, dim_plot, dot_plot, elbow_plot,
-    variable_feature_plot, viz_dim_loadings, dim_heatmap, do_heatmap, ridge_plot,
+    variable_feature_plot, viz_dim_loadings, do_heatmap, ridge_plot,
 )
 
 FIGURES = Path(__file__).parent / "figures"
@@ -128,7 +127,7 @@ def main(data_dir=None):
     import matplotlib.pyplot as plt
     fig, axes = plt.subplots(1, 2, figsize=(11, 4.5))
     # Draw both scatters directly into subplots
-    from shanuz.plotting import _get_expression, _get_groups, _palette
+    from shanuz.plotting import _get_expression
     for ax_idx, (f1, f2) in enumerate([("nCount_RNA", "percent.mt"),
                                         ("nCount_RNA", "nFeature_RNA")]):
         ax = axes[ax_idx]
@@ -136,9 +135,11 @@ def main(data_dir=None):
         y = _get_expression(pbmc_raw, f2)
         ax.scatter(x, y, s=4, alpha=0.5, color="#F8766D" if ax_idx == 0 else "#00BFC4",
                    linewidths=0)
-        ax.set_xlabel(f1); ax.set_ylabel(f2)
+        ax.set_xlabel(f1)
+        ax.set_ylabel(f2)
         ax.set_title(f"{f1} vs {f2}")
-        ax.spines["top"].set_visible(False); ax.spines["right"].set_visible(False)
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
     fig.tight_layout()
     _save(fig, "02_qc_scatter.png")
 

--- a/tutorials/generate_sketch_plots.py
+++ b/tutorials/generate_sketch_plots.py
@@ -27,14 +27,13 @@ import matplotlib
 matplotlib.use("Agg")
 
 import numpy as np
-import pandas as pd
 
 _ROOT = Path(__file__).parent.parent
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
 from tutorials.ifnb_sketch_tutorial import (
-    run_full, FIGURES, CELLTYPE, SKETCH_CELLS, _read_r_scores,
+    run_full, FIGURES, SKETCH_CELLS, _read_r_scores,
 )
 from shanuz.plotting import _palette
 

--- a/tutorials/pbmc3k_tutorial.py
+++ b/tutorials/pbmc3k_tutorial.py
@@ -292,7 +292,6 @@ def run_tutorial(data_dir: str | None = None) -> None:
     # -----------------------------------------------------------------------
     section("14. Validate Canonical Marker Expression")
     # -----------------------------------------------------------------------
-    marker_genes_flat = [g for gs in EXPECTED["canonical_markers"].values() for g in gs]
     found_in_markers = set(all_markers["gene"].tolist())
     for cell_type, canon_genes in EXPECTED["canonical_markers"].items():
         hits = [g for g in canon_genes if g in found_in_markers]
@@ -306,7 +305,7 @@ def run_tutorial(data_dir: str | None = None) -> None:
     # Map cluster labels to cell types using known marker patterns
     # This is R's RenameIdents() step
     cluster_to_celltype = _assign_cell_types(all_markers, pbmc)
-    names = new_cluster_ids = {str(k): v for k, v in cluster_to_celltype.items()}
+    names = {str(k): v for k, v in cluster_to_celltype.items()}
     pbmc.rename_idents(names)
     pbmc.meta_data["celltype"] = [str(i) for i in pbmc.idents]
 


### PR DESCRIPTION
`ruff check shanuz` **51 → 0**, `ruff check .` **201 → 0**.

Most of it is what it looks like: unused imports left behind by the Assay5 refactor, dead locals, semicolon-joined statements. But three reports were pointing at something real, and those are the reason this is worth reading.

## A test had been shadowed and never ran

`test_anchors_seurat_parity.py` defined `test_pca_loadings_are_exact_not_randomized` at **line 275 and again at line 422** (F811). Python keeps the second, so the first was collected by nothing.

It is not a duplicate. The surviving copy checks `_pca_loadings` against `np.linalg.svd` and asserts orthonormality and seed-independence. The shadowed one additionally builds sklearn's **randomized** result and asserts it *disagrees* — the guard that the exact SVD is load-bearing rather than an equivalent spelling:

```python
assert rand_pc.min() < 0.9, (
    "if randomized SVD agreed on every PC the exact solver would not matter"
)
```

That is the assertion behind the 45% → 100% RPCA anchor-recall fix, and it had not executed since it was written. Renamed to `test_randomized_svd_would_visibly_disagree_on_the_trailing_pcs`; it passes.

## A regress-out test with no baseline

`test_sctransform_vars_to_regress_removes_covariate_effect` computed `before` (F841) and never asserted on it — and it was the wrong baseline regardless, taken from a *different object built from un-injected counts*. What remained was:

```python
assert np.nanmean(corr_after) < 0.05
```

which is equally satisfied by a fixture that never carried the covariate in the first place. Rewritten to run SCTransform twice over the **same injected counts**, once plain and once regressing, and to require the signal to be present before requiring its removal: **unregressed 0.2526, regressed 0.0000**.

Verified the new half is load-bearing by zeroing the injection — `corr_before` drops to 0.073 and the test now fails there, where the old one passed.

## `find_markers` named one missing ident but not the other

`ident_1` empty said which ident; `ident_2` empty raised a constant `"No cells found for comparison group."` (F541). Both name it now, and since `ident_2=None` means "every other ident", that case reports there is nothing left outside `ident_1` instead of a parameter the caller never passed. Two new tests — the path had **no coverage at all**.

## The rest

Dead locals worth naming: two computed-and-discarded colour maps in `vln_plot` and `dim_plot`, and a `v3` layout flag in `read_10x` that no branch consumed.

The **121 E402s** in `tests/` and `tutorials/` are all one deliberate line — the `sys.path` bootstrap those files need to run straight from a clone. Ignored by scope in `pyproject.toml` rather than by 121 scattered `# noqa: E402`.

## Verification

| | before | after |
|---|---|---|
| `ruff check shanuz` | 51 | **0** |
| `ruff check .` | 201 | **0** |
| suite | 915 / 25 skipped | **918 / 25 skipped** |
| `mypy shanuz` | 0 | 0 |

+1 from the un-shadowed test, +2 new. The `pbmc3k` tutorial was re-run end to end and its `--report` against Seurat 5.5.1 is unchanged (2,638 barcodes, 2,000 HVGs, kNN 52,760, 8 vs 9 clusters). **5 mutations, 5 killed.**

## One thing this does not fix

CI installs ruff **unpinned** and currently resolves **0.16.0**, whose default rule set is much larger — `uvx ruff@0.16.0 check shanuz` reports **644**, dominated by UP045/UP037/UP007 (`Optional[X]` → `X | None`, ~500 sites) and I001 import sorting. Everything above is measured against the pinned local **0.15.20**. Closing that gap is a separate decision: pin ruff in CI, or take the annotation rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)