### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Milestones are not releases.** [`ROADMAP.md`](ROADMAP.md) tracks progress in
 > `v0.N.0` *milestones*, named after the slice of Seurat they port. Those are
-> planning labels and never become version numbers on their own — the milestone
-> sequence even runs `v0.9.0` → `v0.10.0` with nothing in between. The versions
-> below are the ones actually tagged and released, and the two have drifted a
-> long way apart: the tags stop at 0.2.0 while the milestones have run through
-> v0.9.0. Everything in between sits under [Unreleased]. A milestone can also
-> span releases — v0.7.0's spatial loaders shipped in 0.1.1 while the rest of it
-> is still unreleased — so the two sequences do not line up item for item.
+> planning labels and never become version numbers on their own. Before 0.9.0
+> the two sequences had drifted a long way apart — the tags stopped at 0.2.0
+> while the milestones had run through v0.9.0, with a milestone able to span
+> releases (v0.7.0's spatial loaders shipped in 0.1.1 while the rest of it was
+> still unreleased). The 0.9.0 release below closes that entire gap in one
+> jump, which is why its version number happens to match the milestone it
+> completes — a coincidence of this one release, not a policy of matching them
+> going forward.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-27
+
 Work from six milestones — reference mapping, extra reductions, pseudobulk DE,
-spatial, scale, and the specialized assays — plus one breaking fix. All of it is
-on `main`; none of it is on PyPI.
+spatial, scale, and the specialized assays — plus one breaking fix, plus the
+tutorial fidelity infrastructure that followed (measured bands, staleness
+guards on the R-comparison reports). All of it was on `main`; as of this
+release, all of it is on PyPI.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ ships manylinux wheels only through cp313, and the alternatives are a source
 build needing BLAS or a resolver backtrack that pulls in torch. Everything else
 in the dependency set already has 3.14 wheels, so this is one package away.
 
-> **The PyPI release lags `main` by a long way right now.** The newest release is
-> **0.2.0** (2026-07-05), and much of the Features list above landed after it:
+> **`pip install shanuz` is current again.** The newest release is **0.9.0**
+> (2026-07-27), and it closes the gap the previous note here warned about:
 > reference mapping, sketching, `LazyMatrix`, cell hashing, Mixscape,
