### PR TITLE
Warn when ridge_plot's panels cannot fit the figure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ridge_plot` warns when an explicit `figsize` is too small for the group
+  labels**, instead of silently returning a figure with one panel's labels
+  printed across its neighbour. Ridgeline labels sit outside the axes, so a
+  panel is wider than its axes by the length of the longest label; when the
+  canvas cannot fit that, matplotlib overlaps the panels rather than erroring.
+
+  The warning names the computed default, which a 162-configuration sweep — up
+  to 12 groups, labels as long as `"Haematopoietic stem cell"`, every `ncol` —
+  found collision-free, and a test asserts the suggested size actually resolves
+  the collision. Recommending it beats scaling the caller's size by some
+  function of the overlap, which can still collide.
+
+  No layout engine fixes the underlying case: `constrained_layout` overlaps by
+  slightly *more* here and reports "axes sizes collapsed to zero", because the
+  space genuinely does not exist. The default path is unaffected and pays no
+  cost — the check only runs when `figsize` was passed.
+
 ### Fixed
 
 - **The categorical palette repeated colours, so two clusters could render

--- a/tests/test_plotting_layout.py
+++ b/tests/test_plotting_layout.py
@@ -1,0 +1,128 @@
+"""Panel layout in multi-panel plots.
+
+Ridgeline group labels are drawn outside the axes, so a panel is wider than its
+axes by the length of the longest label. When the figure is too small for that,
+matplotlib draws the panels over each other rather than complaining, and one
+panel's labels end up printed across its neighbour.
+
+The computed default leaves room; an explicit `figsize` can not. These tests fix
+both halves: the default must never collide, and a too-small explicit size must
+say so.
+"""
+import itertools
+import warnings
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+import truecell as tc
+
+# Long enough to actually crowd a panel. The real tutorial labels
+# ("FCGR3A+ Mono") are in this range; the last two are deliberately worse.
+LONG_LABELS = [
+    "Naive CD4 T", "CD14+ Mono", "Memory CD4 T", "B cells", "CD8 T",
+    "FCGR3A+ Mono", "NK", "Dendritic", "Platelet", "Plasmacytoid DC",
+    "Erythrocyte precursor", "Haematopoietic stem cell",
+]
+
+
+@pytest.fixture(scope="module")
+def obj():
+    pytest.importorskip("matplotlib")
+    rng = np.random.default_rng(0)
+    n_genes, n_cells = 24, 600
+    genes = [f"G{i:02d}" for i in range(n_genes)]
+    o = tc.create_truecell_object(
+        counts=sp.csc_matrix(rng.poisson(3.0, size=(n_genes, n_cells)).astype(float)),
+        assay="RNA", feature_names=genes,
+        cell_names=[f"C{i:03d}" for i in range(n_cells)], project="layout",
+    )
+    tc.normalize_data(o)
+    o.meta_data["ct"] = [LONG_LABELS[i % 12] for i in range(n_cells)]
+    return o
+
+
+def worst_overlap(fig) -> float:
+    """Largest overlap between any two panels' *tight* boxes, as a figure
+    fraction. The tight box includes tick labels and the title, so this measures
+    exactly what "labels printed over the neighbouring panel" means."""
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    inv = fig.transFigure.inverted()
+    boxes = [ax.get_tightbbox(renderer).transformed(inv)
+             for ax in fig.axes if ax.get_visible()]
+    worst = 0.0
+    for a, b in itertools.combinations(boxes, 2):
+        ox = min(a.x1, b.x1) - max(a.x0, b.x0)
+        oy = min(a.y1, b.y1) - max(a.y0, b.y0)
+        if ox > 0 and oy > 0:
+            worst = max(worst, min(ox, oy))
+    return worst
+
+
+@pytest.mark.parametrize("n_features", [2, 4, 6])
+@pytest.mark.parametrize("ncol", [None, 2, 3])
+def test_default_figsize_never_collides(obj, n_features, ncol):
+    """The property the computed default exists to have. Twelve groups with the
+    longest labels in the set is the crowded end of realistic usage."""
+    plt = pytest.importorskip("matplotlib.pyplot")
+    genes = obj.assays["RNA"]._all_feature_names[:n_features]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)  # must not warn either
+        fig = tc.ridge_plot(obj, genes, group_by="ct", ncol=ncol)
+    assert worst_overlap(fig) <= 0.005
+    plt.close(fig)
+
+
+def test_too_small_explicit_figsize_warns(obj):
+    plt = pytest.importorskip("matplotlib.pyplot")
+    genes = obj.assays["RNA"]._all_feature_names[:4]
+    with pytest.warns(UserWarning, match="panels overlap"):
+        fig = tc.ridge_plot(obj, genes, group_by="ct", figsize=(8, 5))
+    plt.close(fig)
+
+
+def test_the_suggested_figsize_actually_resolves_it(obj):
+    """A suggestion that still collides is worse than none — it costs the reader
+    a second round trip. Parse the size out of the warning and check it."""
+    import re
+    plt = pytest.importorskip("matplotlib.pyplot")
+    genes = obj.assays["RNA"]._all_feature_names[:4]
+
+    with pytest.warns(UserWarning, match="panels overlap") as rec:
+        plt.close(tc.ridge_plot(obj, genes, group_by="ct", figsize=(8, 5)))
+    msg = str(rec[0].message)
+
+    m = re.search(r"Use figsize=\(([\d.]+), ([\d.]+)\)", msg)
+    assert m, f"warning carries no parseable figsize: {msg}"
+    suggested = (float(m.group(1)), float(m.group(2)))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        fig = tc.ridge_plot(obj, genes, group_by="ct", figsize=suggested)
+    assert worst_overlap(fig) <= 0.005
+    plt.close(fig)
+
+
+def test_a_roomy_explicit_figsize_stays_silent(obj):
+    plt = pytest.importorskip("matplotlib.pyplot")
+    genes = obj.assays["RNA"]._all_feature_names[:4]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        fig = tc.ridge_plot(obj, genes, group_by="ct", figsize=(20, 8))
+    plt.close(fig)
+
+
+def test_short_labels_fit_in_a_small_figure(obj):
+    """The warning must key on whether the panels actually collide, not on the
+    figure being small — a small figure with short labels is fine."""
+    plt = pytest.importorskip("matplotlib.pyplot")
+    obj.meta_data["short"] = [["A", "B", "C", "D"][i % 4]
+                              for i in range(obj.meta_data.shape[0])]
+    genes = obj.assays["RNA"]._all_feature_names[:2]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        fig = tc.ridge_plot(obj, genes, group_by="short", figsize=(8, 5))
+    assert worst_overlap(fig) <= 0.005
+    plt.close(fig)

