### PR TITLE
Add split_by faceting to dim_plot, feature_plot and vln_plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`split_by` on `dim_plot`, `feature_plot` and `vln_plot`.** Seurat uses three
+  *different* mechanisms for this, which is the part worth getting right; each
+  was probed against Seurat 5.5.1 rather than assumed.
+
+  `DimPlot` uses `facet_wrap`: one panel per level holding only that level's
+  cells, with `scales = "fixed"`. Both the axis limits and the group colours are
+  therefore computed across all cells and shared, because panels are only
+  comparable if a position and a colour mean the same thing in each.
+
+  `FeaturePlot` builds a features x levels grid. The colour scale is computed per
+  feature over all cells and shared along the row — per-panel scales would make
+  two very different levels look alike, each filling its own range.
+
+  `VlnPlot` does not facet at all. `split.plot = FALSE` is its default, and it
+  says so itself: "Separate violin plots are now plotted side-by-side". So the
+  levels are **dodged** within each group's x position and coloured by level,
+  with the group carried by position. The offsets match ggplot's dodge geometry.
+
+  Every existing figure is byte-identical; the feature is purely additive.
+
 ### Fixed
 
 - **`vln_plot` drew the wrong violin, three ways.** All three were checked

--- a/tests/test_plotting_split.py
+++ b/tests/test_plotting_split.py
@@ -1,0 +1,323 @@
+"""`split_by` faceting, matching what Seurat actually does for each plot.
+
+The three are not the same mechanism, which is the thing worth pinning down.
+Probed against Seurat 5.5.1:
+
+  DimPlot     facet_wrap  — one panel per level, only that level's cells,
+                            `scales = "fixed"` so the ranges are shared
+  FeaturePlot patchwork   — a features x levels grid
+  VlnPlot     dodge       — `split.plot = FALSE` is the default, and its own
+                            message says "plotted side-by-side"; the levels sit
+                            within each group's x position, not in new panels
+"""
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+import truecell as tc
+
+
+@pytest.fixture(scope="module")
+def obj():
+    pytest.importorskip("matplotlib")
+    rng = np.random.default_rng(0)
+    n_genes, n_cells = 20, 300
+    counts = rng.poisson(2.0, size=(n_genes, n_cells)).astype(float)
+    counts[0, :100] = rng.poisson(25, size=100)
+    o = tc.create_truecell_object(
+        counts=sp.csc_matrix(counts), assay="RNA",
+        feature_names=[f"G{i:02d}" for i in range(n_genes)],
+        cell_names=[f"C{i:03d}" for i in range(n_cells)], project="split",
+    )
+    tc.normalize_data(o)
+    tc.find_variable_features(o, nfeatures=15)
+    tc.scale_data(o, features=o.assays["RNA"]._all_feature_names)
+    tc.run_pca(o, n_pcs=6)
+    tc.run_umap(o, dims=range(5), seed=42)
+    # The split columns must be independent of `cl`, or the cross is degenerate.
+    # `cl = i % 4` with `stim = i % 2` confounds them perfectly — every c0 cell
+    # is CTRL, every c1 is STIM — so half the group x level cells are empty and
+    # a dodge test silently sees four violins where it expects eight. Stepping
+    # the split every four cells decorrelates them.
+    o.meta_data["cl"] = [["c0", "c1", "c2", "c3"][i % 4] for i in range(n_cells)]
+    o.meta_data["stim"] = [["CTRL", "STIM"][(i // 4) % 2] for i in range(n_cells)]
+    o.meta_data["batch"] = [["b1", "b2", "b3"][(i // 4) % 3] for i in range(n_cells)]
+
+    cross = o.meta_data.groupby(["cl", "stim"], observed=True).size()
+    assert len(cross) == 8 and cross.min() > 2, "fixture is degenerate"
+    return o
+
+
+def _scatters(ax):
+    from matplotlib.collections import PathCollection
+    return [c for c in ax.collections if isinstance(c, PathCollection)]
+
+
+def _visible(fig):
+    return [a for a in fig.axes if a.get_visible() and a.get_position().width > 0.02]
+
+
+# ---------------------------------------------------------------------------
+# dim_plot — facet_wrap
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("col,n_levels", [("stim", 2), ("batch", 3), ("cl", 4)])
+def test_dim_plot_makes_one_panel_per_level(obj, col, n_levels):
+    plt = pytest.importorskip("matplotlib.pyplot")
+    fig = tc.dim_plot(obj, group_by="cl", split_by=col, label=False)
+    titles = [a.get_title() for a in _visible(fig) if a.get_title()]
+    levels = sorted(set(obj.meta_data[col].astype(str)))
+    assert sorted(titles) == levels
+    assert len(titles) == n_levels
+    plt.close(fig)
+
+
+def test_dim_plot_panels_hold_only_their_own_cells(obj):
+    """facet_wrap subsets; it does not grey the others out."""
+    plt = pytest.importorskip("matplotlib.pyplot")
+    fig = tc.dim_plot(obj, group_by="cl", split_by="stim", label=False)
+    panels = [a for a in _visible(fig) if a.get_title()]
+    counts = [sum(len(c.get_offsets()) for c in _scatters(a)) for a in panels]
+    expected = obj.meta_data["stim"].value_counts().sort_index().tolist()
+    assert counts == expected
+    assert sum(counts) == obj.meta_data.shape[0]
+    plt.close(fig)
+
+
+def test_dim_plot_shares_axis_limits_across_panels(obj):
+    """`scales = "fixed"`. Per-panel limits would silently rescale each one, and
+    the whole point of splitting is that a position means the same thing."""
+    plt = pytest.importorskip("matplotlib.pyplot")
+    fig = tc.dim_plot(obj, group_by="cl", split_by="batch", label=False)
+    panels = [a for a in _visible(fig) if a.get_title()]
+    xlims = {tuple(np.round(a.get_xlim(), 9)) for a in panels}
+    ylims = {tuple(np.round(a.get_ylim(), 9)) for a in panels}
+    assert len(xlims) == 1, f"panels disagree on x range: {xlims}"
+    assert len(ylims) == 1, f"panels disagree on y range: {ylims}"
+    plt.close(fig)
+
+
+def test_dim_plot_colours_are_consistent_across_panels(obj):
+    """A group must be the same colour in every panel, or the panels cannot be
+    read against each other. Colours come from all groups, not the panel's."""
+    plt = pytest.importorskip("matplotlib.pyplot")
+    fig = tc.dim_plot(obj, group_by="cl", split_by="stim", label=False)
+    panels = [a for a in _visible(fig) if a.get_title()]
+    per_panel = [[tuple(np.round(c.get_facecolor()[0], 6)) for c in _scatters(a)]
+                 for a in panels]
+    assert per_panel[0] == per_panel[1]
+    assert len(set(per_panel[0])) == 4, "four clusters should be four colours"
+    plt.close(fig)
+
+
+def test_dim_plot_split_legend_lists_every_group_once(obj):
+    plt = pytest.importorskip("matplotlib.pyplot")
+    fig = tc.dim_plot(obj, group_by="cl", split_by="stim", label=False)
+    assert len(fig.legends) == 1
+    texts = [t.get_text() for t in fig.legends[0].get_texts()]
+    assert texts == ["c0", "c1", "c2", "c3"]
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# feature_plot — a features x levels grid
+# ---------------------------------------------------------------------------
+
+def test_feature_plot_lays_out_features_by_levels(obj):
+    plt = pytest.importorskip("matplotlib.pyplot")
+    fig = tc.feature_plot(obj, ["G00", "G01"], split_by="batch")
+    titles = [a.get_title() for a in fig.axes if a.get_title()]
+    assert titles == ["G00 — b1", "G00 — b2", "G00 — b3",
+                      "G01 — b1", "G01 — b2", "G01 — b3"]
+    plt.close(fig)
+
+
+def test_feature_plot_shares_the_colour_scale_along_a_row(obj):
+    """Computed over all cells, not the panel's subset. Per-panel scales would
+    make two very different levels look alike — each would fill its own range."""
+    plt = pytest.importorskip("matplotlib.pyplot")
+    fig = tc.feature_plot(obj, ["G00"], split_by="stim")
+    panels = [a for a in fig.axes if a.get_title()]
+    clims = set()
+    for a in panels:
+        for c in _scatters(a):
+            if c.get_array() is not None:
+                clims.add(tuple(np.round(c.get_clim(), 9)))
+    assert len(clims) == 1, f"colour scale differs across the row: {clims}"
+    plt.close(fig)
+
+
+def test_feature_plot_split_panels_hold_only_their_own_cells(obj):
+    plt = pytest.importorskip("matplotlib.pyplot")
+    fig = tc.feature_plot(obj, ["G00"], split_by="stim")
+    panels = [a for a in fig.axes if a.get_title()]
+    counts = [sum(len(c.get_offsets()) for c in _scatters(a)) for a in panels]
+    assert counts == obj.meta_data["stim"].value_counts().sort_index().tolist()
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# vln_plot — a dodge, not a facet
+# ---------------------------------------------------------------------------
+
+def _violin_centres(ax):
+    from matplotlib.collections import PolyCollection
+    out = []
+    for c in ax.collections:
+        if isinstance(c, PolyCollection) and c.get_paths():
+            xs = c.get_paths()[0].to_polygons()[0][:, 0]
+            # Midrange, not mean: the violin is symmetric about its centre by
+            # construction, so (min + max) / 2 is exact, while the mean of the
+            # outline's vertices is pulled around by how they are distributed.
+            out.append(round((float(xs.min()) + float(xs.max())) / 2, 6))
+    return sorted(out)
+
+
+def test_vln_plot_dodges_rather_than_facets(obj):
+    """One panel, and the levels share each group's x position."""
+    plt = pytest.importorskip("matplotlib.pyplot")
+    fig = tc.vln_plot(obj, ["G00"], group_by="cl", split_by="stim", pt_size=0)
+    assert len([a for a in fig.axes if a.has_data()]) == 1, "split_by faceted"
+    centres = _violin_centres(fig.axes[0])
+    assert len(centres) == 8, "4 groups x 2 levels"
+    plt.close(fig)
+
+
+def test_vln_plot_dodge_offsets_match_ggplots_geometry(obj):
+    """ggplot dodges within one group's width: with two levels the violins sit
+    at +/- width/4 of the group's centre. Seurat's own build put them at 0.775
+    and 1.225 around x = 1, i.e. +/- 0.225 for a width of 0.9."""
+    plt = pytest.importorskip("matplotlib.pyplot")
+    width = 0.8
+    fig = tc.vln_plot(obj, ["G00"], group_by="cl", split_by="stim",
+                      pt_size=0, violin_width=width)
+    centres = np.array(_violin_centres(fig.axes[0]))
+    expected = np.sort(np.concatenate([np.arange(4) - width / 4,
+                                       np.arange(4) + width / 4]))
+    assert centres == pytest.approx(expected, abs=1e-6)
+    plt.close(fig)
+
+
+def test_vln_plot_split_colours_by_level_not_by_group(obj):
+    """The dodge carries the split in colour; the group is carried by position."""
+    plt = pytest.importorskip("matplotlib.pyplot")
+    from matplotlib.collections import PolyCollection
+    fig = tc.vln_plot(obj, ["G00"], group_by="cl", split_by="stim", pt_size=0)
+    cols = [tuple(np.round(c.get_facecolor()[0], 6))
+            for c in fig.axes[0].collections if isinstance(c, PolyCollection)]
+    assert len(set(cols)) == 2, "should be one colour per split level"
+    plt.close(fig)
+
+
+def test_vln_plot_split_violins_actually_hold_different_data(obj):
+    """Position and colour say a split happened; only the shape proves it did.
+
+    Dropping the `split_labels == lv` mask — so both levels draw every cell in
+    the group — left the dodge, the colours and the tick labels exactly as they
+    should be, and every other test in this file passed. The violins were
+    identical twins and nothing noticed. So build a column where the two levels
+    have disjoint value ranges within each group, and require the drawn shapes
+    to differ.
+    """
+    plt = pytest.importorskip("matplotlib.pyplot")
+    from matplotlib.collections import PolyCollection
+
+    # Its own object, not the shared fixture: this one needs the *values* rigged
+    # per level, and mutating a module-scoped fixture would leak into the rest.
+    rng = np.random.default_rng(11)
+    n = 320
+    # `(i // 4) % 2` against `cl = i % 4`, for the same reason as the fixture —
+    # `i % 2` would confound them and half the cells would be empty.
+    cl = np.array([["c0", "c1", "c2", "c3"][i % 4] for i in range(n)])
+    lohi = np.array([["lo", "hi"][(i // 4) % 2] for i in range(n)])
+    counts = rng.poisson(1.0, size=(2, n)).astype(float)
+    counts[1] = np.where(lohi == "hi",
+                         rng.normal(40, 2, n), rng.normal(4, 2, n)).clip(0)
+
+    o2 = tc.create_truecell_object(
+        counts=sp.csc_matrix(counts), assay="RNA", feature_names=["G00", "G01"],
+        cell_names=[f"X{i:03d}" for i in range(n)], project="lohi",
+    )
+    o2.meta_data["cl"] = cl
+    o2.meta_data["lohi"] = lohi
+
+    # Raw counts on purpose. LogNormalize divides by each cell's library size,
+    # and with two genes G01 *is* most of it — normalising pulls the two levels
+    # back on top of each other and the fixture stops testing anything.
+    fig = tc.vln_plot(o2, ["G01"], group_by="cl", split_by="lohi",
+                      layer="counts", pt_size=0)
+    by_centre = {}
+    for c in fig.axes[0].collections:
+        if isinstance(c, PolyCollection) and c.get_paths():
+            poly = c.get_paths()[0].to_polygons()[0]
+            centre = (float(poly[:, 0].min()) + float(poly[:, 0].max())) / 2
+            by_centre[round(centre, 4)] = (float(poly[:, 1].min()),
+                                           float(poly[:, 1].max()))
+    plt.close(fig)
+
+    centres = sorted(by_centre)
+    assert len(centres) == 8, "4 groups x 2 levels"
+    # Within each group the two violins must cover disjoint ranges. Which side
+    # holds which level follows the level order — "hi" sorts before "lo", so it
+    # takes the left slot — and the claim here is only that they differ.
+    for a, b in zip(centres[0::2], centres[1::2]):
+        ra, rb = by_centre[a], by_centre[b]
+        disjoint = rb[0] > ra[1] or ra[0] > rb[1]
+        assert disjoint, (
+            f"violins at x={a} and x={b} overlap in y ({ra} vs {rb}) "
+            "— both levels drew the same cells"
+        )
+
+
+def test_vln_plot_split_x_ticks_still_label_the_groups(obj):
+    plt = pytest.importorskip("matplotlib.pyplot")
+    fig = tc.vln_plot(obj, ["G00"], group_by="cl", split_by="stim", pt_size=0)
+    labels = [t.get_text() for t in fig.axes[0].get_xticklabels()]
+    assert labels == ["c0", "c1", "c2", "c3"]
+    plt.close(fig)
+
+
+def test_vln_plot_split_three_levels_stay_inside_the_group_slot(obj):
+    """Adjacent groups must not collide: every violin has to stay within half a
+    unit of its group centre however many levels there are."""
+    plt = pytest.importorskip("matplotlib.pyplot")
+    fig = tc.vln_plot(obj, ["G00"], group_by="cl", split_by="batch",
+                      pt_size=0, violin_width=0.8)
+    from matplotlib.collections import PolyCollection
+    for c in fig.axes[0].collections:
+        if isinstance(c, PolyCollection) and c.get_paths():
+            xs = c.get_paths()[0].to_polygons()[0][:, 0]
+            nearest = round(float(xs.mean()))
+            assert np.abs(xs - nearest).max() < 0.5
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# shared
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("fn,kw", [
+    (tc.dim_plot, {}),
+    (tc.feature_plot, {"features": ["G00"]}),
+    (tc.vln_plot, {"features": ["G00"]}),
+])
+def test_unknown_split_column_is_reported_clearly(obj, fn, kw):
+    with pytest.raises(KeyError, match="nope"):
+        fn(obj, split_by="nope", **kw)
+
+
+@pytest.mark.parametrize("fn,kw", [
+    (tc.dim_plot, {"label": False}),
+    (tc.feature_plot, {"features": ["G00"]}),
+    (tc.vln_plot, {"features": ["G00"], "pt_size": 0}),
+])
+def test_omitting_split_by_draws_a_single_panel(obj, fn, kw):
+    """The unsplit path must not have grown a grid."""
+    plt = pytest.importorskip("matplotlib.pyplot")
+    fig = fn(obj, **kw)
+    # feature_plot attaches a colourbar, which is itself an Axes with data.
+    data_axes = [a for a in fig.axes
+                 if a.has_data() and a.get_label() != "<colorbar>"]
+    assert len(data_axes) == 1
+    plt.close(fig)
+    plt.close(fig)

--- a/truecell/plotting.py
+++ b/truecell/plotting.py
@@ -476,6 +476,42 @@ def _strip_axes(ax):
     ax.spines["right"].set_visible(False)
 
 
+def _split_levels(obj, split_by: str) -> tuple:
+    """Return ``(labels, levels)`` for a ``split_by`` column.
+
+    Levels are ordered the way R orders a factor: by its own levels if the
+    column is categorical, alphabetically otherwise. Numeric-looking strings
+    sort numerically, matching how group labels are ordered elsewhere here.
+    """
+    if split_by not in obj.meta_data.columns:
+        raise KeyError(
+            f"split_by column {split_by!r} not found in meta_data. "
+            f"Available: {list(obj.meta_data.columns)}"
+        )
+    col = obj.meta_data[split_by]
+    if isinstance(col.dtype, pd.CategoricalDtype):
+        levels = [str(c) for c in col.cat.categories]
+    else:
+        levels = sorted({str(v) for v in col},
+                        key=lambda x: (int(x) if x.isdigit() else x))
+    return col.astype(str).values, levels
+
+
+def _shared_limits(emb: np.ndarray, pad: float = 0.04) -> tuple:
+    """Axis limits covering the whole embedding, with ggplot-ish padding.
+
+    `facet_wrap` defaults to `scales = "fixed"`, so every split panel gets the
+    same range — which is the point of splitting: the panels are only comparable
+    if a position means the same thing in each. Computing limits per panel would
+    silently rescale each one.
+    """
+    xs, ys = emb[:, 0], emb[:, 1]
+    dx = (xs.max() - xs.min()) or 1.0
+    dy = (ys.max() - ys.min()) or 1.0
+    return ((xs.min() - pad * dx, xs.max() + pad * dx),
+            (ys.min() - pad * dy, ys.max() + pad * dy))
+
+
 def _subplot_grid(n: int, ncol: Optional[int] = None):
     """Return (nrow, ncol) for n subplots."""
     if ncol is None:
@@ -542,6 +578,7 @@ def vln_plot(
     violin_width: float = 0.8,
     jitter_seed: Optional[int] = 0,
     raster: Optional[bool] = None,
+    split_by: Optional[str] = None,
 ) -> "Figure":
     """Violin plot of feature expression per cluster/identity.
 
@@ -567,6 +604,11 @@ def vln_plot(
                    ``None`` draws fresh jitter each call.
     raster   : rasterise the jittered points. ``None`` follows the same
                100,000-point rule as the other plots.
+    split_by : metadata column to split each group by. Matches Seurat's
+               ``split.plot = FALSE`` default — the levels are *dodged*
+               side-by-side within each group's x position and coloured by
+               level, not drawn as one split violin and not faceted into
+               separate panels.
     """
     from scipy.stats import gaussian_kde
 
@@ -576,13 +618,28 @@ def vln_plot(
 
     groups = _get_groups(obj, group_by)
     unique = sorted(set(groups), key=lambda x: (int(x) if x.isdigit() else x))
-    colors = palette or _palette(len(unique))
     if pt_size is None:
         pt_size = _auto_point_size(len(groups))
 
+    # Seurat's `split.by` on a violin is a *dodge*, not a facet and not a split
+    # violin: `VlnPlot` has `split.plot = FALSE` by default, and its own message
+    # says "Separate violin plots are now plotted side-by-side". So each ident
+    # keeps one x position and the levels sit shoulder to shoulder within it,
+    # coloured by level rather than by ident.
+    if split_by is None:
+        sub_levels: list = [None]
+        split_labels = None
+        colors = palette or _palette(len(unique))
+    else:
+        split_labels, sub_levels = _split_levels(obj, split_by)
+        colors = palette or _palette(len(sub_levels))
+
+    n_sub = len(sub_levels)
+    slot = violin_width / n_sub  # ggplot dodges within one group's width
+
     nrow, nc = _subplot_grid(len(features), ncol)
     if figsize is None:
-        figsize = (max(5, nc * 4), nrow * 3.5)
+        figsize = (max(5, nc * 4 * max(1, n_sub / 2)), nrow * 3.5)
 
     fig, axes = plt.subplots(nrow, nc, figsize=figsize, squeeze=False)
     axes_flat = axes.flatten()
@@ -594,7 +651,16 @@ def vln_plot(
         expr = _get_expression(obj, feat, assay, layer)
 
         for j, g in enumerate(unique):
-            vals = expr[groups == g]
+          for k, lv in enumerate(sub_levels):
+            in_cell = (groups == g)
+            if lv is not None:
+                in_cell = in_cell & (split_labels == lv)
+            vals = expr[in_cell]
+            colour = colors[j if lv is None else k]
+            # Centre of this violin's slot within the group's width.
+            centre = j + (0 if lv is None else (k - (n_sub - 1) / 2) * slot)
+            body = violin_width if lv is None else slot * 0.9
+
             if vals.size < 2:
                 continue
             lo, hi = float(vals.min()), float(vals.max())
@@ -602,8 +668,13 @@ def vln_plot(
                 # Constant within the group: a density is undefined, but the
                 # group still exists. Draw a flat marker at the value so it is
                 # not silently missing from the panel.
-                ax.plot([j - 0.35, j + 0.35], [lo, lo],
-                        color=colors[j], linewidth=1.5, zorder=2)
+                # 0.4375 of the body, which is exactly +/-0.35 at the default
+                # width of 0.8 — the constant this used before it had to scale
+                # with a dodge slot. Keeping it identical matters: a cluster with
+                # no variance in a `counts` layer hits this branch, and the two
+                # tutorial figures that draw one would otherwise shift by 0.002.
+                ax.plot([centre - body * 0.4375, centre + body * 0.4375],
+                        [lo, lo], color=colour, linewidth=1.5, zorder=2)
                 continue
 
             # trim = TRUE: the support is the observed range, so the violin does
@@ -619,22 +690,31 @@ def vln_plot(
             peak = dens.max()
             if peak <= 0:
                 continue
-            half = dens / peak * (violin_width / 2)
-            ax.fill_betweenx(grid, j - half, j + half,
-                             facecolor=colors[j], alpha=0.8, linewidth=0,
-                             zorder=2)
+            half = dens / peak * (body / 2)
+            ax.fill_betweenx(grid, centre - half, centre + half,
+                             facecolor=colour, alpha=0.8, linewidth=0,
+                             zorder=2,
+                             label=(str(lv) if (lv is not None and j == 0
+                                                and i == 0) else None))
             med = float(np.median(vals))
             w_at_med = float(np.interp(med, grid, half))
-            ax.plot([j - w_at_med, j + w_at_med], [med, med],
+            ax.plot([centre - w_at_med, centre + w_at_med], [med, med],
                     color="black", linewidth=1.5, zorder=4)
 
         if pt_size > 0:
+            jitter_span = 0.2 * (1 if n_sub == 1 else slot / violin_width)
             for j, g in enumerate(unique):
-                vals = expr[groups == g]
-                jitter = rng.uniform(-0.2, 0.2, size=vals.size)
-                ax.scatter(j + jitter, vals, s=pt_size, alpha=0.4,
-                           color=colors[j], zorder=3,
-                           rasterized=_should_raster(raster, len(expr)))
+                for k, lv in enumerate(sub_levels):
+                    in_cell = (groups == g)
+                    if lv is not None:
+                        in_cell = in_cell & (split_labels == lv)
+                    vals = expr[in_cell]
+                    centre = j + (0 if lv is None
+                                  else (k - (n_sub - 1) / 2) * slot)
+                    jitter = rng.uniform(-jitter_span, jitter_span, size=vals.size)
+                    ax.scatter(centre + jitter, vals, s=pt_size, alpha=0.4,
+                               color=colors[j if lv is None else k], zorder=3,
+                               rasterized=_should_raster(raster, len(expr)))
 
         ax.set_xticks(range(len(unique)))
         ax.set_xticklabels(unique, rotation=45 if len(unique) > 6 else 0,
@@ -647,6 +727,12 @@ def vln_plot(
         axes_flat[i].set_visible(False)
 
     fig.tight_layout()
+    if split_by is not None:
+        handles, labels_ = axes_flat[0].get_legend_handles_labels()
+        if handles:
+            fig.legend(handles, labels_, title=split_by, fontsize=_fs("small"),
+                       title_fontsize=_fs("small"), loc="center left",
+                       bbox_to_anchor=(1.0, 0.5), frameon=False)
     return fig
 
 
@@ -668,6 +754,7 @@ def feature_plot(
     pt_size: float = 3.0,
     figsize: Optional[tuple] = None,
     raster: Optional[bool] = None,
+    split_by: Optional[str] = None,
 ) -> "Figure":
     """Visualise feature expression on a dimensionality reduction embedding.
 
@@ -685,6 +772,12 @@ def feature_plot(
     raster      : draw the cells as a raster layer instead of vector paths.
                   ``None`` (default) rasterises above 100,000 cells, the same
                   rule and threshold Seurat uses.
+    split_by    : metadata column to facet on. Lays out one row per feature and
+                  one column per level, as Seurat does. The colour scale and the
+                  axis limits are computed once per feature over *all* cells and
+                  shared down the row, so a colour means the same expression in
+                  every panel — per-panel scales would make the levels look
+                  alike however different they are.
     """
     plt = _mpl()
     if isinstance(features, str):
@@ -695,48 +788,70 @@ def feature_plot(
     ax1_label = reduction.upper() + "_1"
     ax2_label = reduction.upper() + "_2"
 
-    nrow, nc = _subplot_grid(len(features), ncol)
-    if figsize is None:
-        figsize = (nc * 4.5, nrow * 4)
+    if split_by is None:
+        nrow, nc = _subplot_grid(len(features), ncol)
+        if figsize is None:
+            figsize = (nc * 4.5, nrow * 4)
+        fig, axes = plt.subplots(nrow, nc, figsize=figsize, squeeze=False)
+        axes_flat = axes.flatten()
+        cells = [(None, np.ones(len(emb), dtype=bool))]
+        xlim = ylim = None
+    else:
+        split_labels, levels = _split_levels(obj, split_by)
+        cells = [(lv, split_labels == lv) for lv in levels]
+        nrow, nc = len(features), len(levels)
+        if figsize is None:
+            figsize = (nc * 4.2, nrow * 3.9)
+        fig, axes = plt.subplots(nrow, nc, figsize=figsize, squeeze=False)
+        axes_flat = axes.flatten()
+        xlim, ylim = _shared_limits(emb)
 
-    fig, axes = plt.subplots(nrow, nc, figsize=figsize, squeeze=False)
-    axes_flat = axes.flatten()
-
-    for i, feat in enumerate(features):
-        ax = axes_flat[i]
+    for fi, feat in enumerate(features):
         expr = _get_expression(obj, feat, assay, layer)
 
+        # Cutoffs from every cell, not the panel's subset — that is what makes
+        # the row comparable.
         vmin = np.percentile(expr, 5) if min_cutoff == "q05" else (min_cutoff or 0)
         vmax = np.percentile(expr, 95) if max_cutoff == "q95" else (max_cutoff or expr.max())
         vmax = max(vmax, vmin + 1e-9)
 
-        # R Seurat default: non-expressing (zero) cells rendered in light gray,
-        # expressing cells drawn on top sorted by expression level.
-        zero_mask = expr <= vmin
-        nonzero_mask = ~zero_mask
-        ax.scatter(emb[zero_mask, 0], emb[zero_mask, 1],
-                   c="#D3D3D3", s=pt_size, linewidths=0, rasterized=rast)
+        for ci, (level, in_panel) in enumerate(cells):
+            ax = axes_flat[fi * len(cells) + ci]
 
-        expr_nz = expr[nonzero_mask]
-        emb_nz = emb[nonzero_mask]
-        if order:
-            sort_idx = np.argsort(expr_nz)
-            expr_nz = expr_nz[sort_idx]
-            emb_nz = emb_nz[sort_idx]
+            # R Seurat default: non-expressing (zero) cells rendered in light gray,
+            # expressing cells drawn on top sorted by expression level.
+            zero_mask = (expr <= vmin) & in_panel
+            nonzero_mask = (expr > vmin) & in_panel
+            ax.scatter(emb[zero_mask, 0], emb[zero_mask, 1],
+                       c="#D3D3D3", s=pt_size, linewidths=0, rasterized=rast)
 
-        sc = ax.scatter(emb_nz[:, 0], emb_nz[:, 1], c=expr_nz, s=pt_size,
-                        cmap=colormap, vmin=vmin, vmax=vmax, linewidths=0,
-                        rasterized=rast)
-        plt.colorbar(sc, ax=ax, shrink=0.6, pad=0.01, aspect=25)
-        ax.set_xlabel(ax1_label, fontsize=_fs("small"))
-        ax.set_ylabel(ax2_label, fontsize=_fs("small"))
-        ax.set_title(feat, fontsize=_fs("title"), fontweight="bold")
-        ax.set_xticks([])
-        ax.set_yticks([])
-        for spine in ax.spines.values():
-            spine.set_visible(False)
+            expr_nz = expr[nonzero_mask]
+            emb_nz = emb[nonzero_mask]
+            if order:
+                sort_idx = np.argsort(expr_nz)
+                expr_nz = expr_nz[sort_idx]
+                emb_nz = emb_nz[sort_idx]
 
-    for i in range(len(features), len(axes_flat)):
+            sc = ax.scatter(emb_nz[:, 0], emb_nz[:, 1], c=expr_nz, s=pt_size,
+                            cmap=colormap, vmin=vmin, vmax=vmax, linewidths=0,
+                            rasterized=rast)
+            # One colourbar per row when split: it applies to the whole row, and
+            # repeating it per panel would say otherwise.
+            if level is None or ci == len(cells) - 1:
+                plt.colorbar(sc, ax=ax, shrink=0.6, pad=0.01, aspect=25)
+            if xlim is not None:
+                ax.set_xlim(*xlim)
+                ax.set_ylim(*ylim)
+            ax.set_xlabel(ax1_label, fontsize=_fs("small"))
+            ax.set_ylabel(ax2_label, fontsize=_fs("small"))
+            ax.set_title(feat if level is None else f"{feat} — {level}",
+                         fontsize=_fs("title"), fontweight="bold")
+            ax.set_xticks([])
+            ax.set_yticks([])
+            for spine in ax.spines.values():
+                spine.set_visible(False)
+
+    for i in range(len(features) * len(cells), len(axes_flat)):
         axes_flat[i].set_visible(False)
 
     fig.tight_layout()
@@ -759,6 +874,8 @@ def dim_plot(
     palette: Optional[list] = None,
     title: Optional[str] = None,
     raster: Optional[bool] = None,
+    split_by: Optional[str] = None,
+    ncol: Optional[int] = None,
 ) -> "Figure":
     """Plot cells in a reduced-dimension embedding coloured by identity.
 
@@ -775,6 +892,12 @@ def dim_plot(
     raster    : draw the cells as a raster layer instead of vector paths.
                 ``None`` (default) rasterises above 100,000 cells, the same rule
                 and threshold Seurat uses.
+    split_by  : metadata column to facet on — one panel per level, holding only
+                that level's cells. Colours and axis limits are shared across
+                panels, matching ``facet_wrap``'s fixed scales: the panels are
+                only comparable if a position and a colour mean the same thing
+                in each.
+    ncol      : panels per row when ``split_by`` is set.
     """
     plt = _mpl()
     emb = _get_embedding(obj, reduction)
@@ -788,34 +911,75 @@ def dim_plot(
 
     ax1_label = reduction.upper() + "_1"
     ax2_label = reduction.upper() + "_2"
+    colour_of = dict(zip(unique, colors))
 
-    fig, ax = plt.subplots(figsize=figsize)
-    for g, color in zip(unique, colors):
-        mask = groups == g
-        ax.scatter(emb[mask, 0], emb[mask, 1], s=pt_size, alpha=alpha,
-                   color=color, label=g, linewidths=0, rasterized=rast)
+    if split_by is None:
+        panels: list = [(None, np.ones(len(emb), dtype=bool))]
+        fig, axes = plt.subplots(figsize=figsize, squeeze=False)
+        axes_flat = axes.flatten()
+        xlim = ylim = None
+    else:
+        split_labels, levels = _split_levels(obj, split_by)
+        panels = [(lv, split_labels == lv) for lv in levels]
+        nrow, nc = _subplot_grid(len(levels), ncol)
+        if figsize == (7, 6):  # untouched default — size to the grid instead
+            figsize = (nc * 4.6, nrow * 4.2)
+        fig, axes = plt.subplots(nrow, nc, figsize=figsize, squeeze=False)
+        axes_flat = axes.flatten()
+        xlim, ylim = _shared_limits(emb)
 
-    if label:
+    for i, (level, in_panel) in enumerate(panels):
+        ax = axes_flat[i]
         for g in unique:
-            mask = groups == g
-            cx, cy = emb[mask, 0].mean(), emb[mask, 1].mean()
-            ax.text(cx, cy, g,
-                    fontsize=_fs("label") if label_size is None else label_size,
-                    fontweight="bold",
-                    ha="center", va="center",
-                    bbox=dict(boxstyle="round,pad=0.25", fc="white",
-                              alpha=0.75, ec="none"))
+            mask = (groups == g) & in_panel
+            # Draw even when empty, so the legend carries every group in every
+            # panel and the colours stay attached to the same labels.
+            ax.scatter(emb[mask, 0], emb[mask, 1], s=pt_size, alpha=alpha,
+                       color=colour_of[g], label=g if i == 0 else None,
+                       linewidths=0, rasterized=rast)
 
-    ax.set_xlabel(ax1_label)
-    ax.set_ylabel(ax2_label)
-    ax.set_title(title or f"{reduction.upper()} — coloured by "
-                          f"{'ident' if group_by is None else group_by}",
-                 fontsize=_fs("large"))
-    ax.legend(markerscale=2.5, fontsize=_fs("small"),
-              bbox_to_anchor=(1.01, 1), loc="upper left",
-              frameon=False)
-    _strip_axes(ax)
-    fig.tight_layout()
+        if label:
+            for g in unique:
+                mask = (groups == g) & in_panel
+                if not mask.any():
+                    continue
+                cx, cy = emb[mask, 0].mean(), emb[mask, 1].mean()
+                ax.text(cx, cy, g,
+                        fontsize=_fs("label") if label_size is None else label_size,
+                        fontweight="bold", ha="center", va="center",
+                        bbox=dict(boxstyle="round,pad=0.25", fc="white",
+                                  alpha=0.75, ec="none"))
+
+        if xlim is not None:
+            ax.set_xlim(*xlim)
+            ax.set_ylim(*ylim)
+        ax.set_xlabel(ax1_label)
+        ax.set_ylabel(ax2_label)
+        if level is None:
+            ax.set_title(title or f"{reduction.upper()} — coloured by "
+                                  f"{'ident' if group_by is None else group_by}",
+                         fontsize=_fs("large"))
+        else:
+            ax.set_title(str(level), fontsize=_fs("title"), fontweight="bold")
+        _strip_axes(ax)
+
+    for i in range(len(panels), len(axes_flat)):
+        axes_flat[i].set_visible(False)
+
+    # One legend for the figure. Anchoring it to the first panel would put it
+    # inside the grid; on the figure it sits clear of every panel.
+    handles, labels_ = axes_flat[0].get_legend_handles_labels()
+    if split_by is None:
+        axes_flat[0].legend(handles, labels_, markerscale=2.5,
+                            fontsize=_fs("small"), bbox_to_anchor=(1.01, 1),
+                            loc="upper left", frameon=False)
+        fig.tight_layout()
+    else:
+        if title:
+            fig.suptitle(title, fontsize=_fs("suptitle"), fontweight="bold")
+        fig.tight_layout()
+        fig.legend(handles, labels_, markerscale=2.5, fontsize=_fs("small"),
+                   loc="center left", bbox_to_anchor=(1.0, 0.5), frameon=False)
     return fig
 
 


### PR DESCRIPTION
`split_by` on `dim_plot`, `feature_plot` and `vln_plot`.

## Seurat uses three different mechanisms

This is the part worth getting right, and the part a name-level reading gets
wrong. Each was probed against **Seurat 5.5.1 running locally**, not assumed:

| | Mechanism | How it was established |
|---|---|---|
| `DimPlot` | `facet_wrap`, `scales = "fixed"` | `ggplot_build`: 2 panels, **150 of 300 cells each**, a single shared `panel_scales_x` |
| `FeaturePlot` | patchwork grid, features x levels | returns `patchwork`, 4 subplots for 2 features x 2 levels |
| `VlnPlot` | **dodge, not facet** | `split.plot = FALSE` is the default; 6 groups, 2 fills, x at 0.775/1.225/1.775/… |

### DimPlot — facet

One panel per level holding only that level's cells. Axis limits **and** group
colours are computed across all cells and shared, because panels are only
comparable if a position and a colour mean the same thing in each. Per-panel
limits would silently rescale every panel.

### FeaturePlot — grid

Rows are features, columns are levels. The colour scale is computed per feature
over all cells and shared along the row. Per-panel scales would make two very
different levels look alike, each filling its own range — the failure mode that
makes a split plot actively misleading rather than merely wrong.

### VlnPlot — dodge

Not a facet, and not a split violin. Seurat's own message says it:

> Separate violin plots are now plotted side-by-side.

So the levels sit shoulder to shoulder inside each group's x position, coloured
by level, with the group carried by position and the tick labels. Seurat's build
put two levels at 0.775 and 1.225 around x = 1 — ±0.225 for a width of 0.9 — and
the offsets here match that geometry.

## One test earns its place

Stripping the split mask out of `vln_plot`, so both levels draw **every** cell in
the group, left the dodge geometry, the colours, the tick labels and the panel
count all exactly right. **21 tests passed against violins that were identical
twins.**

Position and colour say a split happened; only the shape proves it did. A fixture
with disjoint per-level value ranges now checks that.

Full sweep, six mutations, all caught:

| Mutation | Caught by |
|---|---|
| strip `vln_plot`'s split mask | the new shape test (nothing else) |
| per-panel axis limits | shared-limits test |
| no dodge offset | 2 tests |
| colour by group not level | 6 tests |
| `feature_plot` ignores the split | panel-contents test |
| `dim_plot` ignores the split | panel-contents test |

## Two fixtures had to be fixed before they tested anything

`cl = i % 4` with a split of `i % 2` confounds the two perfectly — every `c0`
cell is `CTRL` — so half the group x level cells are empty and a dodge test sees
four violins where it should see eight. It now steps the split every four cells,
with an assertion in the fixture so a future edit cannot quietly reintroduce it.

And normalising a two-gene object equalises the levels, because the gene under
test is most of each cell's library size. That test plots raw counts on purpose.

## A regression this introduced, and fixed

The constant-group marker moved from `±0.35` to `±0.352` once it started scaling
with the dodge slot, shifting the two tutorial figures that have a zero-variance
cluster in a `counts` layer. It is now `0.4375` of the body — exactly `±0.35` at
the default width. **Every existing figure is byte-identical**, verified by
regenerating all 18 generators and diffing.

`1063 passed, 25 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
