### PR TITLE
Resolve the upstream canary under 3.13 as well as 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,10 @@ jobs:
           path: coverage.xml
 
   freshdeps:
-    name: Resolve dependencies fresh (upstream canary)
+    # The interpolation is load-bearing: an explicit `name:` overrides the
+    # default matrix suffix, so without it both legs would report under one
+    # identical name and a single red leg would be unattributable.
+    name: Resolve dependencies fresh (upstream canary, ${{ matrix.python-version }})
     # Pinning the test matrix to `uv.lock` buys reproducibility and gives up the
     # thing the old unpinned install did for free: noticing that a new release
     # of numpy, pandas or scikit-learn has broken us. `pyproject.toml` declares
@@ -103,6 +106,15 @@ jobs:
     # so upstream breaking is never mistaken for the pull request breaking.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    strategy:
+      # Both legs, for the same reason the `test` matrix has both: an upstream
+      # release can break one interpreter and not the other, and a canary that
+      # only resolves under 3.12 stays green through it. `fail-fast: false`
+      # because which legs broke is the diagnosis — one leg red localises the
+      # breakage to that interpreter, both red points at the package itself.
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -111,12 +123,12 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Set up Python
-        run: uv python install 3.12
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install with the lock ignored
         run: |
-          uv venv --python 3.12
+          uv venv --python ${{ matrix.python-version }}
           uv pip install -e ".[all]"
 
       - name: Show what resolved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stopped checking. It runs on a schedule and on demand, not per pull request,
   so upstream breaking is never mistaken for the pull request breaking.
 
+  It resolves under both 3.12 and 3.13, matching the `test` matrix — an upstream
+  release can break one interpreter and not the other, and a canary that only
+  resolved under 3.12 would stay green through it. The legs do not fail fast,
+  because which legs went red is the diagnosis: one is an interpreter problem,
+  both is the package.
+
   The distribution job deliberately still installs the wheel *unlocked*: it
   exists to prove a plain `pip install truecell` works for a real user, and
   pinning it would defeat the point.


### PR DESCRIPTION
`freshdeps` resolved only under 3.12. An upstream release that broke 3.13 and
not 3.12 would have left it green — the interpreter-specific failure the job is
best placed to catch was the one it could not see. It now runs the same
`["3.12", "3.13"]` matrix as `test`.

Two details beyond the matrix itself:

- **`fail-fast: false`.** For a canary, *which* legs went red is the diagnosis:
  one red leg localises the break to that interpreter, both points at the
  package. Cancelling the second leg on the first failure discards that.
- **The job `name:` interpolates `matrix.python-version`.** An explicit `name:`
  overrides GitHub's default matrix suffix, so without it both legs would report
  under one identical name and a single red leg would be unattributable.

## Verification

CI cannot validate this change: `freshdeps` is gated to
`schedule`/`workflow_dispatch`, so it does not run on `pull_request` — by
design, so upstream breakage is never mistaken for a PR breaking. **The checks
on this PR will go green having never run the job it modifies.**

It was verified instead by dispatching CI against the branch ref, which runs
that branch's workflow file: [run 30558345483](https://github.com/GenomicAI/truecell/actions/runs/30558345483),
green on all five jobs.

| Job | Result |
|---|---|
| upstream canary, 3.12 | success — Python 3.12.13, 970 passed, 29 skipped |
| upstream canary, 3.13 | success — Python 3.13.14, 970 passed, 29 skipped |
| test (3.12), test (3.13) | success |
| Build and verify the distributions | success |

Both legs resolved fresh and drifted from `uv.lock` in the same four packages
(`backrefs`, `tqdm`, `twine`, `wrapt`); the only lock entries absent from a
fresh install are `pywin32-ctypes`, `tzdata` and `truecell` itself.

## What this does not buy today

The two legs resolved to **identical** package sets — nothing present in one and
not the other, no version differing across them. The second leg currently
duplicates the first.

Its value is prospective, and this repo already contains the scenario it waits
for: `harmonypy` ships wheels for cp39–cp313 only, which is why 3.14 is absent
from the matrix. When a dependency next ships a release with uneven interpreter
support, the legs diverge and the second earns itself. Today's run proves the
mechanism rather than finding anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)