--- a/truecell/plotting.py
+++ b/truecell/plotting.py
@@ -1250,6 +1250,11 @@ def ridge_plot(
     Mirrors R's ``RidgePlot(pbmc, features = c("LYZ", "CD3D"))``.
 
     Requires ``scipy`` for KDE smoothing.
+
+    Group labels sit outside the axes, so a panel needs more width than its axes
+    alone. The default ``figsize`` allows for that. Passing one that is too small
+    makes matplotlib draw the panels over each other instead of erroring, so an
+    explicit ``figsize`` is checked and warns if the panels end up colliding.
     """
     from scipy.stats import gaussian_kde
     plt = _mpl()
@@ -1262,8 +1267,10 @@ def ridge_plot(
     colors = palette or _palette(len(unique))
 
     nrow, nc = _subplot_grid(len(features), ncol)
+    user_figsize = figsize
+    default_figsize = (nc * 5, nrow * max(3, len(unique) * 0.5))
     if figsize is None:
-        figsize = (nc * 5, nrow * max(3, len(unique) * 0.5))
+        figsize = default_figsize
 
     fig, axes = plt.subplots(nrow, nc, figsize=figsize, squeeze=False)
     axes_flat = axes.flatten()
@@ -1296,7 +1303,68 @@ def ridge_plot(
         axes_flat[i].set_visible(False)
 
     fig.tight_layout()
+    if user_figsize is not None:
+        _warn_if_panels_collide(fig, "ridge_plot", default_figsize)
     return fig
+
+
+def _warn_if_panels_collide(fig, func: str, default_figsize: tuple) -> None:
+    """Warn when panels overlap because the requested figure is too small.
+
+    Group labels sit outside the axes, so a ridgeline panel is wider than its
+    axes by however long the longest label is. The computed default leaves room
+    for that, and a sweep of 162 shapes — up to 12 groups, labels as long as
+    "Haematopoietic stem cell", every ncol — finds no collision at it. An
+    explicit `figsize` can still be too small for the content, and matplotlib's
+    response is to draw the panels on top of each other rather than to complain,
+    which is how a figure ends up with one panel's labels printed across its
+    neighbour.
+
+    No layout engine fixes this — `constrained_layout` overlaps by slightly more
+    here and reports "axes sizes collapsed to zero" — because the space does not
+    exist. So say so, with the size that would work, instead of returning a
+    figure that silently looks wrong.
+
+    Only called when the caller passed `figsize`; the default path never needs it
+    and this costs a draw.
+    """
+    try:
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+    except Exception:  # pragma: no cover - headless backends without a renderer
+        return
+
+    inv = fig.transFigure.inverted()
+    boxes = [ax.get_tightbbox(renderer).transformed(inv)
+             for ax in fig.axes if ax.get_visible()]
+
+    worst = 0.0
+    for i in range(len(boxes)):
+        for j in range(i + 1, len(boxes)):
+            a, b = boxes[i], boxes[j]
+            ox = min(a.x1, b.x1) - max(a.x0, b.x0)
+            oy = min(a.y1, b.y1) - max(a.y0, b.y0)
+            if ox > 0 and oy > 0:
+                worst = max(worst, min(ox, oy))
+
+    # A hair of overlap is just antialiased edges touching; 0.5% of the figure
+    # is the point where a label is visibly sitting on the neighbouring panel.
+    if worst <= 0.005:
+        return
+
+    w, h = (float(v) for v in fig.get_size_inches())
+    dw, dh = (round(float(v), 1) for v in default_figsize)
+    # Recommend the computed default rather than scaling the caller's size by
+    # some function of the overlap. The overlap fraction does not map linearly
+    # onto the inches needed, so a scaled guess can still collide — and the
+    # default is the one size measured collision-free across the whole sweep.
+    warnings.warn(
+        f"{func}: panels overlap at figsize=({w:.1f}, {h:.1f}) — the group "
+        f"labels need more room than this canvas has. Use figsize=({dw}, {dh}), "
+        f"omit figsize to get that automatically, or raise ncol.",
+        UserWarning,
+        stacklevel=3,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The reported collision does not exist on main

I flagged `ridge_plot` as having a label collision — one panel's group labels
printed across its neighbour — from looking at
`tutorials/figures/12_ridge_plot.png`. **That was wrong, and this PR is not that
fix.**

The file I judged was a *stale working-tree copy*, one of the 41 figures left
modified by the lockfile migration and drawn under the older matplotlib. Checked
against git:

| Version | Canvas | Ink pixels | Collides |
|---|---|---|---|
| Committed before #87 | 1783×1184 | 245,712 | no |
| Regenerated in #87 | 1783×1184 | 245,712 | no |

Identical layout, identical ink. Neither committed version has ever collided.

## What a sweep does find

162 configurations — short and long labels, 4/8/12 groups, 2/4/6 features, every
`ncol`, three figure sizes. **Two collide**, both with an explicit
`figsize=(8, 5)`: four columns of twelve labels as long as
`"Haematopoietic stem cell"` in an 8-inch-wide canvas.

**At the computed default, none collide.**

## No layout engine fixes it

I tried `constrained_layout` on exactly those two cases:

| | `figsize=(8,5)` | `figsize=(12,8)` |
|---|---|---|
| `tight_layout` | 0.0270 | 0.0000 |
| `constrained_layout` | **0.0278** | 0.0000 |

It overlaps by slightly *more*, and warns `axes sizes collapsed to zero. Try
making figure larger or Axes decorations smaller`. That is the honest diagnosis:
the room does not exist, and no engine can create it.

## What this PR changes

The defect that remains is not geometry, it is silence. Matplotlib's response to
"too small" is to draw panels on top of each other, so a caller who passes a
cramped `figsize` gets a figure that looks broken with nothing saying why.

An explicit `figsize` is now checked, and warns:

```
ridge_plot: panels overlap at figsize=(8.0, 5.0) — the group labels need more
room than this canvas has. Use figsize=(20.0, 6.0), omit figsize to get that
automatically, or raise ncol.
```

It recommends the **computed default** rather than scaling the caller's size by
some function of the overlap, because the overlap fraction does not map linearly
onto inches and a scaled guess can still collide — the first version I wrote
suggested `(8.4, 5.3)`, which does not help. A test parses the size out of the
warning and asserts it actually resolves.

The default path neither warns nor pays for the extra draw: the check runs only
when `figsize` was passed.

## Tests

13 new tests in `tests/test_plotting_layout.py`, including a parametrised
guarantee that the default figsize never collides across features × ncol at 12
long labels. All three mutations caught, each by the right test:

| Mutation | Caught by |
|---|---|
| Never warn | `..._warns`, `..._suggested_figsize_actually_resolves_it` |
| Suggest the caller's own size back | `..._suggested_figsize_actually_resolves_it` |
| Warn unconditionally | `..._roomy_..._stays_silent`, `..._short_labels_fit...` |

`1023 passed, 25 skipped`. No tutorial figure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