-> `run_spca`/`glm_pca`, pseudobulk DE, and the MERSCOPE/Visium additions are
-> **not** in `pip install shanuz` yet — only in a source install.
-> [`CHANGELOG.md`](https://github.com/GenomicAI/shanuz/blob/main/CHANGELOG.md)
-> records exactly what has and has not been released.
+> `run_spca`/`glm_pca`, pseudobulk DE, and the MERSCOPE/Visium additions are all
+> in it. [`CHANGELOG.md`](https://github.com/GenomicAI/shanuz/blob/main/CHANGELOG.md)
+> is still the authority on exactly what shipped when a gap like that opens up
+> again — a milestone landing on `main` does not mean it has been released.
 
 ### From PyPI — the released core
 
@@ -338,21 +338,21 @@ Shanuz
 
 See **[`ROADMAP.md`](https://github.com/GenomicAI/shanuz/blob/main/ROADMAP.md)** for the full
 development plan, and **[`CHANGELOG.md`](https://github.com/GenomicAI/shanuz/blob/main/CHANGELOG.md)**
-for what has actually shipped. The two are not the same thing: these milestones are planning
-labels rather than release versions, and most of the ✅ rows below are on `main` but not yet in
-any release. Milestones:
+for what has actually shipped. The two are not the same thing — these milestones are planning
+labels rather than release versions — but as of **0.9.0** every row below through v0.9.0 is
+released, not just landed on `main`. Milestones:
 
 | Milestone | Focus |
 |-----------|-------|
-| v0.2.0 | Batch correction — Harmony, CCA/RPCA anchors, `IntegrateLayers` dispatcher ✅ *(complete)* |
-| v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData`, `MapQuery`/`ProjectUMAP` ✅ *(complete)* |
-| v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(delivered — see Tutorial 3)* |
-| v0.5.0 | Additional reductions — t-SNE, ICA, `run_spca`, `glm_pca` (Poisson + negative binomial) ✅ *(complete)* |
-| v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`), bimod (`test_use="bimod"`) ✅ *(complete)* |
-| v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I + markvariogram), `image_*` plots, `VisiumV2` tissue images, `spatial_*` H&E plots ✅ *(delivered — see Tutorial 5)* |
-| v0.8.0 | Scale — `SketchData`/`ProjectData` (leverage-score sketching) ✅; BPCells-style lazy on-disk matrices (`LazyMatrix`) ✅ *(complete)* |
-| v0.9.0 | Specialized — `HTODemux` ✅ + `MULTIseqDemux` ✅ (cell hashing); Mixscape ✅ (`CalcPerturbSig` + `RunMixscape` + `MixscapeLDA` + `PlotPerturbScore` + `MixscapeHeatmap`, CRISPR screens) — **complete** |
-| v0.10.0 | Infrastructure — PyPI ✅, GitHub Actions CI ✅ (3.12–3.13 matrix, wheel build + clean-install verification, coverage), [`CHANGELOG.md`](https://github.com/GenomicAI/shanuz/blob/main/CHANGELOG.md) ✅, `mypy` wired advisory ✅ (annotating to `--strict` clean still open); MkDocs site still open |
+| v0.2.0 | Batch correction — Harmony, CCA/RPCA anchors, `IntegrateLayers` dispatcher ✅ *(released in 0.2.0)* |
+| v0.3.0 | Reference mapping — `FindTransferAnchors`, `TransferData`, `MapQuery`/`ProjectUMAP` ✅ *(released in 0.9.0)* |
+| v0.4.0 | Multimodal WNN — `FindMultiModalNeighbors`, joint UMAP/clustering ✅ *(released in 0.9.0 — see Tutorial 3)* |
+| v0.5.0 | Additional reductions — t-SNE, ICA, `run_spca`, `glm_pca` (Poisson + negative binomial) ✅ *(released in 0.9.0)* |
+| v0.6.0 | Pseudobulk & advanced DE — `AggregateExpression`, `FindConservedMarkers`, DESeq2 (`test_use="deseq2"`), MAST (`test_use="mast"`), bimod (`test_use="bimod"`) ✅ *(released in 0.9.0)* |
+| v0.7.0 | Spatial — Xenium/Visium/CosMx/MERSCOPE loaders, niche/neighbourhood analysis, `find_spatially_variable_features` (Moran's I + markvariogram), `image_*` plots, `VisiumV2` tissue images, `spatial_*` H&E plots ✅ *(released in 0.9.0 — see Tutorial 5)* |
+| v0.8.0 | Scale — `SketchData`/`ProjectData` (leverage-score sketching) ✅; BPCells-style lazy on-disk matrices (`LazyMatrix`) ✅ *(released in 0.9.0)* |
+| v0.9.0 | Specialized — `HTODemux` ✅ + `MULTIseqDemux` ✅ (cell hashing); Mixscape ✅ (`CalcPerturbSig` + `RunMixscape` + `MixscapeLDA` + `PlotPerturbScore` + `MixscapeHeatmap`, CRISPR screens) — **released in 0.9.0** |
+| v0.10.0 | Infrastructure — PyPI ✅, GitHub Actions CI ✅ (3.12–3.13 matrix, wheel build + clean-install verification, coverage), [`CHANGELOG.md`](https://github.com/GenomicAI/shanuz/blob/main/CHANGELOG.md) ✅, `mypy` clean ✅, this release ✅; MkDocs site on `main` but not yet released |
 
 ---
 
@@ -363,7 +363,7 @@ uv pip install -e ".[dev]"
 pytest tests/ -v
 ```
 
-All 798 tests pass.
+All 955 tests pass.
 
 Twenty-five further tests run the tutorials end-to-end against real data. They are opt-in
 — they need the cached datasets (~200 MB) and take minutes, so they do not run in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -758,7 +758,7 @@ regime. Don't "simplify" them.
 
 ### PyPI publication — ✅ delivered
 - `pip install shanuz` works: published as [`shanuz`](https://pypi.org/project/shanuz/),
-  currently 0.2.0 (`build` + `twine` added to `[dev]` extras; published to
+  currently 0.9.0 (`build` + `twine` added to `[dev]` extras; published to
   TestPyPI then PyPI; verified with a clean-venv install + import + mini-pipeline
   smoke test)
 - ~~Still open: replace the hard-coded `__version__` string~~ — ✅ delivered:
@@ -789,13 +789,15 @@ regime. Don't "simplify" them.
   for CI, a scheduled "resolve latest" CI leg} this project wants; the status quo
   is "find out from a user".
 
-- **Still open — cut a release.** The tags stop at 0.2.0 (2026-07-05) while
-  milestones v0.3.0–v0.9.0 have all landed on `main`, so `pip install shanuz`
-  currently ships almost none of the README's feature list: of 22 advertised
-  entry points sampled, 19 are absent from the published wheel (reference
+- **Cut a release — ✅ delivered.** The tags had stopped at 0.2.0 (2026-07-05)
+  while milestones v0.3.0–v0.9.0 had all landed on `main`, so `pip install
+  shanuz` shipped almost none of the README's feature list: of 22 advertised
+  entry points sampled, 19 were absent from the published wheel (reference
   mapping, sketching, `LazyMatrix`, hashing, Mixscape, `run_spca`/`glm_pca`,
-  pseudobulk DE, MERSCOPE/Visium). The README now says so out loud, but the real
-  fix is a release. This is the highest-value remaining infra item.
+  pseudobulk DE, MERSCOPE/Visium). **0.9.0** (2026-07-27) closes that gap in one
+  jump — every milestone through v0.9.0 is now on PyPI, which is also why the
+  version number lines up with the milestone it completes (a coincidence of
+  this one release; see the note atop `CHANGELOG.md`).
 
 ### GitHub Actions CI — ✅ delivered
 - **File:** `.github/workflows/ci.yml`
@@ -1293,13 +1295,16 @@ regime. Don't "simplify" them.
   reached PyPI, so it is not a release and gets no entry. Taking the log at face
   value would have documented a version that never existed. (0.1.0 was tagged but
   never published; 0.1.1 was the first release on PyPI.)
-- Carries a standing note that the milestones on this page are **not** releases,
-  because the two sequences have diverged far enough to mislead: the tags stop at
-  0.2.0 while the milestones run to v0.9.0, and a milestone can straddle releases
-  (v0.7.0's spatial loaders shipped in 0.1.1; the rest of v0.7.0 has not shipped).
-- Everything since 0.2.0 sits under `[Unreleased]`, including the three entries
-  queued by earlier PRs: #32's `BREAKING` CLR margin fix, #33's clara
-  cross-architecture caveat, and #34's `hto_demux` default change.
+- Carried a standing note that the milestones on this page are **not** releases,
+  because the two sequences had diverged far enough to mislead: the tags stopped
+  at 0.2.0 while the milestones ran to v0.9.0, and a milestone can straddle
+  releases (v0.7.0's spatial loaders shipped in 0.1.1; the rest of v0.7.0 stayed
+  unreleased until 0.9.0). **0.9.0** (2026-07-27) closed that gap — everything
+  through v0.9.0, including the three entries queued by earlier PRs (#32's
+  `BREAKING` CLR margin fix, #33's clara cross-architecture caveat, and #34's
+  `hto_demux` default change), moved from `[Unreleased]` into a dated `[0.9.0]`
+  section. The standing note stays on the page: the two sequences will drift
+  again the moment a milestone lands on `main` without a release to match it.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shanuz"
-version = "0.2.0"
+version = "0.9.0"
 description = "Python single-cell genomics toolkit — a port of Seurat's core data structures and analysis pipeline"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Cuts the release ROADMAP.md has been flagging as the highest-value remaining infra item: the tags stopped at 0.2.0 (2026-07-05) while six milestones' worth of work — reference mapping, extra reductions, pseudobulk DE, spatial, scale, and the specialized assays — landed on `main` with nothing published. Of 22 advertised entry points sampled, 19 were absent from the wheel.

## What's in 0.9.0

Everything currently under `[Unreleased]` in `CHANGELOG.md`: the six milestones above, the breaking CLR margin fix (#32), and the tutorial fidelity infrastructure from #72 (measured bands + staleness guards on the R-comparison reports).

## Version number

**0.9.0** — chosen to match the milestone it completes (v0.3.0 through v0.9.0 are all now released), which closes the tag/milestone drift `CHANGELOG.md`'s own standing note warns about. This is a coincidence of this one release, not a new policy of syncing them going forward — the note says so explicitly, and stays on the page for the next time they drift.

## Changes

- `pyproject.toml` → `0.9.0`
- `CHANGELOG.md`: `[Unreleased]` → `[0.9.0] - 2026-07-27`, with a fresh empty `[Unreleased]` above it
- `README.md`: the "PyPI lags main" warning replaced with a current-again note; the milestone table now says which release each row shipped in; test count 798 → 955
- `ROADMAP.md`: the "cut a release" item marked delivered

## Verification

- **955 tests pass**, 25 skipped
- `ruff check shanuz tests tutorials` — clean
- `mypy` — `Success: no issues found in 53 source files`
- `uv build` — wheel + sdist build cleanly as `shanuz-0.9.0`
- `twine check dist/*` — both pass
- Installed the wheel into a clean venv outside the repo and verified `shanuz.__version__ == "0.9.0"` and a normal import

## After merge

Tag `v0.9.0` on the merge commit, then publish to PyPI — the actual `twine upload` is a separate, irreversible step I'll confirm with you before running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
