### PR TITLE
Fix the docs site's raw-HTML figure paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [docs site](https://genomicai.github.io/shanuz/tutorials/). Added all
   eight, in the same format as the rest.
 
+- **Most figures on the docs site 404'd.** MkDocs re-anchors relative paths
+  written in Markdown syntax onto the built page, which under
+  `use_directory_urls` sits a directory deeper than its source — but it passes
+  raw HTML through untouched, and the vignettes write most of their figures as
+  `<img>` inside HTML tables so the R and the Python plot sit side by side.
+  Those resolved one directory too deep: 110 of the site's 133 figures were
+  broken, and the ten vignettes built entirely out of those tables showed no
+  images at all. Added a build hook (`tools/mkdocs_html_relpaths.py`) that
+  applies the same rewrite to raw `<img src>`, so the one path in the source
+  stays correct both on the site and on GitHub, where the vignettes are also
+  read. A reference with no file behind it is now a warning, which
+  `mkdocs build --strict` turns into a failed CI build.
+
+  The existing figure-existence test only understood Markdown image syntax, so
+  it was blind to 126 of the 149 references it was meant to be guarding; it now
+  reads both syntaxes.
+
 ## [0.9.0] - 2026-07-27
 
 Work from six milestones — reference mapping, extra reductions, pseudobulk DE,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,13 @@ markdown_extensions:
   - pymdownx.caret
   - pymdownx.smartsymbols
 
+hooks:
+  # The vignettes put the R and the Python figure side by side in raw HTML
+  # tables, and MkDocs only rewrites relative paths written in Markdown syntax.
+  # This re-anchors the raw `<img src>` ones the same way, so one path in the
+  # source renders correctly both here and on GitHub.
+  - tools/mkdocs_html_relpaths.py
+
 plugins:
   - search
   - mkdocstrings:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -29,8 +29,20 @@ DOCS = ROOT / "docs"
 API = DOCS / "api"
 
 _DIRECTIVE = re.compile(r"^:::\s+(?P<target>[\w.]+)\s*$", re.MULTILINE)
-# Markdown images, minus the absolute and remote ones.
-_IMAGE = re.compile(r"!\[[^\]]*\]\((?P<src>(?!https?:|/)[^)\s]+)")
+# Images, minus the absolute and remote ones. Both syntaxes: the vignettes
+# write most of their figures as raw `<img>` inside HTML tables, to put the R
+# and the Python plot side by side, and a check that only understood Markdown
+# syntax was blind to 126 of the 149 figure references on the site.
+_IMAGE = re.compile(
+    r"!\[[^\]]*\]\((?P<md>(?!https?:|/)[^)\s]+)"
+    r"|<img\b[^>]*?\bsrc=\"(?P<html>(?!https?:|/|data:)[^\"]+)\""
+)
+
+
+def image_sources(text: str):
+    """Every relative image path in a page, whichever syntax wrote it."""
+    for match in _IMAGE.finditer(text):
+        yield match.group("md") or match.group("html")
 
 
 def api_targets() -> dict[str, Path]:
@@ -163,16 +175,56 @@ def test_every_vignette_is_in_the_nav():
     assert not missing, f"vignettes missing from the site nav: {missing}"
 
 
+def doc_pages():
+    return list(DOCS.glob("*.md")) + list(API.glob("*.md")) + list((ROOT / "tutorials").glob("*.md"))
+
+
 def test_every_markdown_image_resolves():
     """Figures are committed, and a vignette linking a missing one is a 404."""
     broken = []
-    pages = list(DOCS.glob("*.md")) + list(API.glob("*.md")) + list((ROOT / "tutorials").glob("*.md"))
-    for page in pages:
-        for match in _IMAGE.finditer(page.read_text()):
-            src = match.group("src").split("#")[0]
-            if not (page.parent / src).resolve().exists():
+    for page in doc_pages():
+        for src in image_sources(page.read_text()):
+            if not (page.parent / src.split("#")[0]).resolve().exists():
                 broken.append(f"{page.relative_to(ROOT)} -> {src}")
