### PR TITLE
docs: build the documentation site, and fix what it exposed

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,59 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# One deployment at a time, and never cancel one halfway: a cancelled Pages
+# deploy can leave the site serving a partial build.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build the site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Create venv and install
+        run: |
+          uv venv --python 3.12
+          uv pip install -e ".[docs]"
+
+      # --strict, deliberately. Every warning mkdocs can raise on this site is a
+      # real defect: a nav entry with no file, a link to a heading that was
+      # renamed, a `:::` directive naming a function that no longer exists, or a
+      # docstring section a NumPy parser cannot read. Letting those through
+      # would publish a site that looks fine and is quietly wrong, which is the
+      # failure mode this whole repo is built to avoid.
+      - name: Build
+        run: uv run mkdocs build --strict
+
+      - name: Upload the site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    # Only from main. A pull request gets the build above — which is the part
+    # that catches breakage — without publishing anything.
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ coverage.xml
 htmlcov/
 .tox/
 
+# Built documentation (mkdocs.yml's site_dir); GitHub Pages builds its own
+site/
+
 # IDE
 .vscode/
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,58 @@ on `main`; none of it is on PyPI.
 
 ### Added
 
+- **A documentation site.** MkDocs + Material + mkdocstrings, built from `main`
+  and published to GitHub Pages, at
+  [genomicai.github.io/shanuz](https://genomicai.github.io/shanuz/). The API
+  reference is generated from the docstrings — which is the point: eighteen
+  tutorials' worth of hard-won fidelity notes lived in them and rendered
+  nowhere. Alongside it, four hand-written pages (overview, installation, a
+  quickstart whose every line was executed to produce the output it shows, and
+  **Fidelity**, which collects how the port is checked against R, what the
+  checking has caught, and the differences that are real), plus all eighteen
+  vignettes and their figures. `docs/tutorials` is a symlink to `tutorials/`, so
+  there is one copy of each vignette rather than a docs copy that drifts.
+
+  **The blocker recorded for this item was not real.** `ROADMAP.md` said
+  mkdocstrings resolves annotations and that `typing.get_type_hints()` raising
+  `NameError` on the plotting and `graph`/`neighbor` signatures would stop the
+  site on day one. It still raises, on 19 callables — but mkdocstrings reads
+  annotations statically through griffe, without importing the module, so those
+  signatures render and cross-link *because* the `if TYPE_CHECKING:` imports are
+  there. Measured rather than assumed, and written up on the Fidelity page.
+
+  Building it surfaced defects the site was the first consumer to notice:
+
+  - **Three `Returns` sections were being parsed as parameters.** `sctransform`,
+    `add_module_score` and `composition_test` each ended their parameter list
+    with a bare `Returns ...` sentence at the same indentation, so a NumPy
+    parser read it as another parameter and the functions documented no return
+    value at all. `composition_test` also had its eleven output column names
+    parsed as eleven parameters.
+  - **Every one of the 370 documented parameters put its description in the
+    type slot.** The convention across the package is `name : what it does` —
+    prose, never a type, because the types are in the signatures. NumPy format
+    reads that slot as the type, so the site printed "min features a cell must
+    have to be kept" as `min_features`'s type and left its description empty.
+    Fixed in `tools/griffe_sphinx_roles.py`, a build-time translation, rather
+    than by rewriting 370 lines of source that are not wrong.
+  - **129 Sphinx cross-reference roles rendered as literal `:func:` text.** The
+    same extension turns them into real links, but **only** when the target is
+    one the site actually publishes; anything else degrades to a code span,
+    because `--strict` treats an unresolvable link as a failure.
+  - **Fifteen `Slots` blocks collapsed into one run-on line.** Markdown joins
+    consecutive lines, so an aligned column block became a paragraph. Rewritten
+    as bullet lists in the source, which reads better under `help()` too.
+  - **Two heading anchors in `xenium_spatial_tutorial.md` were dead** under
+    python-markdown's slugger while being correct on GitHub. Fixed by adopting
+    GitHub's slugger site-wide, so one set of links works in both places.
+
+  `tests/test_docs.py` asserts the parts that rot silently: every public export
+  appears on an API page, every `:::` directive names something that still
+  exists, no symbol is rendered twice, every nav entry and every vignette figure
+  resolves, and the whole site builds under `--strict`. All nine mutations of
+  those guards were killed.
+
 - **The two R-comparison numbers that were allowed to move are now asserted
   bands, and the reports refuse a stale R reference.** `deseq2`'s overlap with
   Seurat's top 50 and JackStraw's PC cutoff both differ from R for understood

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 [![PyPI](https://img.shields.io/pypi/v/shanuz.svg)](https://pypi.org/project/shanuz/)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Docs](https://img.shields.io/badge/docs-genomicai.github.io%2Fshanuz-17423a.svg)](https://genomicai.github.io/shanuz/)
+
+📖 **[Documentation](https://genomicai.github.io/shanuz/)** — API reference, all
+eighteen tutorials, and [how the port is checked against R
+Seurat](https://genomicai.github.io/shanuz/fidelity/).
 
 **Shanuz** is a Python port of the [Seurat](https://satijalab.org/seurat/) single-cell RNA-seq
 analysis framework, implementing Seurat's core data structures, preprocessing pipeline,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -862,10 +862,15 @@ regime. Don't "simplify" them.
   inside function bodies; `graph.py`/`neighbor.py` annotating each other's
   classes to dodge a circular import). Runtime is unaffected — string annotations
   are never evaluated, which is why 444 tests pass — but `typing.get_type_hints()`
-  raises `NameError` on them, which **blocks the documentation site below**, since
-  mkdocstrings resolves annotations. Fix with `if TYPE_CHECKING:` imports; keep
-  the lazy runtime imports exactly as they are (they keep matplotlib optional and
-  the import graph acyclic).
+  raises `NameError` on them. Fixed with `if TYPE_CHECKING:` imports, keeping the
+  lazy runtime imports exactly as they are (they keep matplotlib optional and the
+  import graph acyclic).
+  **This was recorded as blocking the documentation site, and it was not.**
+  `get_type_hints()` still raises on all 19 of them, because a `TYPE_CHECKING`
+  import does not execute — that is its purpose. mkdocstrings never calls it:
+  griffe reads annotations statically, without importing the module, so the
+  signatures render and cross-link precisely *because* those imports are there.
+  The site was built on top of exactly this state; see below.
 - Add `from __future__ import annotations` to all modules (already done on some)
 - Annotate all public function signatures (`mypy --strict` clean)
 
@@ -1268,21 +1273,38 @@ regime. Don't "simplify" them.
   it distribution-against-distribution over matched seeds — single-run pairs were
   actively misleading on T-sk's sketch composition.
 
-### Documentation site
-- **Do the type annotations first.** mkdocstrings resolves annotations, and
-  `typing.get_type_hints()` currently raises `NameError` on the plotting and
-  `graph`/`neighbor` signatures — the site would hit that on day one.
-- **Tool:** MkDocs + mkdocstrings (Material theme)
-- **Structure:**
-  ```
-  docs/
-    index.md          # Overview
-    installation.md
-    api/              # Auto-generated from docstrings
-    tutorials/        # Symlinks to tutorials/*.md
-    changelog.md
-  ```
-- **Deploy:** GitHub Actions → GitHub Pages on every push to `main`
+### Documentation site — ✅ delivered
+- **Tool:** MkDocs + Material + mkdocstrings, config in
+  [`mkdocs.yml`](https://github.com/GenomicAI/shanuz/blob/main/mkdocs.yml), pages in `docs/`.
+- **Structure:** as planned, except that `docs/tutorials` is a symlink to the
+  whole `tutorials/` directory rather than one symlink per vignette — the
+  vignettes reference their figures by relative path, so the figures have to
+  come with them. `docs/CHANGELOG.md` and `docs/ROADMAP.md` are symlinks under
+  their repo names, which keeps the relative links *inside* those two files
+  working unchanged.
+- **Deploy:** [`.github/workflows/docs.yml`](https://github.com/GenomicAI/shanuz/blob/main/.github/workflows/docs.yml) —
+  `mkdocs build --strict` on every pull request, deploy to GitHub Pages on push
+  to `main`. **Needs Pages set to "GitHub Actions" as its source** in the repo
+  settings; until then the build runs and the deploy step is the only part that
+  fails.
+- **The blocker this item led with was wrong, and worth recording as wrong.**
+  It said mkdocstrings resolves annotations and that `typing.get_type_hints()`
+  raising `NameError` on the plotting and `graph`/`neighbor` signatures would
+  stop the site on day one. `get_type_hints()` still raises, on 19 callables.
+  mkdocstrings never calls it — griffe reads annotations statically, without
+  importing the module — so those signatures render and cross-link *because*
+  the `if TYPE_CHECKING:` imports are there. Clearing mypy (#69, #70) was worth
+  doing on its own merits; it was not a prerequisite for this.
+- **What the site found.** Three `Returns` sections parsed as parameters, all
+  370 documented parameters putting their description in the type slot, 129
+  Sphinx roles rendering as literal text, fifteen `Slots` blocks collapsing into
+  one line, and two dead heading anchors. Details in
+  [`CHANGELOG.md`](CHANGELOG.md); the parameter and role fixes live in
+  [`tools/griffe_sphinx_roles.py`](https://github.com/GenomicAI/shanuz/blob/main/tools/griffe_sphinx_roles.py) as a build-time
+  translation rather than as source churn.
+- **Guarded by** [`tests/test_docs.py`](https://github.com/GenomicAI/shanuz/blob/main/tests/test_docs.py): every public export
+  reaches an API page, every `:::` directive resolves, no symbol is documented
+  twice, every nav entry and figure exists, and the site builds under `--strict`.
 
 ### Changelog — ✅ delivered
 - **File:** [`CHANGELOG.md`](CHANGELOG.md) at repo root, in

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,1 @@
+../ROADMAP.md

--- a/docs/api/clustering.md
+++ b/docs/api/clustering.md
@@ -1,0 +1,22 @@
+# Graphs and clustering
+
+`find_neighbors` builds both graphs Seurat builds — the directed KNN graph and
+the shared-nearest-neighbour graph on top of it — and `find_clusters` runs
+community detection over the SNN.
+
+Four details here were wrong before the integration tutorial went looking, and
+each mattered downstream: the KNN graph is stored directed rather than
+symmetrized, the SNN keeps its diagonal and is computed in float64, `run_umap`
+zeroes the diagonal when handed a graph, and singletons are folded into their
+nearest community the way `GroupSingletons` does. They are noted in the
+docstrings because each one changes cluster assignments, not just internals.
+
+## Neighbour graphs
+
+::: shanuz.neighbors.find_neighbors
+
+::: shanuz.multimodal.find_multi_modal_neighbors
+
+## Community detection
+
+::: shanuz.clustering.find_clusters

--- a/docs/api/demux.md
+++ b/docs/api/demux.md
@@ -1,0 +1,36 @@
+# Demultiplexing and pooled screens
+
+Two workflows that both start from a second assay of oligo counts and end in a
+per-cell call written back into `meta_data`.
+
+**Cell hashing** assigns pooled samples from hashtag counts. `hto_demux` is
+Seurat's `HTODemux` — CLR, cluster into `k = n_hashtags + 1`, per-hashtag
+negative-binomial background threshold, then singlet / doublet / negative.
+`multiseq_demux` is the MULTI-seq alternative, a Gaussian-KDE quantile threshold
+per barcode. On the cross-species ground truth they are 99.81 % call-concordant
+with R.
+
+**Mixscape** separates real CRISPR knockouts from escapers. `calc_perturb_sig`
+subtracts each cell's nearest non-targeting controls; `run_mixscape` then fits
+the two-component mixture per guide; `mixscape_lda` builds the supervised map on
+which each guide population separates.
+
+!!! note "The CLR margin defaults are deliberate"
+    `hto_demux` and `multiseq_demux` normalize across **features** (margin 1),
+    not across cells. That is what `HTODemux` does, and it is not the same
+    default as the general-purpose CLR path. Changing it to 2 to "make them
+    consistent" would break agreement with Seurat.
+
+## Cell hashing
+
+::: shanuz.hto.hto_demux
+
+::: shanuz.multiseq.multiseq_demux
+
+## Mixscape
+
+::: shanuz.mixscape.calc_perturb_sig
+
+::: shanuz.mixscape.run_mixscape
+
+::: shanuz.mixscape.mixscape_lda

--- a/docs/api/dimreduc.md
+++ b/docs/api/dimreduc.md
@@ -1,0 +1,35 @@
+# Dimensional reduction
+
+Linear first, then the embeddings you look at. Every one of these writes a
+[`DimReduc`](objects.md#shanuz.dimreduc.DimReduc) into `obj.reductions` under a
+key, and records the features it actually used — not the features it was asked
+for, which are not always the same set.
+
+`jack_straw` is the permutation test for how many PCs to keep. It is worth
+reading its docstring before trusting the number: R's `JackRandom` seeds each
+replicate from its loop index and is therefore deterministic, while this one
+seeds from its `seed` argument and moves. Across 60 seeds on PBMC 3k it keeps
+12–15 PCs, mode 13, which is R's answer. That spread is asserted as a band, not
+described in prose — see [Fidelity](../fidelity.md#bands).
+
+## Linear
+
+::: shanuz.reduction.run_pca
+
+::: shanuz.reduction.run_spca
+
+::: shanuz.reduction.run_ica
+
+::: shanuz.glmpca.glm_pca
+
+## Non-linear embeddings
+
+::: shanuz.umap.run_umap
+
+::: shanuz.reduction.run_tsne
+
+## How many components to keep
+
+::: shanuz.jackstraw.jack_straw
+
+::: shanuz.jackstraw.score_jackstraw

--- a/docs/api/generics.md
+++ b/docs/api/generics.md
@@ -1,0 +1,24 @@
+# Generics
+
+R's Seurat is built on S4 generics — `Cells(x)`, `Idents(x)`, `LayerData(x, ...)`
+— that dispatch on whatever object you hand them. `shanuz.generics` is the
+same surface as free functions, so code ported from R reads the way it did in R.
+
+Everything here also exists as a method or property on the objects themselves.
+Use whichever fits; they are the same code path.
+
+```python
+from shanuz import generics as g
+
+g.cells(pbmc)            # Cells(pbmc)
+g.idents(pbmc)           # Idents(pbmc)
+g.layer_data(pbmc, "counts")   # LayerData(pbmc, layer = "counts")
+```
+
+::: shanuz.generics
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members_order: alphabetical
+      show_source: false
+      heading_level: 2

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,38 @@
+# API reference
+
+Everything on these pages is exported from the top level, so `shanuz.find_markers`
+and `shanuz.markers.find_markers` are the same object. The grouping below is for
+reading; it is not a package layout you need to know.
+
+The docstrings are the primary source. Many of them record a specific decision
+about matching R — which of Seurat's two code paths a function follows, where a
+default was chosen to agree with `Seurat::` rather than with the wider Python
+ecosystem, and the handful of places the two genuinely differ. Those notes are
+the reason this reference exists rather than a signature dump.
+
+## The map from Seurat
+
+| Seurat | shanuz | Page |
+|---|---|---|
+| `CreateSeuratObject`, `Seurat`, `Assay5` | `create_shanuz_object`, `Shanuz`, `Assay5` | [Objects](objects.md) |
+| `NormalizeData`, `FindVariableFeatures`, `ScaleData`, `SCTransform` | `normalize_data`, `find_variable_features`, `scale_data`, `sctransform` | [Preprocessing](preprocessing.md) |
+| `RunPCA`, `RunUMAP`, `RunTSNE`, `JackStraw` | `run_pca`, `run_umap`, `run_tsne`, `jack_straw` | [Dimensional reduction](dimreduc.md) |
+| `FindNeighbors`, `FindClusters`, `FindMultiModalNeighbors` | `find_neighbors`, `find_clusters`, `find_multi_modal_neighbors` | [Graphs and clustering](clustering.md) |
+| `FindMarkers`, `FindAllMarkers`, `AggregateExpression` | `find_markers`, `find_all_markers`, `aggregate_expression` | [Differential expression](markers.md) |
+| `IntegrateLayers`, `FindIntegrationAnchors`, `MapQuery` | `integrate_layers`, `find_integration_anchors`, `map_query` | [Integration and mapping](integration.md) |
+| `AddModuleScore`, `CellCycleScoring` | `add_module_score`, `cell_cycle_scoring` | [Signature scoring](scoring.md) |
+| `HTODemux`, `MULTIseqDemux`, `RunMixscape` | `hto_demux`, `multiseq_demux`, `run_mixscape` | [Demultiplexing and screens](demux.md) |
+| `LoadXenium`, `BuildNicheAssay`, `FindSpatiallyVariableFeatures` | `load_xenium`, `build_niche_assay`, `find_spatially_variable_features` | [Spatial](spatial.md) |
+| `SketchData`, `LeverageScore`, BPCells matrices | `sketch_data`, `leverage_score`, `LazyMatrix` | [Working at scale](scale.md) |
+| `DimPlot`, `FeaturePlot`, `VlnPlot`, `DoHeatmap` | `dim_plot`, `feature_plot`, `vln_plot`, `do_heatmap` | [Plotting](plotting.md) |
+| `Cells`, `Features`, `Idents`, `FetchData`, `LayerData` | `cells`, `features`, `idents`, `fetch_data`, `layer_data` | [Generics](generics.md) |
+| `Read10X`, `SeuratData::` | `read_10x`, `shanuz.datasets` | [Loading data](io.md) |
+
+## Reading the signatures
+
+Type annotations are resolved statically, straight from the source, so
+annotation-only imports guarded by `if TYPE_CHECKING:` still render and still
+cross-link. Three of them matter in practice — `matplotlib.figure.Figure` on
+every plotting function, `Neighbor` on `as_graph`, and `Shanuz` on
+`from_anndata` — and all three are deliberate: they keep matplotlib optional and
+break two import cycles. See [Fidelity](../fidelity.md#the-annotations-that-only-exist-for-readers).

--- a/docs/api/integration.md
+++ b/docs/api/integration.md
@@ -1,0 +1,43 @@
+# Integration and reference mapping
+
+Two different jobs that share machinery. **Integration** removes a batch effect
+between datasets you intend to analyse together. **Reference mapping** leaves the
+reference untouched and projects a query into it, carrying labels across.
+
+`integrate_layers` is the v5 dispatcher — `method="harmony" | "cca" | "rpca"` —
+and runs `integrate_embeddings`, the embedding-space algorithm, as Seurat v5
+does. The v4 pair (`find_integration_anchors` + `integrate_data`, which corrects
+expression rather than embeddings) is still available directly and is still what
+you want if you are reproducing a v4 analysis. These were the same function once,
+which was a bug: the v5 name ran the v4 algorithm.
+
+Both anchor paths are compared against Seurat's own anchors, not just against the
+clustering they produce, in [Anchor internals](../tutorials/anchors_vignette.md).
+
+## Batch correction
+
+::: shanuz.integration.integrate_layers
+
+::: shanuz.integration.run_harmony
+
+## Anchors, directly
+
+::: shanuz.anchors.find_integration_anchors
+
+::: shanuz.anchors.integrate_embeddings
+
+::: shanuz.anchors.integrate_data
+
+::: shanuz.anchors.IntegrationAnchors
+
+## Reference mapping
+
+::: shanuz.transfer.find_transfer_anchors
+
+::: shanuz.transfer.transfer_data
+
+::: shanuz.transfer.TransferAnchors
+
+::: shanuz.mapping.map_query
+
+::: shanuz.mapping.project_umap

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -1,0 +1,36 @@
+# Loading data
+
+## From 10x output
+
+::: shanuz.io.read_10x
+
+## Bundled datasets
+
+`shanuz.datasets` stands in for R's `SeuratData`. Each loader downloads on first
+call into `~/.shanuz_data/` and returns a ready `Shanuz` object; the whole set is
+roughly 770 MB cached. These are the datasets the [tutorials](../tutorials/README.md)
+run on, which is what makes each tutorial reproducible from a clean machine.
+
+::: shanuz.datasets.pbmc3k
+
+::: shanuz.datasets.pbmc8k
+
+::: shanuz.datasets.cbmc_citeseq
+
+::: shanuz.datasets.pbmc_hashing
+
+::: shanuz.datasets.ifnb
+
+::: shanuz.datasets.panc8
+
+::: shanuz.datasets.thp1_eccite
+
+::: shanuz.datasets.xenium_mouse_brain
+
+::: shanuz.datasets.visium_mouse_brain
+
+## AnnData interoperability
+
+::: shanuz.compat.anndata.as_anndata
+
+::: shanuz.compat.anndata.from_anndata

--- a/docs/api/markers.md
+++ b/docs/api/markers.md
@@ -1,0 +1,29 @@
+# Differential expression
+
+`find_markers` implements all eight of Seurat's tests: `wilcox` (tie-corrected),
+`t`, `bimod`, `LR`, `negbinom`, `roc`, `mast` and `deseq2`. Seven of them are
+per-cell and reproduce Seurat's top 50 genes exactly on PBMC 3k; `deseq2` is
+pseudobulk and deliberately does not, because it is answering a different
+question — see [the DE vignette](../tutorials/de_vignette.md).
+
+Two numbers to know before reading a result table:
+
+- **`avg_log2FC` carries Seurat's pseudocount on the group *sum*, not the group
+  mean.** Getting that backwards shifts every fold change and also changes which
+  genes clear `logfc_threshold`, so it silently changes the returned gene set,
+  not just a column.
+- **`pct.1` and `pct.2` are rounded to three decimals**, by Seurat, inside
+  `FindMarkers`. Anything comparing two runs gene-by-gene should not expect them
+  closer than 5e-4.
+
+## Per-cluster and per-pair tests
+
+::: shanuz.markers.find_markers
+
+::: shanuz.markers.find_all_markers
+
+::: shanuz.markers.find_conserved_markers
+
+## Pseudobulk
+
+::: shanuz.aggregate.aggregate_expression

--- a/docs/api/objects.md
+++ b/docs/api/objects.md
@@ -1,0 +1,55 @@
+# Objects
+
+The container, before any analysis touches it. `Shanuz` holds one or more assays,
+the reductions computed off them, the neighbour graphs, the per-cell metadata and
+the command log — the same slots R's `Seurat` S4 class holds, as ordinary Python
+classes with `__slots__`.
+
+The one structural difference worth knowing up front: R's `Assay5` inherits from
+`dgCMatrix`; here `Assay5` *wraps* a SciPy CSC matrix rather than subclassing it,
+because subclassing `scipy.sparse` is a well-known trap. Everything you reach
+through [the generics](generics.md) behaves the same either way.
+
+The object model is checked against Seurat anchor by anchor in
+[The Object Model Itself](../tutorials/objects_vignette.md) — 91 of 91 exact, no
+tolerance.
+
+## The top-level object
+
+::: shanuz.shanuz.Shanuz
+
+::: shanuz.shanuz.create_shanuz_object
+
+## Assays
+
+::: shanuz.assay5.Assay5
+
+::: shanuz.assay5.create_assay5_object
+
+::: shanuz.assay5.StdAssay
+
+::: shanuz.assay.Assay
+
+::: shanuz.assay.create_assay_object
+
+## Reductions, graphs and neighbours
+
+::: shanuz.dimreduc.DimReduc
+
+::: shanuz.graph.Graph
+
+::: shanuz.graph.as_graph
+
+::: shanuz.neighbor.Neighbor
+
+## Supporting structures
+
+::: shanuz.jackstraw.JackStrawData
+
+::: shanuz.logmap.LogMap
+
+::: shanuz.mixins.key_mixin.KeyMixin
+
+::: shanuz.command.ShanuzCommand
+
+::: shanuz.command.log_shanuz_command

--- a/docs/api/plotting.md
+++ b/docs/api/plotting.md
@@ -1,0 +1,52 @@
+# Plotting
+
+Every function here returns a matplotlib `Figure`, so you save it, compose it, or
+let a notebook display it:
+
+```python
+fig = shanuz.dim_plot(pbmc, reduction="umap", label=True)
+fig.savefig("umap.png", dpi=150, bbox_inches="tight")
+```
+
+matplotlib and seaborn are **optional** — they live in the `analysis` extra, and
+`import shanuz` works without them. That is why the `Figure` return annotation is
+an `if TYPE_CHECKING:` import: it documents the return type without making the
+import mandatory.
+
+::: shanuz.plotting.dim_plot
+
+::: shanuz.plotting.feature_plot
+
+::: shanuz.plotting.vln_plot
+
+::: shanuz.plotting.ridge_plot
+
+::: shanuz.plotting.dot_plot
+
+::: shanuz.plotting.feature_scatter
+
+::: shanuz.plotting.elbow_plot
+
+::: shanuz.plotting.variable_feature_plot
+
+::: shanuz.plotting.viz_dim_loadings
+
+::: shanuz.plotting.dim_heatmap
+
+::: shanuz.plotting.do_heatmap
+
+## Spatial
+
+::: shanuz.plotting.image_dim_plot
+
+::: shanuz.plotting.image_feature_plot
+
+::: shanuz.plotting.spatial_dim_plot
+
+::: shanuz.plotting.spatial_feature_plot
+
+## Mixscape diagnostics
+
+::: shanuz.plotting.plot_perturb_score
+
+::: shanuz.plotting.mixscape_heatmap

--- a/docs/api/preprocessing.md
+++ b/docs/api/preprocessing.md
@@ -1,0 +1,27 @@
+# Preprocessing
+
+Counts to something you can do statistics on. Two routes, both of Seurat's:
+log-normalize → find variable features → scale, or `sctransform` in one call.
+
+`find_variable_features` has two selectors and they honour different arguments —
+`"vst"` and `"disp"` take `nfeatures`, `"mvp"` takes the mean and dispersion
+cutoffs. That is Seurat's behaviour, not a quirk of the port; the docstring says
+which is which.
+
+Verified against Seurat in [PBMC 3k](../tutorials/pbmc3k_tutorial.md) and, for the
+regularized-NB route, per fitted gene in
+[SCTransform](../tutorials/sctransform_vignette.md).
+
+## Log-normalize workflow
+
+::: shanuz.preprocessing.normalize_data
+
+::: shanuz.preprocessing.find_variable_features
+
+::: shanuz.preprocessing.scale_data
+
+::: shanuz.preprocessing.percentage_feature_set
+
+## Regularized negative binomial
+
+::: shanuz.sctransform.sctransform

--- a/docs/api/scale.md
+++ b/docs/api/scale.md
@@ -1,0 +1,33 @@
+# Working at scale
+
+Two independent answers to a dataset that will not fit: analyse a representative
+subset, or keep the matrix on disk.
+
+**Sketching** draws a leverage-weighted subset — rare states kept rather than
+sampled away — analyses that, then extends the result back to every cell.
+`leverage_score` gets the per-cell scores via a CountSketch, without a full SVD.
+
+**`LazyMatrix`** is the on-disk path, memory-mapped compressed-sparse-column
+arrays in BPCells' spirit but with no new dependency. A slice reads only the
+cells it touches, `col_blocks` streams a million cells at bounded RAM, and it
+drops straight into an `Assay5` layer. Against BPCells on PBMC 3k, shanuz's
+on-disk and in-memory paths are bit-identical to each other; Seurat's differ by
+1.0e-06. [The comparison](../tutorials/lazy_vignette.md).
+
+## Sketching
+
+::: shanuz.sketch.leverage_score
+
+::: shanuz.sketch.sketch_data
+
+::: shanuz.sketch.project_data
+
+## Out-of-core matrices
+
+::: shanuz.lazy.LazyMatrix
+
+::: shanuz.lazy.write_lazy_matrix
+
+::: shanuz.lazy.open_lazy_matrix
+
+::: shanuz.lazy.is_lazy

--- a/docs/api/scoring.md
+++ b/docs/api/scoring.md
@@ -1,0 +1,18 @@
+# Signature scoring
+
+Score a gene programme per cell against a background of expression-matched
+control genes. `cell_cycle_scoring` is `add_module_score` run twice, on the S and
+G2/M lists, plus the discrete phase call.
+
+The control genes are drawn at random from expression bins, so these scores carry
+an RNG. Against R Seurat the per-cell phase call is 96.6 % concordant and the
+continuous scores correlate at Pearson ≥ 0.998 — the residual is the control
+draw, and nothing else. [Cell-cycle vignette](../tutorials/cellcycle_vignette.md).
+
+::: shanuz.module_score.add_module_score
+
+::: shanuz.module_score.cell_cycle_scoring
+
+## The bundled gene lists
+
+::: shanuz.module_score.CC_GENES

--- a/docs/api/spatial.md
+++ b/docs/api/spatial.md
@@ -1,0 +1,69 @@
+# Spatial
+
+Imaging-based and spot-based assays: Xenium, Visium, CosMx and MERSCOPE. The
+container mirrors Seurat v5's — an `FOV` holding `Centroids`, `Segmentation`
+and `Molecules` boundaries, or a `VisiumV2` holding the H&E image and its
+`ScaleFactors`.
+
+!!! warning "`radius` on a Visium FOV"
+    Seurat stores `spot_diameter_fullres` in the FOV's `radius` slot — a
+    diameter where a radius is named — and `Radius()` on its own `VisiumV2`
+    returns `NULL`. `load_visium` stores a radius. The slide's fixed 100 µm spot
+    pitch is what settles which reading is right; the working is in
+    [the Visium vignette](../tutorials/visium_vignette.md).
+
+`find_spatially_variable_features` computes Moran's I on R's inverse-square
+distance weights, not on a kNN graph. Those give different answers, and the kNN
+version was the bug.
+
+## Loading
+
+::: shanuz.spatial.loaders.load_xenium
+
+::: shanuz.spatial.loaders.load_visium
+
+::: shanuz.spatial.loaders.load_cosmx
+
+::: shanuz.spatial.loaders.load_merscope
+
+## Containers
+
+::: shanuz.spatial.fov.FOV
+
+::: shanuz.spatial.fov.create_fov
+
+::: shanuz.spatial.fov.create_fovs
+
+::: shanuz.spatial.centroids.Centroids
+
+::: shanuz.spatial.centroids.create_centroids
+
+::: shanuz.spatial.segmentation.Segmentation
+
+::: shanuz.spatial.segmentation.create_segmentation
+
+::: shanuz.spatial.molecules.Molecules
+
+::: shanuz.spatial.molecules.create_molecules
+
+::: shanuz.spatial.base.SpatialImage
+
+::: shanuz.spatial.visium.VisiumV2
+
+::: shanuz.spatial.visium.ScaleFactors
+
+## Spatial analysis
+
+::: shanuz.spatial.analysis.get_tissue_coordinates
+
+::: shanuz.spatial.analysis.spatial_knn
+
+::: shanuz.spatial.analysis.nearest_neighbor_distance
+
+::: shanuz.spatial.analysis.local_neighborhood
+
+::: shanuz.spatial.analysis.build_niche_assay
+
+::: shanuz.spatial.variable_features.find_spatially_variable_features
+
+::: shanuz.composition.composition_test

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -1,0 +1,188 @@
+# Fidelity
+
+A port is only worth as much as its evidence. This page is how `shanuz` is
+checked against R Seurat, what the checking has found, and where the two tools
+genuinely disagree.
+
+## How the checking works
+
+Every [tutorial](tutorials/README.md) is three files, not one:
+
+| File | What it does |
+|---|---|
+| `tutorials/<name>_tutorial.py` | Runs the analysis in Python and writes a numeric handoff |
+| `tutorials/<name>_verify.R` | Runs the same analysis under real Seurat and writes its own |
+| `tutorials/<name>_vignette.md` | The write-up, with both sides' code and the comparison |
+
+```bash
+python tutorials/pbmc3k_de_tutorial.py            # writes the handoff
+Rscript tutorials/pbmc3k_de_verify.R              # reads it, writes R's answers
+python tutorials/pbmc3k_de_tutorial.py --report   # compares; exits non-zero if it should
+```
+
+**Order matters, and the tools now enforce it.** Python runs first because it
+writes the handoff the R script reads. The references were taken on
+**Seurat 5.5.1**.
+
+### Two kinds of comparison, deliberately
+
+Some tutorials pin nothing: both sides start from the same 10x bytes and run
+their own pipeline end to end. That tests what a user actually experiences — the
+same cells surviving QC, the same variable genes, the same clusters. PBMC 3k is
+one of these.
+
+Others pin the cells and features and hand them to R explicitly, so a difference
+in an earlier stage cannot pose as a difference in the one under test. The DE
+suite is the clearest case: all eight tests run on **one shared cluster
+assignment**, because otherwise a clustering difference would surface as a DE
+difference and be attributed to the wrong function.
+
+### Anchors, not vibes
+
+Each comparison declares specific quantities. An *anchor* is one named number
+that must match, at a stated tolerance or exactly. "91 of 91 anchors match, no
+tolerance" is a claim you can check line by line; "the object model works" is
+not.
+
+## What the checking has caught
+
+The tutorials are the debugging apparatus, not a showcase. Each vignette names
+the defects its own comparison found:
+
+| Tutorial | Found |
+|---|---|
+| [Anchor internals](tutorials/anchors_vignette.md) | **18** — CCA standardizing instead of L2-normalizing, randomized SVD drifting reciprocal-PCA's trailing PCs, `integrate_layers` silently running v4's algorithm behind the v5 name, a symmetrized KNN graph, a missing SNN diagonal |
+| [The object model](tutorials/objects_vignette.md) | **11** — a split/join round trip that silently misordered columns, `FetchData` returning sparse objects instead of numbers, an inert command log |
+| [Batch integration](tutorials/integration_vignette.md) | **8** — a crash on unequal batch sizes, and a 4× under-integration: batch mixing 0.222 → 0.867 → 0.991 |
+| [Out of core](tutorials/lazy_vignette.md) | **7** — five functions that densified the whole store, so going on disk *raised* peak memory 4.6× |
+| [Spatial statistics](tutorials/svf_vignette.md) | **3** — Moran's I on a kNN graph instead of R's inverse-square weights, centroids with no radius, unclosed polygons |
+| [Dim-reduction extras](tutorials/dimreduc_vignette.md) | **2** — a too-tight JackStraw null, and the wrong aggregation test |
+| [Leverage sketching](tutorials/sketch_vignette.md) | **2** — full-rank leverage, anchor-based label transfer |
+| [The DE test suite](tutorials/de_vignette.md) | **2** — Seurat's pseudocount applied to the group mean instead of the sum, which also changed *which genes* `logfc_threshold` returned |
+| [Visium](tutorials/visium_vignette.md) | **1 in shanuz, and 1 in Seurat** — the first tutorial where R is the one that's wrong |
+
+Two lessons worth stating outright, because both cost real time:
+
+**A documented caveat is where a defect hides.** Twice, a genuine bug sat behind
+a comment explaining it as an expected language difference — the SCTransform
+model was one, JackStraw's null another. A "known difference" nobody has measured
+is a hypothesis, not a finding.
+
+**A fix can make the headline number worse and still be the fix.** Sketching's
+`project_data` scored *above* Seurat while it was broken. When a divergence
+flatters the port, that is a reason to look harder, not to keep it.
+
+## What actually differs { #what-actually-differs }
+
+Real, understood, and not going away:
+
+**Louvain cluster counts drift by one.** Both tools run the same algorithm at the
+same resolution and land on different local optima. On PBMC 3k, shanuz finds 8
+clusters to Seurat's 9 at ARI 0.938. On ifnb RPCA, Seurat's deeper modularity
+search buys 0.17 % modularity by splitting CD14 Mono along the batch — and
+shanuz's coarser partition then scores **ARI 0.92 against the annotations to
+Seurat's 0.74**. The coarser answer is the better one there.
+
+**Variable-feature selection jitters at the boundary.** 1,998 of 2,000 genes
+shared on PBMC 3k. The genes that swap sit at ranks 1916–2016, where
+standardized variances differ in the third decimal. Harmless in itself — but it
+changes which genes a later stage sees, which is why references have to be
+regenerated together rather than piecemeal.
+
+**Anything with an RNG differs by its RNG, and only by that.** `add_module_score`
+draws control genes at random: per-cell phase calls come out 96.6 % concordant
+and the continuous scores correlate at Pearson ≥ 0.998. JackStraw permutes.
+Differences here get proved distribution-against-distribution over matched seeds,
+never from a single pair — single-run pairs were actively misleading on the
+sketch composition.
+
+**R's `clara` is architecture-dependent.** It gives different answers on arm64
+and x86_64. The port targets IEEE/x86_64 semantics on purpose rather than
+emulating whichever one a given laptop produces.
+
+**Seurat's default neighbour search is approximate.** `annoy` against an exact
+search is a difference in the *reference*, not in either implementation. The
+verify scripts pass `nn.method = "rann"`; skipping that once cost one script a
+false negative of 182 SNN edges.
+
+## Numbers that move are declared as bands { #bands }
+
+A comparison that legitimately varies used to carry a prose caveat — "expect
+around 22 of 50 here" — and prose does not fail a build. A regression landing
+inside the expected spread read as normal variation.
+
+`tutorials/bands.py` replaces those caveats with `Band` objects carrying a range
+**and the reason for it**. `--report` prints a verdict per band and exits
+non-zero outside one. Two rules make them worth having:
+
+- **Every band came from a sweep, not from one run.** The JackStraw band is 60
+  seeds; the DESeq2 band is 20 resampled replicate splits.
+- **A missing measurement fails.** `Band.holds(nan)` is `False`, because a
+  measurement that quietly vanished is exactly how a stale reference goes
+  unnoticed.
+
+| Band | Range | Why it is where it is |
+|---|---|---|
+| JackStraw PC cutoff | \|shanuz − R\| ≤ 2 | R's `JackRandom` seeds each replicate from its loop index, so R is deterministic at 13. shanuz seeds from its `seed` argument and keeps 12/13/14/15 for 2/28/11/19 of 60 seeds — mode 13, which is R's answer. |
+| `deseq2` top-50 overlap | 15–32 | Measured 20–26 over 20 replicate splits, median 22. A **divergence** measurement, not a parity target, and the *upper* bound is the load-bearing half: reaching 50 would mean `sample_col` had stopped being honoured and the pseudobulk aggregation was no longer happening. |
+| The other seven DE tests | exactly 50 | Two different cluster assignments both gave 50 of 50. One dropped gene is a regression. |
+| `roc` max ∆AUC | ≤ 5e-4 | Half a unit in Seurat's third decimal. Measured 4.9986e-4 — bands are inclusive by design, and this one sits on its boundary. |
+
+`max |Δlog2FC|` excludes `deseq2` **by name rather than by threshold**: its 3.47
+is correct — a pseudobulk fold change on summed counts — and a threshold wide
+enough to admit it would set the tolerance for everyone else.
+
+## The reference has to be the one the handoff asked for
+
+Three of the comparison paths would silently accept an out-of-date R reference,
+and one was actively doing so: a Python run from 25 July compared against R files
+from 19 July, taken on a *different* cluster assignment, printing a full parity
+table that showed `wilcox` at 48 of 50 with p-value Spearman 0.907. Against a
+matching R run it is 50 of 50 at 1.000000. The regression was in the reference.
+
+The guards now in `tutorials/bands.py`:
+
+- **DE**: `pct.1` and `pct.2` must agree to 5e-4. They are counts of detected
+  cells per group with no statistics in the way, which is what makes them the
+  discriminator — they had differed for 12,491 of 13,712 genes. To 5e-4 and no
+  closer, because Seurat rounds them to three decimals.
+- **Dim-reduction**: exact cell-set and feature-set equality. The old code
+  reindexed R's frame onto Python's cells, which filled absent barcodes with NaN
+  and printed `nan` correlations without complaint.
+- **`pytest` no longer corrupts the handoff.** `prep()` wrote the HVG and cell
+  lists unconditionally, so running the test suite replaced 2,000 real variable
+  features with 100 synthetic genes named `GENE171` — which the R verify script
+  then read.
+
+## The annotations that only exist for readers { #the-annotations-that-only-exist-for-readers }
+
+Three groups of annotations in this package name symbols that do not exist at
+runtime. All are guarded by `if TYPE_CHECKING:`, and all are deliberate:
+
+- `matplotlib.figure.Figure`, on all 17 plotting functions, so matplotlib stays
+  an optional dependency;
+- `Neighbor` in `graph.py`, because `Graph` and `Neighbor` convert into each
+  other and a module-scope import would be a genuine cycle;
+- `Shanuz` in `compat/anndata.py`, for the same reason.
+
+**`typing.get_type_hints()` raises `NameError` on all 19 of them**, and that was
+recorded as a blocker for this documentation site. It turned out not to be one.
+mkdocstrings reads annotations *statically*, through griffe, without importing
+the module — so the signatures render and the types cross-link precisely
+*because* the deferred imports are there. Runtime resolution is a separate
+question that nothing here needs an answer to.
+
+## Reproducing any of it
+
+```bash
+git clone https://github.com/GenomicAI/shanuz.git
+cd shanuz && uv venv && uv pip install -e ".[all]"
+
+python tutorials/pbmc3k_de_tutorial.py
+Rscript tutorials/pbmc3k_de_verify.R
+python tutorials/pbmc3k_de_tutorial.py --report
+```
+
+Every vignette's header names the datasets it needs and the R packages beyond
+Seurat. Data downloads on first run to `~/.shanuz_data/`; the full set is about
+770 MB.

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,9 +89,11 @@ genuinely differ.
 
 </div>
 
-!!! warning "The PyPI release lags `main`"
-    The newest release is **0.2.0**. Reference mapping, sketching, `LazyMatrix`,
-    cell hashing, Mixscape, `run_spca`/`glm_pca`, pseudobulk DE and the
-    MERSCOPE/Visium additions are on `main` but **not** in `pip install shanuz`
-    yet. [The changelog](CHANGELOG.md) records exactly what is where; these docs
-    are built from `main`.
+!!! info "`pip install shanuz` is current"
+    The newest release is **0.9.0**, which closed a long-standing gap: reference
+    mapping, sketching, `LazyMatrix`, cell hashing, Mixscape, `run_spca`/
+    `glm_pca`, pseudobulk DE and the MERSCOPE/Visium additions had all sat on
+    `main` since 0.2.0 with no release to match. They're all in `pip install
+    shanuz` now. These docs are built from `main`, so the next gap — if one
+    opens — will show up here first; [the changelog](CHANGELOG.md) is the
+    authority on exactly what shipped when.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,97 @@
+---
+hide:
+  - navigation
+---
+
+# shanuz
+
+**Seurat's single-cell pipeline, in Python, checked against R Seurat number by
+number.**
+
+`shanuz` ports Seurat v5 — the object model, preprocessing, dimensional
+reduction, clustering, differential expression, integration, spatial and the
+rest — to pure Python on NumPy, SciPy and pandas. It is not a reimplementation
+that borrows the ideas. It follows the same code paths, keeps the same defaults,
+and where the two disagree, the disagreement is measured and written down.
+
+```python
+import shanuz
+from shanuz.datasets import pbmc3k
+
+counts, genes, cells = pbmc3k()
+pbmc = shanuz.create_shanuz_object(
+    counts=counts, feature_names=genes, cell_names=cells,
+    project="pbmc3k", min_cells=3, min_features=200,
+)
+
+shanuz.normalize_data(pbmc)
+shanuz.find_variable_features(pbmc, selection_method="vst", nfeatures=2000)
+shanuz.scale_data(pbmc)
+shanuz.run_pca(pbmc, n_pcs=50)
+shanuz.find_neighbors(pbmc, dims=range(10), k_param=20)
+shanuz.find_clusters(pbmc, resolution=0.5)
+shanuz.run_umap(pbmc, dims=range(10), seed=42)
+
+markers = shanuz.find_all_markers(pbmc, only_pos=True, min_pct=0.25)
+```
+
+[Install it](installation.md){ .md-button .md-button--primary }
+[Run the first tutorial](tutorials/pbmc3k_tutorial.md){ .md-button }
+
+## What "checked against R" means here
+
+Eighteen tutorials, each with a matching R script that runs the same analysis
+under real Seurat 5.5.1 on the same data, and a comparison that names specific
+numbers rather than declaring success. A few of them:
+
+| Comparison | Result |
+|---|---|
+| Object model — `Cells`, `Layers`, `FetchData`, `Idents`, `Command` | 91 of 91 anchors exact, no tolerance |
+| Differential expression, all eight tests | seven per-cell tests reproduce Seurat's top 50 exactly; `avg_log2FC` to 7.1e-15 |
+| Anchors, RPCA | 649 of 649 of Seurat's v4 anchors, 30 of 30 v5 embedding PCs |
+| Moran's I on 36,602 Xenium cells | 1.6e-14, on a slide R cannot hold in memory |
+| Cell hashing against cross-species ground truth | 99.81 % call-concordant |
+| Label transfer, celseq2 → smartseq2 | 98.71 % per-cell concordant |
+
+The tutorials are not a demo. **They are how the defects were found** — dozens of
+them in this package, and one in Seurat. Each vignette says which bugs its
+comparison caught and what the number was before and after. See
+[Fidelity](fidelity.md) for how the checking works and where the two tools
+genuinely differ.
+
+## Where to start
+
+<div class="grid cards" markdown>
+
+-   **[Installation](installation.md)**
+
+    Python 3.12+. `pip install shanuz`, plus which extra you need for what.
+
+-   **[Quickstart](quickstart.md)**
+
+    PBMC 3k from counts to labelled clusters, and the same thing in R.
+
+-   **[Tutorials](tutorials/README.md)**
+
+    Eighteen workflows, each side by side with its R original.
+
+-   **[API reference](api/index.md)**
+
+    Every public function, with the Seurat call it mirrors.
+
+-   **[Fidelity](fidelity.md)**
+
+    How the port is verified, and the differences that are real.
+
+-   **[Changelog](CHANGELOG.md)**
+
+    What has shipped, and what is only on `main`.
+
+</div>
+
+!!! warning "The PyPI release lags `main`"
+    The newest release is **0.2.0**. Reference mapping, sketching, `LazyMatrix`,
+    cell hashing, Mixscape, `run_spca`/`glm_pca`, pseudobulk DE and the
+    MERSCOPE/Visium additions are on `main` but **not** in `pip install shanuz`
+    yet. [The changelog](CHANGELOG.md) records exactly what is where; these docs
+    are built from `main`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,87 @@
+# Installation
+
+**Python 3.12 or newer.** CI tests 3.12 and 3.13.
+
+## From PyPI
+
+```bash
+pip install shanuz
+```
+
+That gets the core: the object model, preprocessing, PCA and marker detection,
+on `numpy`, `scipy`, `pandas` and `packaging` alone. Everything heavier is an
+extra, and everything heavier is imported lazily — a base install imports and
+runs without matplotlib, scikit-learn or umap-learn anywhere on the system.
+
+| Extra | Adds | You need it for |
+|---|---|---|
+| `analysis` | statsmodels, scikit-learn, numba, umap-learn, igraph, leidenalg, matplotlib, seaborn, scikit-misc | Clustering, UMAP/t-SNE, every plot, and the `LR`/`negbinom`/`mast` DE tests |
+| `anndata` | anndata | `as_anndata` / `from_anndata` |
+| `integration` | harmonypy | `run_harmony`, and `integrate_layers(method="harmony")` |
+| `deseq2` | pydeseq2 | `find_markers(test_use="deseq2", ...)` |
+| `all` | all of the above, plus the dev tooling | Running the test suite |
+
+```bash
+pip install "shanuz[analysis]"      # what most analyses want
+pip install "shanuz[all]"           # everything
+```
+
+Or with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv pip install "shanuz[analysis]"
+```
+
+## From source
+
+The PyPI release is **0.2.0** and `main` is well ahead of it — reference
+mapping, sketching, `LazyMatrix`, cell hashing, Mixscape, `run_spca`/`glm_pca`,
+pseudobulk DE and the MERSCOPE/Visium work are all source-only right now.
+[The changelog](CHANGELOG.md) is the authority on which is which.
+
+```bash
+git clone https://github.com/GenomicAI/shanuz.git
+cd shanuz
+uv venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+uv pip install -e ".[all]"
+```
+
+A source checkout is also what the [tutorials](tutorials/README.md) expect: each
+one is a script in `tutorials/` next to the R script it is checked against.
+
+## Why the floor is 3.12
+
+`requires-python` tracks [SPEC 0](https://scientific-python.org/specs/spec-0000/)
+— three years past each Python release — because numpy, scipy, pandas and
+scikit-learn are what actually constrain this package, and that is the calendar
+they keep. It is stricter than CPython's own EOL schedule, which would have held
+3.11 until October 2027.
+
+Published releases stay installable on the versions they declared: on 3.10 or
+3.11, `pip` resolves to **0.2.0**, the last release with `>=3.10`. Nothing breaks
+retroactively.
+
+**3.14 is one package away.** Everything in the dependency set has cp314 wheels
+except `harmonypy`, which publishes manylinux wheels only through cp313. Without
+one, a 3.14 install either builds it from source — needing BLAS and a
+CMake-fetched armadillo — or lets the resolver backtrack to harmonypy 0.2.0,
+which depends on torch and drags in the whole CUDA stack. Neither is worth
+declaring support for, so the CI matrix stops at 3.13 until that wheel exists.
+
+## R, for the comparisons
+
+Nothing in `shanuz` needs R. The R side is only for reproducing the
+[fidelity checks](fidelity.md) yourself — each tutorial ships a `*_verify.R`
+that runs the same analysis under Seurat and writes the numbers the Python
+script compares against.
+
+```r
+install.packages("Seurat")            # 5.5.1 is what the references were taken on
+install.packages("remotes")
+remotes::install_github("satijalab/seurat-data")
+```
+
+Four tutorials need more: `harmony` for integration, `MAST` and `DESeq2`
+(Bioconductor) for two of the DE tests, and `BPCells` for the out-of-core
+comparison.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,10 +34,12 @@ uv pip install "shanuz[analysis]"
 
 ## From source
 
-The PyPI release is **0.2.0** and `main` is well ahead of it — reference
-mapping, sketching, `LazyMatrix`, cell hashing, Mixscape, `run_spca`/`glm_pca`,
-pseudobulk DE and the MERSCOPE/Visium work are all source-only right now.
-[The changelog](CHANGELOG.md) is the authority on which is which.
+The PyPI release is **0.9.0**, which as of 2026-07-27 tracks `main` closely —
+reference mapping, sketching, `LazyMatrix`, cell hashing, Mixscape,
+`run_spca`/`glm_pca`, pseudobulk DE and the MERSCOPE/Visium work are all in it.
+A source checkout is still how to get anything that lands on `main` afterward,
+before the next release; [the changelog](CHANGELOG.md) is the authority on
+which is which.
 
 ```bash
 git clone https://github.com/GenomicAI/shanuz.git

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,176 @@
+# Quickstart
+
+The PBMC 3k guided-clustering workflow, end to end, next to the Seurat code it
+mirrors. Every Python line below was run to produce the output shown.
+
+```bash
+pip install "shanuz[analysis]"
+```
+
+## Load and build the object
+
+The dataset downloads on first call into `~/.shanuz_data/` (~24 MB). Loaders
+return the raw pieces — a counts matrix, gene names, cell names — and
+`create_shanuz_object` assembles them, applying the same `min_cells` /
+`min_features` prefilter `CreateSeuratObject` does.
+
+=== "Python"
+
+    ```python
+    import shanuz
+    from shanuz.datasets import pbmc3k
+
+    counts, genes, cells = pbmc3k()
+    pbmc = shanuz.create_shanuz_object(
+        counts=counts, feature_names=genes, cell_names=cells,
+        project="pbmc3k", min_cells=3, min_features=200,
+    )
+    shanuz.percentage_feature_set(pbmc, pattern=r"^MT-", col_name="percent.mt")
+    ```
+
+=== "R"
+
+    ```r
+    library(Seurat)
+
+    pbmc <- CreateSeuratObject(Read10X(data.dir), project = "pbmc3k",
+                               min.cells = 3, min.features = 200)
+    pbmc[["percent.mt"]] <- PercentageFeatureSet(pbmc, pattern = "^MT-")
+    ```
+
+## Quality control
+
+=== "Python"
+
+    ```python
+    md = pbmc.meta_data
+    keep = (md["nFeature_RNA"] > 200) & (md["nFeature_RNA"] < 2500) & (md["percent.mt"] < 5)
+    pbmc = pbmc.subset(cells=list(md.index[keep]))
+    ```
+
+=== "R"
+
+    ```r
+    pbmc <- subset(pbmc, subset = nFeature_RNA > 200 &
+                                  nFeature_RNA < 2500 & percent.mt < 5)
+    ```
+
+Both keep **2,638** of the 2,700 cells — the same 2,638 barcodes, not just the
+same count.
+
+## Normalize, select features, scale
+
+=== "Python"
+
+    ```python
+    shanuz.normalize_data(pbmc, normalization_method="LogNormalize", scale_factor=10000)
+    shanuz.find_variable_features(pbmc, selection_method="vst", nfeatures=2000)
+    shanuz.scale_data(pbmc, features=shanuz.generics.features(pbmc))
+    ```
+
+=== "R"
+
+    ```r
+    pbmc <- NormalizeData(pbmc, normalization.method = "LogNormalize",
+                          scale.factor = 10000)
+    pbmc <- FindVariableFeatures(pbmc, selection.method = "vst", nfeatures = 2000)
+    pbmc <- ScaleData(pbmc, features = rownames(pbmc))
+    ```
+
+!!! note "`scale_data` mutates in place"
+    Seurat's functions return a modified object; shanuz's write into the one you
+    pass and return `None`. `pbmc = shanuz.normalize_data(pbmc)` will leave you
+    holding `None` — a difference worth internalising early. `subset` is the
+    exception: it returns a new object, as it must.
+
+`find_variable_features` picks **1,998 of the same 2,000 genes** Seurat picks.
+The two that differ sit at the selection boundary, where the standardized
+variances agree to three decimals; see [Fidelity](fidelity.md#what-actually-differs).
+
+## Reduce, cluster, embed
+
+=== "Python"
+
+    ```python
+    shanuz.run_pca(pbmc, n_pcs=50)
+    shanuz.find_neighbors(pbmc, dims=range(10), k_param=20)
+    shanuz.find_clusters(pbmc, resolution=0.5, algorithm=1, random_seed=0)
+    shanuz.run_umap(pbmc, dims=range(10), seed=42)
+    ```
+
+=== "R"
+
+    ```r
+    pbmc <- RunPCA(pbmc, npcs = 50)
+    pbmc <- FindNeighbors(pbmc, dims = 1:10, k.param = 20, nn.method = "rann")
+    pbmc <- FindClusters(pbmc, resolution = 0.5, algorithm = 1, random.seed = 0)
+    pbmc <- RunUMAP(pbmc, dims = 1:10, seed.use = 42)
+    ```
+
+!!! warning "`dims` is 0-based here, 1-based in R"
+    `range(10)` and `1:10` are the same ten PCs. This is the one indexing
+    difference in the API, and it follows Python rather than R on purpose.
+
+!!! tip "Use `nn.method = \"rann\"` when comparing against R"
+    Seurat's default neighbour search is `annoy`, which is approximate; shanuz's
+    is exact. Leaving the default in place compares two different neighbour
+    tables and reports a difference that belongs to `annoy` rather than to
+    either implementation. That trap cost one of the verify scripts a false
+    negative of 182 SNN edges.
+
+```
+clusters: [692, 515, 458, 344, 301, 159, 155, 14]
+```
+
+Eight clusters, against Seurat's nine on the same data, at **ARI 0.938** — the
+extra one is a 32-cell dendritic-cell population Seurat's deeper modularity
+search separates.
+
+## Markers
+
+=== "Python"
+
+    ```python
+    markers = shanuz.find_all_markers(
+        pbmc, only_pos=True, min_pct=0.25, logfc_threshold=0.25,
+    )
+    ```
+
+=== "R"
+
+    ```r
+    markers <- FindAllMarkers(pbmc, only.pos = TRUE,
+                              min.pct = 0.25, logfc.threshold = 0.25)
+    ```
+
+```
+cluster   gene  avg_log2FC
+      1   FCN1    4.070133
+      1 S100A8    6.607992
+      3  CD79A    6.911221
+      3  MS4A1    5.718520
+      7 TMEM40   11.633066
+      7 ITGA2B   12.070139
+```
+
+`find_markers` runs all eight of Seurat's tests via `test_use=`. On a shared
+cell assignment, seven of them reproduce Seurat's top 50 genes exactly and
+`avg_log2FC` agrees to 7.1e-15 — [the DE vignette](tutorials/de_vignette.md)
+has the full table.
+
+## Plot
+
+Every plotting function returns a matplotlib `Figure`.
+
+```python
+fig = shanuz.dim_plot(pbmc, reduction="umap", label=True)
+fig.savefig("umap.png", dpi=150, bbox_inches="tight")
+```
+
+## Next
+
+- [The full PBMC 3k tutorial](tutorials/pbmc3k_tutorial.md) — the same workflow
+  with QC plots, elbow plot, feature plots, heatmaps and cell-type annotation,
+  and the R comparison at each step.
+- [All eighteen tutorials](tutorials/README.md).
+- [API reference](api/index.md).

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,96 @@
+/*
+ * A palette of its own rather than one of Material's named ones.
+ *
+ * This site is mostly two things: dense tables of numbers, and prose arguing
+ * about whether two numbers agree. So the chrome stays quiet — a deep pine that
+ * reads as ink rather than as a brand — and the one saturated colour, a burnt
+ * amber, is spent on links and on the things a reader is meant to act on.
+ */
+
+:root {
+  --md-primary-fg-color:        #17423a;
+  --md-primary-fg-color--light: #2c6157;
+  --md-primary-fg-color--dark:  #0e2b26;
+  --md-primary-bg-color:        #f3f6f4;
+  --md-primary-bg-color--light: #f3f6f4bf;
+
+  --md-accent-fg-color:         #b2560d;
+  --md-accent-fg-color--transparent: #b2560d1a;
+
+  /* Neutrals biased a few degrees toward the primary, so greys read as chosen
+     rather than inherited. */
+  --md-default-fg-color:        #16211f;
+  --md-default-fg-color--light: #3f4b48;
+  --md-default-fg-color--lighter: #7c8784;
+  --md-default-bg-color:        #fcfdfc;
+  --md-code-bg-color:           #f0f3f1;
+  --md-typeset-a-color:         #a04e0b;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color:        #0e2b26;
+  --md-primary-fg-color--light: #2c6157;
+  --md-primary-fg-color--dark:  #081c19;
+  --md-primary-bg-color:        #e6ede9;
+
+  --md-accent-fg-color:         #eb9d5c;
+  --md-accent-fg-color--transparent: #eb9d5c1f;
+
+  --md-default-fg-color:        #dfe6e3;
+  --md-default-bg-color:        #131a19;
+  --md-code-bg-color:           #1c2523;
+  --md-typeset-a-color:         #e8a066;
+}
+
+/* Numbers in the comparison tables line up in columns; they should be read
+   column-wise, so give them figures of equal width. */
+.md-typeset table:not([class]) td,
+.md-typeset table:not([class]) th {
+  font-variant-numeric: tabular-nums;
+}
+
+.md-typeset table:not([class]) th {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+/*
+ * The vignettes put R and Python side by side in a raw two-column <table>.
+ * Material renders each line of a code block as a block-level span inside a
+ * `display: grid` <code>; in a half-width table cell those spans clip their own
+ * text without ever reporting overflow, so no scrollbar appears and the line
+ * simply ends mid-word. Wrapping is the right answer rather than a scrollbar:
+ * the whole point of the layout is reading the two columns against each other,
+ * and a horizontal scroll in one of them defeats that.
+ */
+.md-typeset td .highlight pre > code,
+.md-typeset td .highlight pre > code > span {
+  white-space: pre-wrap;
+}
+
+.md-typeset td .highlight pre > code {
+  overflow-x: auto; /* backstop for a long line with nowhere to wrap */
+}
+
+/* Tutorial figures are wide plots on white; a hairline keeps them from
+   dissolving into the page in light mode and floating in dark mode. */
+.md-typeset img:not(.twemoji) {
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 2px;
+  background: #fff;
+}
+
+/* mkdocstrings signatures are the densest thing on the API pages. */
+.md-typeset .doc-signature > pre {
+  font-size: 0.72rem;
+}
+
+.md-typeset .doc-heading code {
+  background: transparent;
+  padding-left: 0;
+}
+
+/* The uppercase eyebrow above each API symbol group. */
+.md-typeset .doc-symbol {
+  letter-spacing: 0.04em;
+}

--- a/docs/tutorials
+++ b/docs/tutorials
@@ -1,0 +1,1 @@
+../tutorials

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,216 @@
+site_name: shanuz
+site_description: A Python port of Seurat's single-cell pipeline, verified against R Seurat test by test
+site_url: https://genomicai.github.io/shanuz/
+repo_url: https://github.com/GenomicAI/shanuz
+repo_name: GenomicAI/shanuz
+edit_uri: edit/main/docs/
+copyright: MIT-licensed. Seurat is a trademark of its own authors; shanuz is an independent port.
+
+# The vignettes and their figures live in `tutorials/`, next to the scripts that
+# produce them, and `docs/tutorials` is a symlink there. That keeps one copy of
+# each vignette — the one a reader of the repo finds — instead of a docs copy
+# that drifts from it. It is also why the exclusions below exist: the symlink
+# brings the whole tutorial working directory with it, intermediates included.
+docs_dir: docs
+site_dir: site
+
+# `mkdocs serve` watches docs_dir and the config; the API pages are generated
+# from the package, so it has to be told about the source too — otherwise a
+# docstring edit shows no change until the server is restarted.
+watch:
+  - shanuz
+  - tools
+
+exclude_docs: |
+  # Regenerable handoff data between the Python and R sides of each tutorial —
+  # megabytes of CSV that nothing on the site links to. The `.py` and `.R`
+  # sources are deliberately *not* excluded: several vignettes link to them,
+  # and a reader following "the script that produced this" should land on it.
+  tutorials/figures*/*.csv
+  tutorials/figures*/*.json
+  tutorials/figures*/*.txt
+  tutorials/figures*/*.npy
+  tutorials/figures*/*_store*/
+  tutorials/figures*/*.lazy/
+  tutorials/**/__pycache__/
+
+not_in_nav: |
+  tutorials/*.py
+  tutorials/*.R
+
+validation:
+  # A nav entry pointing at a file that no longer exists, or a heading link that
+  # no longer resolves, is exactly the kind of rot this site is meant not to
+  # have. Both are errors, and CI builds with --strict.
+  nav:
+    omitted_files: info
+    not_found: warn
+  links:
+    not_found: warn
+    anchors: warn
+    absolute_links: info
+    unrecognized_links: info
+
+theme:
+  name: material
+  language: en
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - navigation.indexes
+    - toc.follow
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - search.suggest
+    - search.highlight
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Follow system
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light
+
+extra_css:
+  - stylesheets/extra.css
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      toc_depth: 3
+      # GitHub's heading slugs, not python-markdown's. The vignettes are read on
+      # GitHub as well as here and link to each other's headings, and the two
+      # sluggers disagree wherever a heading contains an em dash or a middle dot
+      # — `## Step 12 · UMAP` is `step-12--umap` there and `step-12-umap` here.
+      # Matching GitHub keeps one set of links correct in both places; the
+      # alternative was rewriting anchors in the vignettes and breaking them on
+      # the repo page instead.
+      slugify: !!python/object/apply:pymdownx.slugs.slugify {kwds: {case: lower}}
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tilde
+  - pymdownx.caret
+  - pymdownx.smartsymbols
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: ["."]
+          options:
+            extensions:
+              # The docstrings use Sphinx roles. Translated to autorefs links
+              # here rather than rewritten across 129 source sites.
+              - tools/griffe_sphinx_roles.py:SphinxRolesExtension
+            # The package documents itself in NumPy style — 54 `Parameters
+            # ----------` blocks and no Google-style `Args:` anywhere.
+            docstring_style: numpy
+            # `table` squeezes annotations like `Optional[Union[list[int],
+            # range]]` into a narrow Type column where they wrap mid-bracket.
+            # The separate signature above already carries every annotation, so
+            # the parameter list only has to carry prose.
+            docstring_section_style: list
+            # Signatures rendered separately, with annotations, and every type
+            # linked where it resolves. `matplotlib.figure.Figure`,
+            # `Neighbor` and `Shanuz` are all annotation-only imports guarded by
+            # `if TYPE_CHECKING:`; griffe reads them statically, so they render
+            # here even though `typing.get_type_hints()` cannot resolve them at
+            # runtime. See docs/fidelity.md.
+            separate_signature: true
+            show_signature_annotations: true
+            signature_crossrefs: true
+            line_length: 88
+            show_source: true
+            show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            heading_level: 2
+            filters: ["!^_"]
+            merge_init_into_class: true
+            inherited_members: false
+            annotations_path: brief
+
+nav:
+  - Home:
+      - index.md
+      - installation.md
+      - quickstart.md
+      - fidelity.md
+  - Tutorials:
+      - tutorials/README.md
+      - Foundations:
+          - tutorials/pbmc3k_tutorial.md
+          - tutorials/advanced_pbmc8k_subclustering.md
+          - tutorials/objects_vignette.md
+      - Normalization and DE:
+          - tutorials/sctransform_vignette.md
+          - tutorials/de_vignette.md
+          - tutorials/dimreduc_vignette.md
+          - tutorials/cellcycle_vignette.md
+      - Integration and mapping:
+          - tutorials/integration_vignette.md
+          - tutorials/anchors_vignette.md
+          - tutorials/refmap_vignette.md
+      - Multimodal and screens:
+          - tutorials/multimodal_citeseq.md
+          - tutorials/hashing_vignette.md
+          - tutorials/mixscape_vignette.md
+      - Spatial:
+          - tutorials/xenium_spatial_tutorial.md
+          - tutorials/svf_vignette.md
+          - tutorials/visium_vignette.md
+      - Scale:
+          - tutorials/sketch_vignette.md
+          - tutorials/lazy_vignette.md
+  - API reference:
+      - api/index.md
+      - api/objects.md
+      - api/preprocessing.md
+      - api/dimreduc.md
+      - api/clustering.md
+      - api/markers.md
+      - api/integration.md
+      - api/scoring.md
+      - api/demux.md
+      - api/spatial.md
+      - api/scale.md
+      - api/plotting.md
+      - api/generics.md
+      - api/io.md
+  - Project:
+      - CHANGELOG.md
+      - ROADMAP.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,16 @@ dev = [
     "build",
     "twine",
 ]
-all = ["shanuz[analysis,anndata,integration,deseq2,dev]"]
+# The documentation site. In `all` on purpose: tests/test_docs.py builds the
+# site with --strict, which is the only check that catches a broken
+# cross-reference or a stale heading anchor, and it can only run if the
+# toolchain is present in the same environment CI tests in.
+docs = [
+    "mkdocs>=1.6",
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.26",
+]
+all = ["shanuz[analysis,anndata,integration,deseq2,dev,docs]"]
 
 [project.urls]
 Homepage = "https://github.com/GenomicAI/shanuz"

--- a/shanuz/anchors.py
+++ b/shanuz/anchors.py
@@ -61,20 +61,20 @@ class IntegrationAnchors:
 
     Slots
     -----
-    anchors         : DataFrame with columns ``dataset1, cell1, dataset2,
-                      cell2, score``. ``dataset1`` is always the reference; the
-                      cell columns hold *within-dataset* 0-based row indices.
-    objects         : the list of Shanuz objects passed to
-                      :func:`find_integration_anchors` (order preserved).
-    reference       : index into ``objects`` of the reference dataset.
-    reduction       : ``"cca"`` or ``"rpca"`` — how the shared space was built.
-    anchor_features : the features the anchors (and correction) run on.
-    dims            : number of shared dimensions used.
-    weight_embeddings : ``{query_index: (n_query_cells × dims) array}`` — each
-                      query dataset's cells in the shared anchor space. Kept for
-                      inspection; :func:`integrate_data` does *not* weight with
-                      it, because Seurat weights in a fresh PCA of the merged
-                      pair instead.
+    - ``anchors`` — DataFrame with columns ``dataset1, cell1, dataset2,
+      cell2, score``. ``dataset1`` is always the reference; the
+      cell columns hold *within-dataset* 0-based row indices.
+    - ``objects`` — the list of Shanuz objects passed to
+      :func:`find_integration_anchors` (order preserved).
+    - ``reference`` — index into ``objects`` of the reference dataset.
+    - ``reduction`` — ``"cca"`` or ``"rpca"`` — how the shared space was built.
+    - ``anchor_features`` — the features the anchors (and correction) run on.
+    - ``dims`` — number of shared dimensions used.
+    - ``weight_embeddings`` — ``{query_index: (n_query_cells × dims) array}`` — each
+      query dataset's cells in the shared anchor space. Kept for
+      inspection; :func:`integrate_data` does *not* weight with
+      it, because Seurat weights in a fresh PCA of the merged
+      pair instead.
     """
 
     __slots__ = (

--- a/shanuz/assay.py
+++ b/shanuz/assay.py
@@ -22,19 +22,19 @@ class Assay(KeyMixin):
 
     Slots
     -----
-    counts        : raw counts / TPMs  (features × cells)
-    data          : normalised expression (features × cells)
-    scale_data    : scaled expression  (features × cells, dense) — a *subset*
-                    of the features, since ScaleData defaults to the variable
-                    ones. R's slot is a matrix and carries its own rownames;
-                    a bare ndarray does not, so the labels live alongside it in
-                    `_scaled_features` and every read of the layer goes through
-                    `features("scale_data")`.
-    assay_orig    : name of original assay this was derived from
-    var_features  : list of highly variable feature names
-    meta_features : per-feature metadata DataFrame (features × cols)
-    misc          : dict for miscellaneous storage
-    _key          : string key prefix (inherited from KeyMixin)
+    - ``counts`` — raw counts / TPMs  (features × cells)
+    - ``data`` — normalised expression (features × cells)
+    - ``scale_data`` — scaled expression  (features × cells, dense) — a *subset*
+      of the features, since ScaleData defaults to the variable
+      ones. R's slot is a matrix and carries its own rownames;
+      a bare ndarray does not, so the labels live alongside it in
+      `_scaled_features` and every read of the layer goes through
+      `features("scale_data")`.
+    - ``assay_orig`` — name of original assay this was derived from
+    - ``var_features`` — list of highly variable feature names
+    - ``meta_features`` — per-feature metadata DataFrame (features × cols)
+    - ``misc`` (dict) — for miscellaneous storage
+    - ``_key`` (str) — ing key prefix (inherited from KeyMixin)
     """
 
     __slots__ = (

--- a/shanuz/assay5.py
+++ b/shanuz/assay5.py
@@ -30,14 +30,14 @@ class StdAssay(KeyMixin, ABC):
 
     Slots
     -----
-    layers      : dict[str, AnyMatrix]   named expression matrices (features × cells)
-    cells       : LogMap                 per-layer boolean cell membership
-    features    : LogMap                 per-layer boolean feature membership
-    default     : int                    index of the default layer
-    assay_orig  : Optional[str]
-    meta_data   : pd.DataFrame           per-feature metadata
-    misc        : dict
-    _key        : str                    (from KeyMixin)
+    - ``layers`` (dict[str, AnyMatrix]) — named expression matrices (features × cells)
+    - ``cells`` (LogMap) — per-layer boolean cell membership
+    - ``features`` (LogMap) — per-layer boolean feature membership
+    - ``default`` (int) — index of the default layer
+    - ``assay_orig`` (Optional[str])
+    - ``meta_data`` (pd.DataFrame) — per-feature metadata
+    - ``misc`` (dict)
+    - ``_key`` (str) — inherited from KeyMixin
     """
 
     __slots__ = (

--- a/shanuz/command.py
+++ b/shanuz/command.py
@@ -12,11 +12,11 @@ class ShanuzCommand:
 
     Slots
     -----
-    name        : str        function/method name
-    time_stamp  : datetime   when the command ran
-    assay_used  : Optional[str]
-    call_string : str        human-readable call representation
-    params      : dict       non-function parameters passed to the command
+    - ``name`` (str) — function/method name
+    - ``time_stamp`` (datetime) — when the command ran
+    - ``assay_used`` (Optional[str])
+    - ``call_string`` (str) — human-readable call representation
+    - ``params`` (dict) — non-function parameters passed to the command
     """
 
     __slots__ = ("name", "time_stamp", "assay_used", "call_string", "params", "key")

--- a/shanuz/composition.py
+++ b/shanuz/composition.py
@@ -52,9 +52,11 @@ def composition_test(
     reference : which ``split_by`` level is the denominator (default: the first
                 sorted level). log2 > 0 ⇒ enriched in the *other* level.
 
-    Returns a DataFrame ordered by ``log2_ratio`` with columns:
-    ``group, n_<ref>, n_<test>, prop_<ref>, prop_<test>, log2_ratio,
-    odds_ratio, p, padj, sig, enriched_in``.
+    Returns
+    -------
+    A DataFrame ordered by ``log2_ratio``, with the columns ``group``,
+    ``n_<ref>``, ``n_<test>``, ``prop_<ref>``, ``prop_<test>``, ``log2_ratio``,
+    ``odds_ratio``, ``p``, ``padj``, ``sig`` and ``enriched_in``.
     """
     md = seurat.meta_data
     for col in (group_by, split_by):

--- a/shanuz/datasets.py
+++ b/shanuz/datasets.py
@@ -113,9 +113,9 @@ def cbmc_citeseq(
 
     Returns
     -------
-    (rna_counts, rna_genes, adt_counts, adt_proteins, cell_names)
-      rna_counts : (genes x cells) csc_matrix
-      adt_counts : (proteins x cells) csc_matrix, same cell order as rna_counts
+    (rna_counts, rna_genes, adt_counts, adt_proteins, cell_names), where
+    ``rna_counts`` is a (genes x cells) ``csc_matrix`` and ``adt_counts`` is a
+    (proteins x cells) ``csc_matrix`` in the same cell order.
     """
     import pandas as pd
 
@@ -306,9 +306,9 @@ def pbmc_hashing(
 
     Returns
     -------
-    (rna_counts, rna_genes, hto_counts, hto_names, cell_names)
-      rna_counts : (genes x cells) csc_matrix, raw counts
-      hto_counts : (8 x cells) csc_matrix, same cell order as rna_counts
+    (rna_counts, rna_genes, hto_counts, hto_names, cell_names), where
+    ``rna_counts`` is a (genes x cells) ``csc_matrix`` of raw counts and
+    ``hto_counts`` is an (8 x cells) ``csc_matrix`` in the same cell order.
     """
     from .io import _make_unique
 
@@ -371,11 +371,12 @@ def thp1_eccite(
 
     Returns
     -------
-    (rna_counts, rna_genes, adt_counts, adt_names, meta, cell_names)
-      rna_counts : (genes x cells) csc_matrix, raw counts
-      adt_counts : (proteins x cells) csc_matrix, same cell order
-      meta       : pandas.DataFrame indexed by cell barcode (guide_ID, gene,
-                   NT, crispr, replicate, Phase, S.Score, G2M.Score, ...)
+    (rna_counts, rna_genes, adt_counts, adt_names, meta, cell_names), where
+    ``rna_counts`` is a (genes x cells) ``csc_matrix`` of raw counts,
+    ``adt_counts`` is a (proteins x cells) ``csc_matrix`` in the same cell
+    order, and ``meta`` is a ``pandas.DataFrame`` indexed by cell barcode
+    (``guide_ID``, ``gene``, ``NT``, ``crispr``, ``replicate``, ``Phase``,
+    ``S.Score``, ``G2M.Score``, ...).
     """
     import pandas as pd
 

--- a/shanuz/dimreduc.py
+++ b/shanuz/dimreduc.py
@@ -16,15 +16,15 @@ class DimReduc(KeyMixin):
 
     Slots
     -----
-    cell_embeddings              : np.ndarray  (n_cells × n_dims)   required
-    feature_loadings             : np.ndarray  (n_features × n_dims) optional
-    feature_loadings_projected   : np.ndarray  projected loadings    optional
-    assay_used                   : str         source assay name
-    global_                      : bool        if True, persists when assay is removed
-    stdev                        : np.ndarray  per-dimension std devs
-    jackstraw                    : JackStrawData
-    misc                         : dict
-    _key                         : str         prefix, e.g. "PC_"
+    - ``cell_embeddings`` (np.ndarray) — (n_cells × n_dims), required
+    - ``feature_loadings`` (np.ndarray) — (n_features × n_dims), optional
+    - ``feature_loadings_projected`` (np.ndarray) — projected loadings, optional
+    - ``assay_used`` (str) — source assay name
+    - ``global_`` (bool) — if True, persists when assay is removed
+    - ``stdev`` (np.ndarray) — per-dimension std devs
+    - ``jackstraw`` (JackStrawData)
+    - ``misc`` (dict)
+    - ``_key`` (str) — prefix, e.g. "PC_"
     """
 
     __slots__ = (

--- a/shanuz/graph.py
+++ b/shanuz/graph.py
@@ -23,9 +23,9 @@ class Graph:
 
     Slots
     -----
-    _matrix    : scipy.sparse.csc_matrix   underlying adjacency matrix
-    assay_used : Optional[str]             assay that generated this graph
-    _cell_names: list[str]                 row/col names (cells)
+    - ``_matrix`` (scipy.sparse.csc_matrix) — underlying adjacency matrix
+    - ``assay_used`` (Optional[str]) — assay that generated this graph
+    - ``_cell_names`` (list[str]) — row/col names (cells)
     """
 
     __slots__ = ("_matrix", "assay_used", "_cell_names")

--- a/shanuz/markers.py
+++ b/shanuz/markers.py
@@ -606,13 +606,15 @@ def find_conserved_markers(
     *every* level, and combines their per-level p-values with Fisher's method
     (:func:`scipy.stats.combine_pvalues`).
 
+    Every argument not listed below is forwarded verbatim to
+    :func:`find_markers`.
+
     Parameters
     ----------
     ident_1      : cluster label(s) for group 1.
     grouping_var : metadata column whose levels define the independent
                    comparisons (e.g. condition, batch, donor).
     ident_2      : cluster label(s) for group 2 (None = all other cells).
-    (remaining args are forwarded to :func:`find_markers`.)
 
     Returns
     -------

--- a/shanuz/module_score.py
+++ b/shanuz/module_score.py
@@ -132,7 +132,9 @@ def add_module_score(
     search   : if True, resolve program genes not found verbatim by a
                case/punctuation-insensitive match (local ``UpdateSymbolList``).
 
-    Stores one metadata column per program and returns ``seurat``.
+    Returns
+    -------
+    ``seurat``, with one metadata column added per program.
     """
     rng = np.random.default_rng(seed)
 

--- a/shanuz/neighbor.py
+++ b/shanuz/neighbor.py
@@ -18,11 +18,11 @@ class Neighbor:
 
     Slots
     -----
-    nn_idx       : int matrix  (n_cells × k), neighbor indices (1-based in R; 0-based here)
-    nn_dist      : float matrix (n_cells × k), corresponding distances
-    alg_idx      : Any         algorithm index object (e.g. annoy index)
-    alg_info     : dict        metadata about the algorithm used
-    cell_names   : list[str]   cell barcodes, length n_cells
+    - ``nn_idx`` (int matrix) — (n_cells × k), neighbor indices (1-based in R; 0-based here)
+    - ``nn_dist`` (float matrix) — (n_cells × k), corresponding distances
+    - ``alg_idx`` (Any) — algorithm index object (e.g. annoy index)
+    - ``alg_info`` (dict) — metadata about the algorithm used
+    - ``cell_names`` (list[str]) — cell barcodes, length n_cells
     """
 
     __slots__ = ("nn_idx", "nn_dist", "alg_idx", "alg_info", "cell_names")

--- a/shanuz/sctransform.py
+++ b/shanuz/sctransform.py
@@ -460,7 +460,9 @@ def sctransform(
     bw_adjust   : multiplier on the Sheather-Jones smoothing bandwidth (R's 3).
     set_default : make the new assay the active assay.
 
-    Returns ``seurat`` with the new assay added.
+    Returns
+    -------
+    ``seurat``, with the new assay added.
     """
     if vst_flavor not in ("v1", "v2"):
         raise ValueError(f"vst_flavor must be 'v1' or 'v2', got {vst_flavor!r}")

--- a/shanuz/shanuz.py
+++ b/shanuz/shanuz.py
@@ -28,19 +28,19 @@ class Shanuz:
 
     Slots
     -----
-    assays        : dict[str, AnyAssay]
-    meta_data     : pd.DataFrame           cells × metadata columns
-    active_assay  : str
-    active_ident  : pd.Categorical
-    graphs        : dict[str, Graph]
-    neighbors     : dict[str, Neighbor]
-    reductions    : dict[str, DimReduc]
-    images        : dict[str, FOV]
-    project_name  : str
-    misc          : dict
-    version       : packaging.version.Version
-    commands      : list[ShanuzCommand]
-    tools         : dict
+    - ``assays`` (dict[str, AnyAssay])
+    - ``meta_data`` (pd.DataFrame) — cells × metadata columns
+    - ``active_assay`` (str)
+    - ``active_ident`` (pd.Categorical)
+    - ``graphs`` (dict[str, Graph])
+    - ``neighbors`` (dict[str, Neighbor])
+    - ``reductions`` (dict[str, DimReduc])
+    - ``images`` (dict[str, FOV])
+    - ``project_name`` (str)
+    - ``misc`` (dict)
+    - ``version`` (packaging.version.Version)
+    - ``commands`` (list[ShanuzCommand])
+    - ``tools`` (dict)
     """
 
     __slots__ = (

--- a/shanuz/spatial/base.py
+++ b/shanuz/spatial/base.py
@@ -17,9 +17,9 @@ class SpatialImage(KeyMixin, ABC):
 
     Slots
     -----
-    assay : str            associated assay name
-    misc  : dict           miscellaneous storage
-    _key  : str            (from KeyMixin)
+    - ``assay`` (str) — associated assay name
+    - ``misc`` (dict) — miscellaneous storage
+    - ``_key`` (str) — inherited from KeyMixin
     """
 
     __slots__ = ("assay", "misc", "_key")

--- a/shanuz/spatial/centroids.py
+++ b/shanuz/spatial/centroids.py
@@ -38,10 +38,10 @@ class Centroids(SpatialImage):
 
     Slots
     -----
-    _coords  : pd.DataFrame   columns: x, y, cell
-    nsides   : int            number of polygon sides (0 = circle)
-    radius_  : Optional[float] spot radius (for spot-based technologies)
-    theta_   : Optional[float] angle offset
+    - ``_coords`` (pd.DataFrame) — columns: x, y, cell
+    - ``nsides`` (int) — number of polygon sides (0 = circle)
+    - ``radius_`` (Optional[float]) — spot radius (for spot-based technologies)
+    - ``theta_`` (Optional[float]) — angle offset
     """
 
     __slots__ = ("_coords", "nsides", "radius_", "theta_", "assay", "misc", "_key")

--- a/shanuz/spatial/fov.py
+++ b/shanuz/spatial/fov.py
@@ -21,9 +21,9 @@ class FOV(SpatialImage):
 
     Slots
     -----
-    molecules             : dict[str, Molecules]
-    boundaries            : dict[str, BoundaryType]
-    coords_x_orientation  : str   which axis x maps to in visualisation
+    - ``molecules`` (dict[str, Molecules])
+    - ``boundaries`` (dict[str, BoundaryType])
+    - ``coords_x_orientation`` (str) — which axis x maps to in visualisation
     """
 
     __slots__ = (

--- a/shanuz/spatial/molecules.py
+++ b/shanuz/spatial/molecules.py
@@ -15,8 +15,8 @@ class Molecules(SpatialImage):
 
     Slots
     -----
-    _coords : pd.DataFrame  columns: x, y, gene, [cell]
-                             'cell' is optional (not all FISH protocols assign cells)
+    - ``_coords`` (pd.DataFrame) — columns: x, y, gene, [cell]
+      'cell' is optional (not all FISH protocols assign cells)
     """
 
     __slots__ = ("_coords", "assay", "misc", "_key")

--- a/shanuz/spatial/segmentation.py
+++ b/shanuz/spatial/segmentation.py
@@ -38,7 +38,7 @@ class Segmentation(SpatialImage):
 
     Slots
     -----
-    _coords : pd.DataFrame  columns: x, y, cell   (multiple rows per cell)
+    - ``_coords`` (pd.DataFrame) — columns: x, y, cell   (multiple rows per cell)
     """
 
     __slots__ = ("_coords", "assay", "misc", "_key")

--- a/shanuz/spatial/visium.py
+++ b/shanuz/spatial/visium.py
@@ -145,9 +145,9 @@ class VisiumV2(FOV):
 
     Slots
     -----
-    image            : (H, W[, C]) array, or None
-    scale_factors    : ScaleFactors, or None
-    image_resolution : 'hires' | 'lowres' — which image is stored
+    - ``image`` (np.ndarray) — (H, W[, C]), or None
+    - ``scale_factors`` (ScaleFactors) — or None
+    - ``image_resolution`` (str) — ``'hires'`` or ``'lowres'``, which image is stored
     """
 
     __slots__ = ("image", "scale_factors", "image_resolution")

--- a/shanuz/transfer.py
+++ b/shanuz/transfer.py
@@ -69,18 +69,18 @@ class TransferAnchors:
 
     Slots
     -----
-    anchors          : DataFrame with columns ``cell1, cell2, score``.
-                       ``cell1`` is a *within-reference* 0-based cell index,
-                       ``cell2`` a *within-query* one; the reference is never
-                       moved.
-    reference        : the reference Shanuz object (annotated atlas).
-    query            : the query Shanuz object (to be annotated).
-    reduction        : ``"pcaproject"`` or ``"cca"`` — how the shared space was
-                       built.
-    anchor_features  : the features the anchors run on.
-    dims             : number of shared dimensions used.
-    query_embedding  : ``(n_query_cells × dims)`` — the query cells in the shared
-                       space, used by :func:`transfer_data` to weight anchors.
+    - ``anchors`` — DataFrame with columns ``cell1, cell2, score``.
+      ``cell1`` is a *within-reference* 0-based cell index,
+      ``cell2`` a *within-query* one; the reference is never
+      moved.
+    - ``reference`` — the reference Shanuz object (annotated atlas).
+    - ``query`` — the query Shanuz object (to be annotated).
+    - ``reduction`` — ``"pcaproject"`` or ``"cca"`` — how the shared space was
+      built.
+    - ``anchor_features`` — the features the anchors run on.
+    - ``dims`` — number of shared dimensions used.
+    - ``query_embedding`` — ``(n_query_cells × dims)`` — the query cells in the shared
+      space, used by :func:`transfer_data` to weight anchors.
     """
 
     __slots__ = (

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,280 @@
+"""The documentation site cannot silently rot.
+
+Four things go stale on their own and none of them break anything at import
+time, which is exactly why they need asserting:
+
+* a new export lands in ``shanuz.__all__`` and nobody adds it to an API page;
+* a function is renamed and the ``:::`` directive pointing at it keeps its old
+  name — mkdocstrings then renders an empty page section;
+* a nav entry outlives the file it names;
+* a vignette's figure is moved or regenerated under a new name.
+
+The strict build at the end catches all four *and* every broken cross-reference,
+but it needs the docs toolchain installed. These tests do not, so the checks
+that matter most still run on a plain ``pip install -e ".[all]"``.
+"""
+import importlib
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import shanuz  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+API = DOCS / "api"
+
+_DIRECTIVE = re.compile(r"^:::\s+(?P<target>[\w.]+)\s*$", re.MULTILINE)
+# Markdown images, minus the absolute and remote ones.
+_IMAGE = re.compile(r"!\[[^\]]*\]\((?P<src>(?!https?:|/)[^)\s]+)")
+
+
+def api_targets() -> dict[str, Path]:
+    """Every ``::: shanuz.x.y`` on the API pages, mapped to the page it is on."""
+    found: dict[str, Path] = {}
+    for page in sorted(API.glob("*.md")):
+        for match in _DIRECTIVE.finditer(page.read_text()):
+            found[match.group("target")] = page
+    return found
+
+
+def resolve(dotted: str):
+    """Import-and-getattr a dotted path, module or attribute."""
+    try:
+        return importlib.import_module(dotted)
+    except ImportError:
+        module, _, attr = dotted.rpartition(".")
+        return getattr(importlib.import_module(module), attr)
+
+
+# ---------------------------------------------------------------------------
+# The API pages against the package
+# ---------------------------------------------------------------------------
+
+def defining_module(name: str, obj: object) -> str:
+    """Where an export really lives.
+
+    `__module__` answers for functions and classes. Data constants like
+    `CC_GENES` have none, so find the submodule that holds the same object.
+    """
+    module = getattr(obj, "__module__", None)
+    if module:
+        return module
+    if isinstance(obj, type(shanuz)):  # a re-exported module
+        return obj.__name__
+    import pkgutil
+
+    for info in pkgutil.walk_packages(shanuz.__path__, "shanuz."):
+        try:
+            candidate = importlib.import_module(info.name)
+        except ImportError:
+            continue
+        if getattr(candidate, name, None) is obj:
+            return info.name
+    return ""
+
+
+def test_every_public_export_is_on_an_api_page():
+    documented = set(api_targets())
+    missing = []
+    for name in shanuz.__all__:
+        if name == "__version__":
+            continue
+        obj = getattr(shanuz, name)
+        module = defining_module(name, obj)
+        if isinstance(obj, type(shanuz)):
+            # A re-exported module — `generics` is rendered whole, `plotting`
+            # one function at a time. Either counts.
+            covered = module in documented or any(t.startswith(f"{module}.") for t in documented)
+            canonical = f"::: {module}"
+        else:
+            canonical = f"::: {module}.{name}"
+            covered = f"{module}.{name}" in documented
+        if not covered:
+            missing.append(f"{name} (would be `{canonical}`)")
+    assert not missing, (
+        "public exports with no API page — add a `::: ` directive under docs/api/:\n  "
+        + "\n  ".join(sorted(missing))
+    )
+
+
+def test_every_directive_points_at_something_that_exists():
+    broken = []
+    for target, page in sorted(api_targets().items()):
+        try:
+            resolve(target)
+        except (ImportError, AttributeError) as exc:
+            broken.append(f"{page.name}: ::: {target} ({exc.__class__.__name__})")
+    assert not broken, "API directives naming objects that no longer exist:\n  " + "\n  ".join(broken)
+
+
+def test_no_public_export_is_documented_twice():
+    """Two pages rendering the same symbol makes one of the two anchors dead."""
+    seen: dict[str, list[str]] = {}
+    for page in sorted(API.glob("*.md")):
+        for match in _DIRECTIVE.finditer(page.read_text()):
+            seen.setdefault(match.group("target"), []).append(page.name)
+    duplicated = {t: pages for t, pages in seen.items() if len(pages) > 1}
+    assert not duplicated, f"symbols rendered on more than one page: {duplicated}"
+
+
+# ---------------------------------------------------------------------------
+# The site's own files
+# ---------------------------------------------------------------------------
+
+def nav_entries() -> list[str]:
+    """The markdown paths named in mkdocs.yml's nav, without parsing the YAML.
+
+    `mkdocs.yml` carries a `!!python/object/apply:` tag for the slugifier, which
+    `yaml.safe_load` refuses and `yaml.unsafe_load` would execute. The nav is a
+    flat list of `.md` paths either way, so match those directly.
+    """
+    text = (ROOT / "mkdocs.yml").read_text()
+    nav = text[text.index("\nnav:"):]
+    return re.findall(r"^\s*-\s+(?:[^:\n]+:\s*)?([\w./-]+\.md)\s*$", nav, re.MULTILINE)
+
+
+def test_every_nav_entry_exists():
+    entries = nav_entries()
+    assert len(entries) > 25, f"nav parsing found only {len(entries)} pages; the regex is wrong"
+    missing = [e for e in entries if not (DOCS / e).exists()]
+    assert not missing, f"nav names files that are not in docs/: {missing}"
+
+
+def test_every_api_page_is_in_the_nav():
+    entries = set(nav_entries())
+    orphans = [
+        f"api/{p.name}" for p in sorted(API.glob("*.md")) if f"api/{p.name}" not in entries
+    ]
+    assert not orphans, f"API pages that no reader can navigate to: {orphans}"
+
+
+def test_every_vignette_is_in_the_nav():
+    entries = set(nav_entries())
+    vignettes = {
+        f"tutorials/{p.name}"
+        for p in sorted((ROOT / "tutorials").glob("*.md"))
+    }
+    missing = sorted(vignettes - entries)
+    assert not missing, f"vignettes missing from the site nav: {missing}"
+
+
+def test_every_markdown_image_resolves():
+    """Figures are committed, and a vignette linking a missing one is a 404."""
+    broken = []
+    pages = list(DOCS.glob("*.md")) + list(API.glob("*.md")) + list((ROOT / "tutorials").glob("*.md"))
+    for page in pages:
+        for match in _IMAGE.finditer(page.read_text()):
+            src = match.group("src").split("#")[0]
+            if not (page.parent / src).resolve().exists():
+                broken.append(f"{page.relative_to(ROOT)} -> {src}")
+    assert not broken, "markdown images with no file behind them:\n  " + "\n  ".join(broken)
+
+
+def test_the_tutorials_symlink_still_points_at_the_tutorials():
+    link = DOCS / "tutorials"
+    assert link.is_symlink(), "docs/tutorials must stay a symlink, not become a copy"
+    assert link.resolve() == (ROOT / "tutorials").resolve()
+
+
+# ---------------------------------------------------------------------------
+# The griffe extension
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, str(ROOT / "tools"))
+
+
+@pytest.fixture(scope="module")
+def roles():
+    pytest.importorskip("griffe", reason="needs the docs toolchain")
+    import griffe_sphinx_roles
+
+    return griffe_sphinx_roles
+
+
+def test_a_role_pointing_at_a_documented_symbol_becomes_a_link(roles):
+    ext = roles.SphinxRolesExtension()
+    out = ext._substitute(roles._ROLE.search(":func:`run_pca`"))
+    assert out == "[`run_pca`][shanuz.reduction.run_pca]"
+
+
+def test_a_role_pointing_at_a_private_helper_degrades_to_code(roles):
+    """Never emit a link the site cannot resolve — --strict would fail the build."""
+    ext = roles.SphinxRolesExtension()
+    out = ext._substitute(roles._ROLE.search(":func:`_get_scaled_data`"))
+    assert out == "`_get_scaled_data`"
+
+
+def test_a_role_pointing_outside_the_package_degrades_to_code(roles):
+    ext = roles.SphinxRolesExtension()
+    out = ext._substitute(roles._ROLE.search(":class:`pandas.DataFrame`"))
+    assert out == "`pandas.DataFrame`"
+
+
+def test_the_tilde_prefix_shortens_the_link_text(roles):
+    ext = roles.SphinxRolesExtension()
+    out = ext._substitute(roles._ROLE.search(":class:`~shanuz.spatial.visium.VisiumV2`"))
+    assert out == "[`VisiumV2`][shanuz.spatial.visium.VisiumV2]"
+
+
+def test_parameter_prose_moves_out_of_the_type_slot(roles):
+    doc = (
+        "Do a thing.\n\n"
+        "Parameters\n"
+        "----------\n"
+        "min_features : min features a cell must have to be kept\n"
+        "assay        : assay name, wrapping onto\n"
+        "               a second line\n\n"
+        "Returns\n"
+        "-------\n"
+        "``seurat``, modified.\n"
+    )
+    out = roles._reflow_parameters(doc)
+    assert "min_features\n    min features a cell must have to be kept" in out
+    assert "assay\n    assay name, wrapping onto\n    a second line" in out
+    # The section after Parameters must survive untouched.
+    assert out.endswith("Returns\n-------\n``seurat``, modified.\n")
+
+
+def test_the_reflow_never_drops_a_word_from_any_docstring(roles):
+    """A transform that silently ate prose would be invisible on the rendered page."""
+    import inspect
+    import pkgutil
+
+    checked = 0
+    for info in pkgutil.walk_packages(shanuz.__path__, "shanuz."):
+        try:
+            module = importlib.import_module(info.name)
+        except ImportError:
+            continue
+        for name in dir(module):
+            obj = getattr(module, name, None)
+            doc = getattr(obj, "__doc__", None)
+            if not doc or getattr(obj, "__module__", None) != info.name:
+                continue
+            before = inspect.cleandoc(doc)
+            after = roles._reflow_parameters(before)
+            checked += 1
+            assert "".join(before.split()).replace(":", "") == \
+                   "".join(after.split()).replace(":", ""), f"{info.name}.{name} lost content"
+    assert checked > 100, f"only inspected {checked} docstrings; the walk is broken"
+
+
+# ---------------------------------------------------------------------------
+# The build itself
+# ---------------------------------------------------------------------------
+
+def test_the_site_builds_strict(tmp_path):
+    """--strict turns every broken link, anchor and docstring warning into a failure."""
+    pytest.importorskip("mkdocs", reason="needs the docs toolchain")
+    import subprocess
+
+    result = subprocess.run(
+        [sys.executable, "-m", "mkdocs", "build", "--strict", "--site-dir", str(tmp_path / "site")],
+        cwd=ROOT, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tools/griffe_sphinx_roles.py
+++ b/tools/griffe_sphinx_roles.py
@@ -1,0 +1,173 @@
+"""Make the package's two docstring conventions legible to mkdocstrings.
+
+Both fixes are build-time translations rather than source rewrites, for the same
+reason: the source form is the one a reader of the code and a caller of `help()`
+sees, it is consistent across the package, and it is not wrong — it just is not
+what a NumPy-format parser expects.
+
+**Sphinx roles.** The docstrings cross-reference with ``:func:`run_pca``` and
+friends, 129 times. mkdocstrings does not understand that syntax, so left alone
+they render as the literal text ``:func:`` followed by a code span.
+
+**Parameter descriptions.** Every one of the 370 documented parameters is
+written ``name : what it does`` — prose after the colon, never a type, because
+the types are in the signatures where they belong. NumPy format reads that slot
+as the type, so without this the site prints "min features a cell must have to
+be kept" in the Type column and leaves the description empty.
+
+Roles are rewritten to mkdocs-autorefs links **only when the target is one this
+site actually renders**. Anything else — private helpers filtered out of the
+API pages, `pandas.DataFrame`, `scipy.sparse.load_npz` — degrades to a plain
+code span. That rule is the point of the extension rather than an edge case:
+autorefs treats an unresolvable target as a warning, CI builds with ``--strict``,
+so a link this file is not sure of would fail the build. Better to render it as
+code than to guess.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from griffe import Extension, Object
+
+# `:role:`target`` — optionally `~target`, meaning "display the last component
+# only", and optionally `text <target>`, Sphinx's explicit-title form.
+_ROLE = re.compile(
+    r":(?:py:)?(?P<role>func|meth|class|obj|attr|mod|data|exc):"
+    r"`(?P<body>[^`]+)`"
+)
+_EXPLICIT_TITLE = re.compile(r"^(?P<title>.*?)\s*<(?P<target>[^>]+)>$")
+
+# A `Parameters` / `Other Parameters` header and its underline.
+_PARAM_HEADER = re.compile(r"^(?P<name>Parameters|Other Parameters)[ \t]*$")
+_UNDERLINE = re.compile(r"^-{3,}[ \t]*$")
+# `name : prose`, at the section's own indentation. `*args` and `**kwargs` count.
+_PARAM_ENTRY = re.compile(r"^(?P<name>\*{0,2}\w[\w ,]*?)[ \t]*:[ \t]?(?P<desc>\S.*)$")
+
+
+def _reflow_parameters(text: str) -> str:
+    """Move each parameter's prose off the type slot and onto its own line.
+
+    ``name : what it does`` becomes ``name`` followed by an indented
+    description, which is the shape NumPy format expects. Leaving the type slot
+    empty is what makes griffe fall back to the signature annotation — the one
+    place in this package where the type is actually declared.
+    """
+    lines = text.splitlines()
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        header = _PARAM_HEADER.match(lines[i])
+        if not (header and i + 1 < len(lines) and _UNDERLINE.match(lines[i + 1])):
+            out.append(lines[i])
+            i += 1
+            continue
+        out.append(lines[i])
+        out.append(lines[i + 1])
+        i += 2
+        while i < len(lines):
+            line = lines[i]
+            # A blank line ends the section only when what follows is not an
+            # indented continuation — some sections have a gap mid-list.
+            if not line.strip():
+                nxt = next((s for s in lines[i + 1:] if s.strip()), "")
+                if not nxt or not nxt.startswith((" ", "\t")) and not _PARAM_ENTRY.match(nxt):
+                    break
+                out.append(line)
+                i += 1
+                continue
+            if line[:1].strip() == "" :  # already indented: a continuation line
+                out.append("    " + line.strip())
+                i += 1
+                continue
+            entry = _PARAM_ENTRY.match(line)
+            if entry is None:
+                break
+            out.append(entry.group("name").strip())
+            out.append("    " + entry.group("desc").strip())
+            i += 1
+    rebuilt = "\n".join(out)
+    return rebuilt + "\n" if text.endswith("\n") else rebuilt
+
+
+def _render_targets() -> dict[str, str]:
+    """Map every name a docstring might use to the anchor this site publishes.
+
+    The anchors mkdocstrings emits are canonical paths — `shanuz.reduction.run_pca`,
+    not `shanuz.run_pca` — because that is what the `:::` directives on the API
+    pages name. So the index is built from the canonical path of each public
+    export and of each public method on the exported classes, and a bare name
+    resolves only when exactly one object answers to it.
+    """
+    import inspect
+
+    import shanuz
+
+    canonical: dict[str, str] = {}
+    ambiguous: set[str] = set()
+
+    def offer(alias: str, path: str) -> None:
+        if alias in canonical and canonical[alias] != path:
+            ambiguous.add(alias)
+        canonical.setdefault(alias, path)
+
+    for name in shanuz.__all__:
+        obj = getattr(shanuz, name, None)
+        module = getattr(obj, "__module__", None)
+        if obj is None or not module or not module.startswith("shanuz"):
+            continue
+        path = f"{module}.{name}"
+        offer(name, path)
+        offer(path, path)
+        offer(f"shanuz.{name}", path)
+        if inspect.isclass(obj):
+            for attr, member in vars(obj).items():
+                if attr.startswith("_") or not callable(member):
+                    continue
+                offer(attr, f"{path}.{attr}")
+                offer(f"{name}.{attr}", f"{path}.{attr}")
+
+    for alias in ambiguous:
+        del canonical[alias]
+    return canonical
+
+
+class SphinxRolesExtension(Extension):
+    """Translate Sphinx roles in every docstring griffe collects."""
+
+    def __init__(self) -> None:
+        self._targets: dict[str, str] | None = None
+
+    @property
+    def targets(self) -> dict[str, str]:
+        # Built on first use, not in __init__: importing shanuz while griffe is
+        # still loading modules is a cycle waiting to happen.
+        if self._targets is None:
+            self._targets = _render_targets()
+        return self._targets
+
+    def _substitute(self, match: re.Match[str]) -> str:
+        body = match.group("body").strip()
+        title: str | None = None
+        if (explicit := _EXPLICIT_TITLE.match(body)) is not None:
+            title, body = explicit.group("title"), explicit.group("target").strip()
+
+        abbreviate = body.startswith("~")
+        body = body.lstrip("~")
+        if title is None:
+            title = body.rsplit(".", 1)[-1] if abbreviate else body
+
+        target = self.targets.get(body)
+        if target is None:
+            return f"`{title}`"
+        return f"[`{title}`][{target}]"
+
+    def on_object(self, *, obj: Object, **kwargs: Any) -> None:
+        docstring = obj.docstring
+        if docstring is None:
+            return
+        value = docstring.value
+        if ":" in value:
+            value = _ROLE.sub(self._substitute, value)
+        docstring.value = _reflow_parameters(value)


### PR DESCRIPTION
Closes the last open item on the accuracy audit's plan: the documentation site.

MkDocs + Material + mkdocstrings, built from `main` and published to GitHub Pages. The API reference is generated from the docstrings, which is the whole point — eighteen tutorials' worth of hard-won fidelity notes lived in them and rendered nowhere.

## What's in it

- **`docs/`** — an overview, an installation page, a quickstart whose every line was executed to produce the output it shows, and **Fidelity**: how the port is checked against R, what the checking has caught tutorial by tutorial, the differences that are real, and the measured bands from #72.
- **API reference** over every name in `shanuz.__all__`, grouped by what you'd be doing rather than by module, with a Seurat→shanuz map on the index.
- **All eighteen vignettes and their figures.** `docs/tutorials` is a symlink to `tutorials/`, so there is one copy of each vignette — the one a reader of the repo finds — rather than a docs copy that drifts. `docs/CHANGELOG.md` and `docs/ROADMAP.md` are symlinks under their repo names, which keeps the relative links *inside* those two files working unchanged.
- **`.github/workflows/docs.yml`** — `mkdocs build --strict` on every PR, deploy on push to `main`.

## The recorded blocker was not real

`ROADMAP.md` said mkdocstrings resolves annotations, and that `typing.get_type_hints()` raising `NameError` on the plotting and `graph`/`neighbor` signatures would stop the site on day one.

It still raises, on **19 callables** — a `TYPE_CHECKING` import does not execute, which is its purpose. But mkdocstrings never calls it: griffe reads annotations *statically*, without importing the module, so those signatures render and cross-link precisely **because** the deferred imports are there. Both ROADMAP entries now say so, and the Fidelity page records it. Clearing mypy (#69, #70) was worth doing on its own merits; it was not a prerequisite for this.

## What the site found

The site was the first consumer to read these docstrings mechanically, and it found five things:

| Defect | Effect |
|---|---|
| Three `Returns` sections written inside the parameter list | `sctransform`, `add_module_score` and `composition_test` documented **no return value at all**; `composition_test` also had its eleven output columns parsed as eleven parameters |
| All **370** documented parameters put their description in the type slot | The site printed "min features a cell must have to be kept" as `min_features`'s *type*, with an empty description |
| **129** Sphinx roles (`` :func:`run_pca` ``) | Rendered as literal `:func:` text, linking nothing |
| **15** `Slots` blocks | Markdown joined the aligned columns into one run-on paragraph |
| **2** heading anchors in `xenium_spatial_tutorial.md` | Dead here while being correct on GitHub |

The parameter and role fixes live in `tools/griffe_sphinx_roles.py` as a **build-time translation**, not source churn: the source form is what a reader of the code and a caller of `help()` sees, it is consistent across the package, and it is not wrong — it just is not what a NumPy parser expects. Roles become autorefs links **only** when the target is one the site actually publishes; anything else degrades to a code span, because `--strict` treats an unresolvable link as a failure.

The `Slots` blocks *were* rewritten in source, as bullet lists — that one reads better under `help()` too. The anchors were fixed by adopting GitHub's slugger site-wide, so one set of links works in both places rather than trading one breakage for another.

## Guards

`tests/test_docs.py` asserts the four things that rot without breaking anything at import time: every public export reaches an API page, every `:::` directive names something that still exists, no symbol is rendered twice, every nav entry and every vignette figure resolves — plus a full `--strict` build, which is the only check that catches a broken cross-reference or a stale anchor.

**All nine mutations of those guards were killed**: dropping a directive, renaming a target, documenting a symbol twice, dropping a vignette from the nav, pointing the nav at a missing file, breaking a figure path, making the reflow silently eat a line, making the extension emit an unresolvable link, and breaking a heading anchor.

`mkdocs`/`mkdocs-material`/`mkdocstrings[python]` go in a new `docs` extra, which is in `all` on purpose — the strict-build test can only run if the toolchain is in the same environment CI tests in. Verified that `pip install -e ".[docs]"` alone builds the site from a clean venv, which is what the workflow does.

## Before merging

**GitHub Pages is not enabled on this repo.** The deploy job needs Pages set to **"GitHub Actions"** as its source in Settings → Pages. Until that is flipped, the build job runs and passes on every PR — that is the part that catches breakage — and only the deploy step fails.

## Verification

- **970 tests pass**, 25 skipped (was 955/25)
- `ruff check shanuz tests tutorials tools` — clean
- `mypy` — `Success: no issues found in 53 source files`
- `mkdocs build --strict` — clean, from both the dev venv and a fresh `[docs]`-only one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