-    assert not broken, "markdown images with no file behind them:\n  " + "\n  ".join(broken)
+    assert not broken, "images with no file behind them:\n  " + "\n  ".join(broken)
+
+
+def test_image_paths_are_written_relative_to_their_own_page():
+    """The one path in the source has to be the one GitHub resolves.
+
+    The build hook re-anchors these onto the page URL. It can only do that from
+    a path that is correct relative to the source file, so a `../` that reaches
+    out of `tutorials/` — the shape someone lands on when they fix the site by
+    hand and break the repo page — is wrong at the source even though both
+    surfaces may happen to render.
+    """
+    escaping = [
+        f"{page.relative_to(ROOT)} -> {src}"
+        for page in doc_pages()
+        for src in image_sources(page.read_text())
+        if src.startswith("../")
+    ]
+    assert not escaping, (
+        "image paths must be relative to their own source file, not to the built page:\n  "
+        + "\n  ".join(escaping)
+    )
+
+
+def test_the_build_hook_reanchors_raw_html_images():
+    """Without this the ten table-built vignettes 404 every figure.
+
+    Pinned against the two URL styles, because the fix is a no-op under
+    `use_directory_urls: false` and has to stay correct if that ever changes.
+    """
+    sys.path.insert(0, str(ROOT / "tools"))
+    import mkdocs_html_relpaths as hook
+
+    src_uri = "tutorials/advanced_pbmc8k_subclustering.md"
+    src = "figures_advanced/r_01_qc_violin.png"
+    assert hook.target_of(src, src_uri) == "tutorials/figures_advanced/r_01_qc_violin.png"
+    # Directory URLs put the page a level deeper than its source; plain ones do not.
+    assert hook.rewrite(src, src_uri, "tutorials/advanced_pbmc8k_subclustering/") == f"../{src}"
+    assert hook.rewrite(src, src_uri, "tutorials/advanced_pbmc8k_subclustering.html") == src
 
 
 def test_the_tutorials_symlink_still_points_at_the_tutorials():

--- a/tools/mkdocs_html_relpaths.py
+++ b/tools/mkdocs_html_relpaths.py
@@ -1,0 +1,82 @@
+"""Make raw-HTML ``<img>`` paths survive the same rewrite Markdown images get.
+
+MkDocs resolves relative links written in Markdown syntax against the *source*
+file and rewrites them to point at the *built* page, which under
+``use_directory_urls`` sits one directory deeper than its source:
+``tutorials/svf_vignette.md`` builds to ``tutorials/svf_vignette/index.html``,
+so ``![](figures_svf/x.png)`` correctly becomes ``../figures_svf/x.png``.
+
+Raw HTML in a Markdown document is passed through untouched, attributes and
+all. That is normally harmless, but the vignettes use ``<img>`` inside HTML
+tables to put the R figure and the Python figure side by side — most of the
+figure references on this site are written that way. Untouched, every one of
+them resolves a directory too deep and 404s, which is what happened to the ten
+vignettes built entirely out of those tables.
+
+Rewriting the source to ``../figures_svf/x.png`` would fix the site and break
+GitHub, where the vignettes are also read and where the path *is* relative to
+the source file. So the rewrite happens here, at build time, against the same
+target the Markdown treeprocessor uses: the site keeps working and the repo
+page keeps working, from one correct path in the source.
+
+A reference with no file behind it is warned about rather than silently
+rewritten, so ``mkdocs build --strict`` in CI fails on it.
+"""
+from __future__ import annotations
+
+import logging
+import posixpath
+import re
+
+log = logging.getLogger("mkdocs.hooks.html_relpaths")
+
+# `src` on an <img>, captured with its quotes so the replacement can put them
+# back untouched. Deliberately not a general HTML parser: the vignettes use
+# exactly one raw-HTML tag with a path in it, and a regex that only matches
+# that tag cannot quietly start rewriting something else.
+_IMG_SRC = re.compile(r'(?P<head><img\b[^>]*?\bsrc=)(?P<quote>["\'])(?P<src>[^"\']+)(?P=quote)')
+
+# Anything already absolute, remote, inline, or a bare fragment is left alone.
+_ABSOLUTE = re.compile(r"^(?:[a-zA-Z][\w+.-]*:|//|/|#)")
+
+
+def target_of(src: str, src_uri: str) -> str:
+    """Where a source-relative path lands, as a path from the docs root."""
+    src_dir = posixpath.dirname(src_uri)
+    return posixpath.normpath(posixpath.join(src_dir, src) if src_dir else src)
+
+
+def rewrite(src: str, src_uri: str, url: str) -> str:
+    """Re-anchor one path from the source file's directory onto the page's URL.
+
+    ``url`` is ``page.file.url``: ``tutorials/x/`` with directory URLs and
+    ``tutorials/x.html`` without. ``dirname`` gives the directory the browser
+    resolves against in either case.
+    """
+    return posixpath.relpath(target_of(src, src_uri), posixpath.dirname(url) or ".")
+
+
+def on_page_markdown(markdown: str, page, config, files, **kwargs) -> str:
+    """Rewrite before rendering, not after.
+
+    By ``on_page_content`` the Markdown images are already ``<img>`` tags and
+    already re-anchored, and a rewrite there would move them a second time.
+    Here the only ``<img>`` in the document is the raw HTML one — python-markdown
+    stashes those verbatim, which is why the treeprocessor never sees them and
+    why editing them at this stage survives rendering untouched.
+    """
+    def replace(match: re.Match) -> str:
+        src = match.group("src")
+        if _ABSOLUTE.match(src):
+            return match.group(0)
+        target = target_of(src, page.file.src_uri)
+        if files.get_file_from_path(target) is None:
+            log.warning(
+                "%s: <img src=%r> has no file behind it (looked for %r)",
+                page.file.src_uri, src, target,
+            )
+            return match.group(0)
+        new = rewrite(src, page.file.src_uri, page.file.url)
+        return f'{match.group("head")}{match.group("quote")}{new}{match.group("quote")}'
+
+    return _IMG_SRC.sub(replace, markdown)


### PR DESCRIPTION
Reported: [`advanced_pbmc8k_subclustering`](https://genomicai.github.io/shanuz/tutorials/advanced_pbmc8k_subclustering/) showed no figures at all.

## What was wrong

MkDocs re-anchors relative paths written in **Markdown** syntax onto the built page, which under `use_directory_urls` sits a directory deeper than its source. Raw HTML is passed through untouched — and the vignettes write most of their figures as `<img>` inside HTML tables, to put the R plot and the Python plot side by side.

So the figures were deployed correctly and the links pointed one directory too deep:

| URL | |
|---|---|
| `/tutorials/figures_advanced/r_01_qc_violin.png` | 200 — where the file actually is |
| `/tutorials/advanced_pbmc8k_subclustering/figures_advanced/r_01_qc_violin.png` | 404 — what the page asked for |

Measured on the built site: **110 of 133 figures broken**. The ten vignettes written entirely as HTML tables — `advanced_pbmc8k_subclustering`, `pbmc3k_tutorial`, `multimodal_citeseq`, `xenium_spatial_tutorial`, `sctransform_vignette`, `hashing_vignette`, `integration_vignette`, `mixscape_vignette`, `dimreduc_vignette`, `cellcycle_vignette`, `refmap_vignette` — lost every image. The eight using `![]()` were fine, which is why it looked like "some tutorials".

## The fix

Rewriting the source to `../figures_x/` would fix the site and break GitHub, where the vignettes are also read and where the path *is* relative to the source file. So the rewrite happens at build time (`tools/mkdocs_html_relpaths.py`), against the same target the Markdown treeprocessor uses — one correct path in the source, both surfaces working.

It runs on the Markdown, not the rendered content: by `on_page_content` the Markdown images are already `<img>` tags and already re-anchored, and rewriting there moved them a second time. The strict build caught that.

A reference with no file behind it now warns, which `mkdocs build --strict` turns into a failed CI build.

## Why nothing caught this

`test_every_markdown_image_resolves` only understood Markdown image syntax — it was blind to 126 of the 149 references it existed to guard. Widened to both syntaxes.

## Verification

- Built site: **0 of 133** relative `<img>` broken (was 110).
- Mutation-tested — hook removed: 110/133 break again. Figure deleted: the widened test fails, the old markdown-only regex passes blindly.
- 972 passed, 25 skipped; ruff clean; mypy clean; `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)