### PR TITLE
Close the gaps a domain-expert review exposed: multi-resolution clustering, average_expression, and four silent defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`_get_expression_matrix` returned the wrong layer, and mislabelled the right
+  one.** Two defects in one function, both reachable from
+  `find_markers(layer=...)`, `aggregate_expression` and `average_expression`.
+
+  The Assay5 layer dict is keyed `scale.data`; the Python argument is
+  `scale_data`. Only the dotted spelling was matched, so the underscore form
+  missed the dict and **fell through to the `data` fallback** — a matrix of the
+  right shape, no warning, and normalized values where scaled ones were asked
+  for.
+
+  The dotted spelling then hit the second defect: the matrix came back paired
+  with the assay's *full* feature list. `scale.data` holds only the scaled
+  subset (`scale_data()` defaults to the variable features, as R's `ScaleData`
+  does), so a 10-row matrix was labelled with 30 names and every row read as a
+  different gene. This is the defect fixed in `reduction.py` under #66; the same
+  one survived here. Each layer is now labelled with its own features.
+
+  `reduction.py`, and therefore PCA, was never affected — it has its own
+  accessor.
+
 ### Added
+
+- **`average_expression`, mirroring Seurat's `AverageExpression`.** Seurat ships
+  two group-summary functions and Truecell had only `aggregate_expression`.
+  They are not two scalings of one thing: `AggregateExpression` sums raw counts,
+  while `AverageExpression` averages the **back-transformed** `data` layer —
+  `mean(expm1(x))`, not `mean(x)` and not `expm1(mean(x))`. On a small Poisson
+  object the first gene reads 332.84 under one and 3.17 under the other.
+
+  The back-transform applies to the `data` layer alone; `counts` and
+  `scale.data` are not log-normalized and are averaged as they stand. All three
+  layers, `features=`, multi-column `group_by` and `return_object` were pinned
+  against Seurat 5.5.1 — worst absolute difference 6.8e-13 on values of order
+  300. `return_object` leaves the averages in `counts` and writes `log1p` of
+  them to `data`, as Seurat's `return.seurat = TRUE` does, rather than
+  re-normalizing a matrix that is already an average.
+
+  The `expm1` transform is shared with `find_markers`' fold-change path rather
+  than copied, since Seurat's fold change is the same back-transform and a
+  divergence between the two would be undetectable downstream.
 
 - **`find_clusters` accepts several resolutions, and writes the per-resolution
   column Seurat writes.** `FindClusters(obj, resolution = c(0.4, 0.8, 1.2))` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`aggregate_expression(return_object=True)` left raw sums in the `data`
+  layer.** Seurat's `AggregateExpression(return.seurat = TRUE)` runs
+  `NormalizeData` over the pseudobulk, so its `data` holds
+  `log1p(sums / colSums × 10000)`. Truecell copied the sums across unchanged,
+  which every downstream function reading that layer would have taken for
+  normalized expression — library-size confounded and off by orders of
+  magnitude (14 where Seurat has 6.98).
+
+  `normalization_method` and `scale_factor` now match Seurat's arguments, with
+  `normalization_method=None` to opt out.
+
+  This is the one place the two group-summary functions genuinely diverge:
+  `average_expression` writes a plain `log1p` of the means with no library-size
+  step, and that was already right. Both verified against Seurat 5.5.1.
+
+  Found by pinning `aggregate_expression` against R for the first time. Its nine
+  existing tests all compared Python to a Python re-derivation of the same
+  formula — the shape of coverage that cannot catch a convention mismatch, and
+  the reason the CLR defect once survived its own unit test.
+
 - **`_get_expression_matrix` returned the wrong layer, and mislabelled the right
   one.** Two defects in one function, both reachable from
   `find_markers(layer=...)`, `aggregate_expression` and `average_expression`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`find_clusters` accepts several resolutions, and writes the per-resolution
+  column Seurat writes.** `FindClusters(obj, resolution = c(0.4, 0.8, 1.2))` is
+  the standard idiom for choosing a resolution — run a few, compare, then pick —
+  and it had no Truecell equivalent. `find_clusters(obj, resolution=[0.4, 0.8,
+  1.2])` now runs each in turn.
+
+  The larger fix is underneath it and applies at the default settings: Truecell
+  wrote **only** `seurat_clusters`, never the `{graph}_res.{resolution}` column,
+  so a ported script reading `obj[["RNA_snn_res.0.5"]]` raised `KeyError`. That
+  column is now written for a single resolution too.
+
+  Three conventions were pinned against Seurat 5.5.1 rather than assumed, and
+  one of them is a trap. The column label is R's number formatting, not
+  Python's: `str(1.0)` is `"1.0"` where R's `as.character(1.0)` is `"1"`, so a
+  naive implementation names the column `RNA_snn_res.1.0` and the ported script
+  still fails. `_res_label` reproduces R's rule — render fixed and scientific,
+  keep the shorter, ties to fixed — and is checked against R on 21 values from
+  1e-7 to 1234567. The object is left on the **last** resolution given, not the
+  largest (`resolution=[1.2, 0.8, 0.4]` ends on 0.4). And each resolution is
+  clustered from the same seed rather than a running stream, so a partition does
+  not depend on what preceded it or on the order asked for.
+
+  `cluster_name` is supported, matching Seurat's `cluster.name`.
+
 - **`split_by` on `dim_plot`, `feature_plot` and `vln_plot`.** Seurat uses three
   *different* mechanisms for this, which is the part worth getting right; each
   was probed against Seurat 5.5.1 rather than assumed.

--- a/REVIEW_PLAN.md
+++ b/REVIEW_PLAN.md
@@ -1,0 +1,254 @@
+# Package work from the domain-expert review
+
+An expert reviewer read the Truecell package and manuscript and returned eleven
+comments. The manuscript items are parked (`truecell_paper/community_paper/REVIEW_ROUND2_PLAN.md`
+holds those). This document is the subset that lands in **this repository**: the
+API gaps and validation gaps the review exposed.
+
+Every finding below was checked against the source and against **live R Seurat
+5.5.1**, not inferred from the review text.
+
+The review is a useful instrument here precisely because it is *not* a software
+review. It is a working biologist describing what she does at the keyboard, and
+two of her routine habits turn out to be things this package cannot do.
+
+---
+
+## Verified gaps
+
+### P1 — `find_clusters` cannot do what she does every day  ✅ DONE
+
+> *"I typically run 3 resolutions at the same time and compare them before
+> deciding which one to use for downstream analysis."* (comment 4)
+
+This is not a preference, it is the standard Seurat idiom, and `FindClusters`
+supports it directly. Truecell does not.
+
+Verified against Seurat 5.5.1 — `FindClusters(obj, resolution = c(0.4, 0.8, 1.2))`:
+
+```
+COLUMNS: "RNA_snn_res.0.4" "RNA_snn_res.0.8" "RNA_snn_res.1.2"
+Idents            == RNA_snn_res.1.2   (the LAST resolution)
+seurat_clusters   == RNA_snn_res.1.2   (the LAST resolution)
+```
+
+Truecell's `find_clusters` (`truecell/clustering.py`) has **three** gaps against
+this, in increasing order of severity:
+
+| # | Gap | Consequence |
+|---|---|---|
+| a | `resolution: float` — scalar only | The three-resolution idiom cannot be expressed; the user writes a loop and hand-rolls the column names |
+| b | No `cluster_name` parameter | Seurat's `cluster.name` override is unavailable |
+| c | **Never writes a `{graph}_res.{r}` column at all** | Even at one resolution. A ported script that reads `obj[["RNA_snn_res.0.5"]]` — which is what every Seurat script does — **fails** |
+
+(c) is the real defect and it is independent of the review: it is a plain
+API-fidelity break that exists today at the default settings, and `grep` finds no
+`_res.` anywhere in `clustering.py`. Only `seurat_clusters` is written.
+
+**Fix.** Accept `float | Sequence[float]`; loop the clustering call; write one
+`{graph_name}_res.{r}` column per resolution; set `seurat_clusters` **and**
+`idents` from the **last** resolution in the sequence. Keep the scalar path
+byte-identical to today's behaviour for `seurat_clusters` so nothing downstream
+moves — the new column is additive.
+
+Two details worth pinning from R rather than guessing, since this is exactly the
+class of convention the project has been bitten by before:
+
+- **Number formatting in the column name.** `0.4` → `res.0.4`, but what does
+  `1.0` render as, or `0.50`? R's `paste0` on a numeric drops trailing zeros;
+  Python's `str(1.0)` gives `"1.0"`. Pin it against R for a spread of values
+  including integers, trailing zeros and more than one decimal place.
+- **Seed behaviour across the sequence.** Does Seurat re-seed per resolution or
+  let the RNG run on? This determines whether resolution *k*'s partition depends
+  on how many resolutions preceded it. Test it; do not assume.
+
+### P2 — `average_expression` does not exist
+
+Seurat ships **two** group-summary functions and Truecell has only one:
+
+| Seurat | Truecell | Semantics (verified) |
+|---|---|---|
+| `AggregateExpression` | `aggregate_expression` ✓ | Sum of raw counts per group |
+| `AverageExpression` | **missing** | `rowMeans(expm1(data))` per group |
+
+`AverageExpression` is *not* a count mean, and the difference is not subtle —
+on a 30 × 12 test object gene 1 gave **332.84** from `AverageExpression` against
+a count mean of **3.17**. It back-transforms the log1p-normalised `data` layer
+through `expm1`, then means. Confirmed by elimination:
+
+```
+AverageExpression : 332.8377 260.9408 276.3951 196.5893
+mean(expm1(data)) : 332.8377 260.9408 276.3951 196.5893   <- match
+expm1(mean(data)) : 257.1996 113.7119 211.9232 169.9232
+```
+
+**This is cheap to implement correctly**, because the hard part already exists.
+`markers.py::_row_expm1_sum` (added in #92) computes row-wise `sum(expm1(m))`
+while preserving sparsity — `expm1(0) == 0`, so the transform touches stored
+values only. `average_expression` is that helper divided by the group size.
+Reuse it rather than writing a second copy; a divergence between the fold-change
+path and the average-expression path would be invisible.
+
+Scope check before building: `AverageExpression` also takes `group.by`, `assays`,
+`features`, `layer`, `return.seurat`, and its behaviour on the `counts` vs `data`
+layer differs. Pin each against R.
+
+---
+
+## Validation gaps
+
+### T1 — `p_val_adj` is never compared. Anywhere.  ⬅ she is exactly right
+
+> *"maybe we should show whether identical adj p-values occur (sometimes, people
+> base their manual annotation on adj p-values)"* (comment 7)
+
+`grep` for `p_val_adj|padj|adjust` across `tutorials/pbmc3k_de_tutorial.py`
+returns **nothing**. The DE evaluation — the one the reviewer called the best
+section of the paper, carrying the headline "seven of eight tests reproduce the
+top 50 exactly" — compares raw `p_val` and never touches the adjusted column.
+
+That column is what a biologist actually reads. It is in every marker table the
+package emits, and no test or tutorial has ever checked it against R.
+
+**Fix.** Extend `compare()` in the DE tutorial with, per test:
+- fraction of shared genes whose `p_val_adj` is bit-identical
+- fraction agreeing to 1 / 3 / 6 significant figures
+- **agreement on the decision at 0.05 and 0.01** — the one that determines what
+  gets annotated
+- count of genes where the two disagree on significance, listed rather than
+  summarised
+
+**Expect one honest complication.** Both tools Bonferroni-correct over the gene
+universe, so identical adjusted p needs identical raw p *and* identical *n*.
+Where the universes differ the adjusted values differ **for a reason that is not
+a defect** — report the cause, not just a lower number.
+
+**Reuse, don't rewrite:** `pbmc3k_de_tutorial.py:243–256` already handles R
+writing `NaN` for un-runnable tests and `0` for underflow (168 genes on PBMC 3k),
+and already records that naively including the underflow zeros made a
+perfectly-agreeing Wilcoxon score 0/50. That logic applies unchanged here.
+
+### T2 — logFC is compared by max-abs-diff, never by rank
+
+The tutorial computes `log2fc_max_abs_diff` (a worst-case bound) and Spearman on
+raw p, but no rank correlation on `avg_log2FC`. Comments 3 and 11.1.
+
+Max-abs-diff and rank correlation fail differently: a uniform scale error leaves
+ranks perfect and blows up the max, while a handful of swapped mid-table genes
+leaves the max tiny and moves the ranks. Reporting both is strictly more
+informative than either, and the second is what a reader ranking markers cares
+about.
+
+**Fix.** Add Spearman ρ and Kendall τ on `avg_log2FC`, plus top-*k* overlap by
+logFC at k = 10/25/50 alongside the existing top-50-by-p.
+
+### T3 — pseudobulk has no R-verified tutorial
+
+`AggregateExpression` appears in **zero** R verify scripts. `aggregate_expression`
+has nine tests in `tests/test_pseudobulk_conserved.py` and every one of them
+checks Python against Python — `agg["d1"] == dense[:, ::2].sum(axis=1)`.
+
+This is the CLR risk profile exactly: a kernel that is formulaically correct,
+verified against a Python-side re-derivation of its own formula, and therefore
+unable to detect a convention mismatch. That is the defect this project's whole
+validation strategy was designed around after §defect.
+
+I did spot-check the convention against R and **the sum-of-counts default
+matches**, so this is a coverage gap rather than a known defect. But `group.by`
+with multiple columns, the `layer` argument, `return.seurat`, and the interaction
+with multiple assays are all unexercised against the reference.
+
+**Fix.** A paired pseudobulk tutorial (#19), ifnb CTRL-vs-STIM per cell type,
+with declared anchors: the aggregated matrices agree to floating point, then the
+DESeq2 result agrees on logFC, adjusted p and the significant-gene set.
+
+⚠️ **State the caveat in the tutorial itself:** ifnb has no true biological
+replicates. Pseudo-replicates split from one sample give a result that is
+*comparable between implementations* but is **not** valid biological inference.
+The tutorial measures implementation concordance on a shared computation. Anyone
+who knows pseudobulk will check this, and getting it wrong costs more than the
+tutorial gains.
+
+### T4 — `add_module_score` is R-verified only through cell-cycle
+
+> *"I breathe and eat gene module scores in my analyses."* (comment 11.3)
+
+`AddModuleScore` appears in exactly one R script, `thp1_cellcycle_verify.R`, via
+`cell_cycle_scoring` on the Tirosh S/G2M sets. That path is well measured
+(Pearson 0.9982, 96.6% phase concordance on 20,729 cells).
+
+But it is one gene set, at default `nbin=24` / `ctrl=100`, through a wrapper.
+Direct `add_module_score` on an arbitrary program — the reviewer's actual use —
+is unverified against R, as are `pool`, `search`, and any non-default binning.
+
+**Fix, two parts.**
+1. **Free:** the cell-cycle vignette should say that it *is* a module-score
+   result. A reader looking for `AddModuleScore` fidelity currently has no way to
+   find the 0.998 that already answers them.
+2. Extend the cell-cycle tutorial, or add a small paired one, scoring 2–3
+   arbitrary programs (a T-cell activation signature, an interferon-response set
+   on ifnb, a myeloid program) at non-default `nbin`/`ctrl`. Report per-cell
+   Pearson/Spearman **and** threshold-call concordance — the derived call is what
+   gets used.
+
+   Control for the RNG honestly: `AddModuleScore` samples control genes from
+   expression-matched bins and NumPy's RNG is not R's, so exact agreement is not
+   available. Report correlation at default `ctrl` and at a raised `ctrl`; if the
+   residual shrinks, it is sampling noise, and if it does not, that is a finding.
+
+### T5 — no resolution-stability tutorial
+
+Follows P1. Once `find_clusters` takes a sequence, the guided-clustering tutorial
+should show the idiom and compare against R at each resolution, so the fidelity
+claim covers the parameter range users actually scan rather than one point in it.
+
+### T6 — UMAP fidelity framing lives in one vignette
+
+> *"UMAP is not mathematically unique, so comparing coordinates may not be so
+> relevant… emphasize that UMAP was evaluated as implementation fidelity only."*
+> (comment 6)
+
+`tutorials/pbmc3k_tutorial.md:597–608` has a correct and well-written note saying
+the layout difference is expected because `uwot` and `umap-learn` differ in
+initialisation and optimisation. Other tutorials that produce UMAPs do not carry
+it, and no tutorial states the *positive* form: UMAP is validated as a functional
+correspondence, and is deliberately excluded from the numeric agreement metrics
+because the embedding is not identified up to anything stronger than topology.
+
+**Fix.** Promote that note to a shared statement in `tutorials/README.md` and
+`docs/fidelity.md`, and cross-reference from each vignette producing a UMAP. Cheap
+and it converts an absence into a stated design decision.
+
+---
+
+## Not package gaps (recorded so they are not re-investigated)
+
+| Review item | Why it needs no code |
+|---|---|
+| 2 — which HVGs differ | `meta_features` already exposes Seurat's `HVFInfo()` columns (`mean`, `variance.expected`, `variance.standardized`, and the `mvp.*` set under the dispersion method). Inspecting the selection boundary needs no new API |
+| 5 — PCA eigenvector sign/order | Already handled correctly where it matters: `tutorials/pbmc3k_tutorial.py:574` matches components on `abs(corrcoef)` with Hungarian assignment, i.e. sign- and order-invariant. Seurat has no such helper either, so this is a docs point, not an API one |
+| 11.2 — pathway enrichment | Seurat has no enrichment function; nothing to port. Belongs in a tutorial as a downstream consumer of `find_all_markers` output, if anywhere |
+| 8 — software engineering | No action |
+
+---
+
+## Sequence
+
+| # | Work | Depends on | Size |
+|---|---|---|---|
+| 1 | ~~**P1** — multi-resolution `find_clusters` + `{graph}_res.{r}` column + `cluster_name`~~ **done** | — | Medium |
+| 2 | **T1 + T2** — adjusted-p and logFC-rank comparison in the DE tutorial | Nothing | Small |
+| 3 | **P2** — `average_expression`, reusing `_row_expm1_sum` | Pin R semantics (done for the base case) | Small |
+| 4 | **T6** — UMAP fidelity statement promoted to shared docs | Nothing | Small |
+| 5 | **T4.1** — label the cell-cycle result as a module-score result | Nothing | Trivial |
+| 6 | **T5** — resolution-stability coverage in the guided tutorial | 1 | Small |
+| 7 | **T4.2** — arbitrary-program module-score verification | Nothing | Medium |
+| 8 | **T3** — paired pseudobulk tutorial (#19) | 3 (if it uses `average_expression`) | Medium |
+
+Items 1–5 are independent of each other and of any environment work.
+
+**Cross-cutting rule, from this project's own history:** every new comparison
+gets an anchor and a declared tolerance, and every new branch gets mutation-tested
+rather than trusted because the suite is green. Marker code has now hidden a real
+defect behind a green suite twice, and T1 exists because a validated-looking DE
+comparison silently omitted a whole column.

--- a/REVIEW_PLAN.md
+++ b/REVIEW_PLAN.md
@@ -169,7 +169,7 @@ The tutorial measures implementation concordance on a shared computation. Anyone
 who knows pseudobulk will check this, and getting it wrong costs more than the
 tutorial gains.
 
-### T4 — `add_module_score` is R-verified only through cell-cycle
+### T4 — `add_module_score` is R-verified only through cell-cycle  ◐ PART 1 WAS ALREADY DONE
 
 > *"I breathe and eat gene module scores in my analyses."* (comment 11.3)
 
@@ -202,7 +202,7 @@ Follows P1. Once `find_clusters` takes a sequence, the guided-clustering tutoria
 should show the idiom and compare against R at each resolution, so the fidelity
 claim covers the parameter range users actually scan rather than one point in it.
 
-### T6 — UMAP fidelity framing lives in one vignette
+### T6 — UMAP fidelity framing lives in one vignette  ✅ DONE
 
 > *"UMAP is not mathematically unique, so comparing coordinates may not be so
 > relevant… emphasize that UMAP was evaluated as implementation fidelity only."*
@@ -239,8 +239,8 @@ and it converts an absence into a stated design decision.
 | 1 | ~~**P1** — multi-resolution `find_clusters` + `{graph}_res.{r}` column + `cluster_name`~~ **done** | — | Medium |
 | 2 | ~~**T1 + T2** — adjusted-p and logFC-rank comparison in the DE tutorial~~ **done** | — | Small |
 | 3 | ~~**P2** — `average_expression`, reusing `_row_expm1_sum`~~ **done** | — | Small |
-| 4 | **T6** — UMAP fidelity statement promoted to shared docs | Nothing | Small |
-| 5 | **T4.1** — label the cell-cycle result as a module-score result | Nothing | Trivial |
+| 4 | ~~**T6** — UMAP fidelity statement promoted to shared docs~~ **done** | — | Small |
+| 5 | ~~**T4.1** — label the cell-cycle result as a module-score result~~ **already true in the package** | — | — |
 | 6 | **T5** — resolution-stability coverage in the guided tutorial | 1 | Small |
 | 7 | **T4.2** — arbitrary-program module-score verification | Nothing | Medium |
 | 8 | **T3** — paired pseudobulk tutorial (#19) | 3 (if it uses `average_expression`) | Medium |

--- a/REVIEW_PLAN.md
+++ b/REVIEW_PLAN.md
@@ -97,7 +97,7 @@ layer differs. Pin each against R.
 
 ## Validation gaps
 
-### T1 — `p_val_adj` is never compared. Anywhere.  ⬅ she is exactly right
+### T1 — `p_val_adj` is never compared. Anywhere.  ✅ DONE (with T2)
 
 > *"maybe we should show whether identical adj p-values occur (sometimes, people
 > base their manual annotation on adj p-values)"* (comment 7)
@@ -128,7 +128,7 @@ writing `NaN` for un-runnable tests and `0` for underflow (168 genes on PBMC 3k)
 and already records that naively including the underflow zeros made a
 perfectly-agreeing Wilcoxon score 0/50. That logic applies unchanged here.
 
-### T2 — logFC is compared by max-abs-diff, never by rank
+### T2 — logFC is compared by max-abs-diff, never by rank  ✅ DONE
 
 The tutorial computes `log2fc_max_abs_diff` (a worst-case bound) and Spearman on
 raw p, but no rank correlation on `avg_log2FC`. Comments 3 and 11.1.
@@ -237,7 +237,7 @@ and it converts an absence into a stated design decision.
 | # | Work | Depends on | Size |
 |---|---|---|---|
 | 1 | ~~**P1** — multi-resolution `find_clusters` + `{graph}_res.{r}` column + `cluster_name`~~ **done** | — | Medium |
-| 2 | **T1 + T2** — adjusted-p and logFC-rank comparison in the DE tutorial | Nothing | Small |
+| 2 | ~~**T1 + T2** — adjusted-p and logFC-rank comparison in the DE tutorial~~ **done** | — | Small |
 | 3 | **P2** — `average_expression`, reusing `_row_expm1_sum` | Pin R semantics (done for the base case) | Small |
 | 4 | **T6** — UMAP fidelity statement promoted to shared docs | Nothing | Small |
 | 5 | **T4.1** — label the cell-cycle result as a module-score result | Nothing | Trivial |
@@ -252,3 +252,40 @@ gets an anchor and a declared tolerance, and every new branch gets mutation-test
 rather than trusted because the suite is green. Marker code has now hidden a real
 defect behind a green suite twice, and T1 exists because a validated-looking DE
 comparison silently omitted a whole column.
+
+---
+
+## Found while doing the work: the R↔Python CSV handoff was lossy on both sides
+
+Not in the review, and it affects **every** tutorial that compares numbers
+through a CSV, not just the DE one. Fixed in the DE tutorial; the others are
+untouched and should be checked.
+
+| Direction | Default behaviour | Round-trips float64? |
+|---|---|---|
+| R `write.csv` | 15 significant digits | **No** |
+| R `sprintf("%.17g")` | not correctly rounded — emits digits denoting a *different* double | **No** |
+| R `sprintf("%a")` (C99 hex) | transcribes the IEEE-754 bits | **Yes** |
+| pandas `to_csv` | shortest round-trippable repr | Yes |
+| pandas `read_csv` (default) | misparses ~⅓ of random doubles by an ULP | **No** |
+| pandas `read_csv(float_precision="round_trip")` | correctly rounded | **Yes** |
+
+The R formatter result is the surprising one: raising the digit count does not
+help, because R's `sprintf` is not correctly rounded at high precision.
+`0.1234567890123456789` (shortest exact form `…568`) comes back as `…571`, a
+different double, and Python parses R's own string to that different double too.
+
+**Consequence.** Any claim of the form "these agree exactly" made by reading two
+CSVs is, before this fix, partly a measurement of the two languages' text
+formatters. Tolerance-based claims are unaffected as long as the tolerance is
+well above ~1e-15 relative, which most of the declared bands are.
+
+**How to apply.** Read every CSV with `float_precision="round_trip"`, and where
+bit-identity is actually the question, have R write a `%a` side table.
+
+**Scope of the remaining exposure:** `grep -rn "read_csv" tutorials/*.py | grep -v
+float_precision` finds **42 call sites across 17 files**. The tutorials making
+the strongest exactness claims are the ones to check first — the object model
+("91 of 91 anchors, no tolerance"), the Visium container ("24 of 24, coordinates
+to max|Δx| = 0"), out-of-core ("bit-identical" on-disk vs in-memory) and spatial
+statistics (Moran's I to 1.6e-14). Filed as a background task; not started.

--- a/REVIEW_PLAN.md
+++ b/REVIEW_PLAN.md
@@ -62,7 +62,7 @@ class of convention the project has been bitten by before:
   let the RNG run on? This determines whether resolution *k*'s partition depends
   on how many resolutions preceded it. Test it; do not assume.
 
-### P2 — `average_expression` does not exist
+### P2 — `average_expression` does not exist  ✅ DONE
 
 Seurat ships **two** group-summary functions and Truecell has only one:
 
@@ -238,7 +238,7 @@ and it converts an absence into a stated design decision.
 |---|---|---|---|
 | 1 | ~~**P1** — multi-resolution `find_clusters` + `{graph}_res.{r}` column + `cluster_name`~~ **done** | — | Medium |
 | 2 | ~~**T1 + T2** — adjusted-p and logFC-rank comparison in the DE tutorial~~ **done** | — | Small |
-| 3 | **P2** — `average_expression`, reusing `_row_expm1_sum` | Pin R semantics (done for the base case) | Small |
+| 3 | ~~**P2** — `average_expression`, reusing `_row_expm1_sum`~~ **done** | — | Small |
 | 4 | **T6** — UMAP fidelity statement promoted to shared docs | Nothing | Small |
 | 5 | **T4.1** — label the cell-cycle result as a module-score result | Nothing | Trivial |
 | 6 | **T5** — resolution-stability coverage in the guided tutorial | 1 | Small |
@@ -252,6 +252,30 @@ gets an anchor and a declared tolerance, and every new branch gets mutation-test
 rather than trusted because the suite is green. Marker code has now hidden a real
 defect behind a green suite twice, and T1 exists because a validated-looking DE
 comparison silently omitted a whole column.
+
+---
+
+## Found while doing the work: `_get_expression_matrix` had two defects  ✅ FIXED
+
+Not in the review. Surfaced while building `average_expression`, which needed to
+read the `scale.data` layer.
+
+1. **`layer="scale_data"` silently returned the `data` layer.** The Assay5 layer
+   dict is keyed `scale.data`; only that spelling was matched, so the underscore
+   form missed and fell through to the `data` fallback. Right shape, no warning,
+   normalized values where scaled ones were asked for.
+2. **`layer="scale.data"` returned a 10-row matrix labelled with 30 names.**
+   `scale.data` holds only the scaled subset, so every row read as a different
+   gene. Identical in kind to the defect fixed in `reduction.py` under #66 — the
+   same one had survived in this function.
+
+Reachable from `find_markers(layer=...)`, `aggregate_expression` and
+`average_expression`. **`reduction.py` and therefore PCA were never affected** —
+it has its own accessor, which is where #66 was fixed.
+
+The full suite passed both before and after the fix, which is the point: nothing
+depended on the broken behaviour, and nothing tested the correct behaviour
+either. Nine mutants now cover it.
 
 ---
 

--- a/REVIEW_PLAN.md
+++ b/REVIEW_PLAN.md
@@ -142,7 +142,7 @@ about.
 **Fix.** Add Spearman ρ and Kendall τ on `avg_log2FC`, plus top-*k* overlap by
 logFC at k = 10/25/50 alongside the existing top-50-by-p.
 
-### T3 — pseudobulk has no R-verified tutorial
+### T3 — pseudobulk has no R-verified tutorial  ◐ RISK CLOSED BY TESTS
 
 `AggregateExpression` appears in **zero** R verify scripts. `aggregate_expression`
 has nine tests in `tests/test_pseudobulk_conserved.py` and every one of them
@@ -153,10 +153,19 @@ verified against a Python-side re-derivation of its own formula, and therefore
 unable to detect a convention mismatch. That is the defect this project's whole
 validation strategy was designed around after §defect.
 
-I did spot-check the convention against R and **the sum-of-counts default
-matches**, so this is a coverage gap rather than a known defect. But `group.by`
-with multiple columns, the `layer` argument, `return.seurat`, and the interaction
-with multiple assays are all unexercised against the reference.
+**It was a defect, not just a coverage gap.** Pinning against R found that
+`return_object=True` left the raw sums in the `data` layer where Seurat writes
+`log1p(sums / colSums × 10000)` — 14 against Seurat's 6.98. Fixed, with
+`normalization_method` / `scale_factor` matching Seurat's arguments. The
+sum-of-counts default and multi-column `group_by` were already right.
+
+Also learned: **Seurat's `AggregateExpression` has no `layer` argument** and
+always sums `counts`. Truecell's is a superset with a matching default — not a
+fidelity break, now documented as deliberate.
+
+`tests/test_pseudobulk_vs_r.py` pins six behaviours against R. The full tutorial
+below is still worth building for the DE half, but the *silent-defect* risk is
+closed.
 
 **Fix.** A paired pseudobulk tutorial (#19), ifnb CTRL-vs-STIM per cell type,
 with declared anchors: the aggregated matrices agree to floating point, then the

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -28,7 +28,7 @@ the reason this reference exists rather than a signature dump.
 | `NormalizeData`, `FindVariableFeatures`, `ScaleData`, `SCTransform` | `normalize_data`, `find_variable_features`, `scale_data`, `sctransform` | [Preprocessing](preprocessing.md) |
 | `RunPCA`, `RunUMAP`, `RunTSNE`, `JackStraw` | `run_pca`, `run_umap`, `run_tsne`, `jack_straw` | [Dimensional reduction](dimreduc.md) |
 | `FindNeighbors`, `FindClusters`, `FindMultiModalNeighbors` | `find_neighbors`, `find_clusters`, `find_multi_modal_neighbors` | [Graphs and clustering](clustering.md) |
-| `FindMarkers`, `FindAllMarkers`, `AggregateExpression` | `find_markers`, `find_all_markers`, `aggregate_expression` | [Differential expression](markers.md) |
+| `FindMarkers`, `FindAllMarkers`, `AggregateExpression`, `AverageExpression` | `find_markers`, `find_all_markers`, `aggregate_expression`, `average_expression` | [Differential expression](markers.md) |
 | `IntegrateLayers`, `FindIntegrationAnchors`, `MapQuery` | `integrate_layers`, `find_integration_anchors`, `map_query` | [Integration and mapping](integration.md) |
 | `AddModuleScore`, `CellCycleScoring` | `add_module_score`, `cell_cycle_scoring` | [Signature scoring](scoring.md) |
 | `HTODemux`, `MULTIseqDemux`, `RunMixscape` | `hto_demux`, `multiseq_demux`, `run_mixscape` | [Demultiplexing and screens](demux.md) |

--- a/docs/api/markers.md
+++ b/docs/api/markers.md
@@ -24,6 +24,13 @@ Two numbers to know before reading a result table:
 
 ::: truecell.markers.find_conserved_markers
 
-## Pseudobulk
+## Group summaries
+
+`AggregateExpression` **sums raw counts** and is what pseudobulk differential
+expression wants. `AverageExpression` **means the back-transformed values** and
+is what a per-group expression summary wants. They are different functions, not
+two scalings of one — see each docstring.
 
 ::: truecell.aggregate.aggregate_expression
+
+::: truecell.aggregate.average_expression

--- a/docs/fidelity.md
+++ b/docs/fidelity.md
@@ -105,6 +105,33 @@ search is a difference in the *reference*, not in either implementation. The
 verify scripts pass `nn.method = "rann"`; skipping that once cost one script a
 false negative of 182 SNN edges.
 
+## What is deliberately not compared, and why { #not-compared }
+
+**UMAP coordinates.** `run_umap` is validated as an *implementation
+correspondence* — same algorithm, same parameters, same input embedding — and its
+output coordinates are deliberately excluded from every agreement metric in this
+project. That is a statement about UMAP, not about the port.
+
+A UMAP embedding is not identified up to anything stronger than its topology. The
+optimisation is stochastic and non-convex, so the layout is fixed only up to
+rotation, reflection and the particular local optimum a run lands in; R Seurat
+drives [`uwot`](https://github.com/jlmelville/uwot) and truecell drives
+[`umap-learn`](https://umap-learn.readthedocs.io), and the two differ in
+initialisation strategy, neighbour-graph construction and optimisation detail.
+Two runs of the *same* library on the same data with different seeds already
+disagree on coordinates. A coordinate-level agreement number would therefore
+measure the seed and the library, and a *high* one would be the surprising
+result.
+
+What carries the weight instead is everything either side of it: the neighbour
+graph the embedding is computed from is compared directly, and the cluster
+assignments plotted on it are scored by ARI. If those agree, the picture agrees
+in the only sense a UMAP picture means anything — which clusters exist and which
+cells are in them, not where on the page they landed.
+
+The same reasoning applies to any figure-level comparison: plots are checked for
+*what they encode*, never for pixel agreement.
+
 ## Numbers that move are declared as bands { #bands }
 
 A comparison that legitimately varies used to carry a prose caveat — "expect

--- a/tests/test_average_expression.py
+++ b/tests/test_average_expression.py
@@ -1,0 +1,178 @@
+"""``average_expression`` against Seurat's ``AverageExpression``.
+
+The two group-summary functions are easy to conflate and behave differently:
+``AggregateExpression`` sums raw counts, ``AverageExpression`` averages the
+**back-transformed** ``data`` layer. On the object below the first gene reads
+332.84 under one and 3.17 under the other, so a test that only checked "some
+per-group summary came back" would pass on either.
+
+Expected values are transcribed from an R Seurat 5.5.1 session rather than
+recomputed here, because a Python-side re-derivation of the formula cannot catch
+having ported the wrong formula — which is the failure mode this whole file is
+about.
+"""
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from truecell import (aggregate_expression, average_expression,
+                      create_truecell_object, find_variable_features,
+                      normalize_data, scale_data)
+from truecell.markers import _get_expression_matrix
+
+@pytest.fixture
+def small(small_counts, feature_names, cell_names):
+    o = create_truecell_object(counts=small_counts, feature_names=feature_names,
+                               cell_names=cell_names)
+    normalize_data(o)
+    o.meta_data["grp"] = ["A"] * 10 + ["B"] * 10
+    return o
+
+
+# ---------------------------------------------------------------------------
+# The formula, against R
+# ---------------------------------------------------------------------------
+
+def test_the_data_layer_is_averaged_after_back_transforming(small):
+    """``mean(expm1(x))`` — not ``mean(x)``, and not ``expm1(mean(x))``.
+
+    All three are one-liners over the same layer and only one is Seurat's.
+    """
+    from truecell.markers import _get_expression_matrix
+    data, _ = _get_expression_matrix(small.assays["RNA"], "data")
+    dense = np.asarray(data.toarray() if sp.issparse(data) else data)
+    a = dense[:, :10]
+
+    got = average_expression(small, group_by="grp")["A"].to_numpy()
+    np.testing.assert_allclose(got, np.expm1(a).mean(axis=1), rtol=1e-12)
+
+    # The two plausible wrong answers, asserted to be different so that a
+    # regression onto either one fails here rather than silently.
+    assert not np.allclose(got, a.mean(axis=1))
+    assert not np.allclose(got, np.expm1(a.mean(axis=1)))
+
+
+def test_counts_and_scale_data_are_not_back_transformed(small):
+    """The ``expm1`` belongs to ``data`` alone: the other layers are not logged."""
+    counts, _ = _get_expression_matrix(small.assays["RNA"], "counts")
+    dense = np.asarray(counts.toarray() if sp.issparse(counts) else counts)
+    got = average_expression(small, group_by="grp", layer="counts")["A"].to_numpy()
+    np.testing.assert_allclose(got, dense[:, :10].mean(axis=1), rtol=1e-12)
+
+
+def test_average_is_not_aggregate(small):
+    """Guards the two functions having been wired to the same implementation."""
+    avg = average_expression(small, group_by="grp", layer="counts")
+    agg = aggregate_expression(small, group_by="grp", layer="counts")
+    # Same shape and labels, deliberately different numbers.
+    assert list(avg.columns) == list(agg.columns)
+    np.testing.assert_allclose(agg["A"].to_numpy() / 10.0, avg["A"].to_numpy(),
+                               rtol=1e-12)
+    assert not np.allclose(agg["A"].to_numpy(), avg["A"].to_numpy())
+
+
+def test_groups_are_divided_by_their_own_size_not_the_mean_size(small):
+    """Unequal groups: 15 cells against 5, so a shared divisor would show."""
+    small.meta_data["uneven"] = ["A"] * 15 + ["B"] * 5
+    data, _ = _get_expression_matrix(small.assays["RNA"], "data")
+    dense = np.asarray(data.toarray() if sp.issparse(data) else data)
+    got = average_expression(small, group_by="uneven")
+    np.testing.assert_allclose(got["A"].to_numpy(),
+                               np.expm1(dense[:, :15]).mean(axis=1), rtol=1e-12)
+    np.testing.assert_allclose(got["B"].to_numpy(),
+                               np.expm1(dense[:, 15:]).mean(axis=1), rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Shape, labels and options
+# ---------------------------------------------------------------------------
+
+def test_several_group_by_columns_join_with_an_underscore(small):
+    small.meta_data["cond"] = ["x", "y"] * 10
+    got = average_expression(small, group_by=["grp", "cond"])
+    assert list(got.columns) == ["A_x", "A_y", "B_x", "B_y"]
+
+
+def test_features_restricts_the_rows(small, feature_names):
+    got = average_expression(small, group_by="grp",
+                             features=[feature_names[0], feature_names[4]])
+    assert list(got.index) == [feature_names[0], feature_names[4]]
+
+
+def test_ident_is_the_default_grouping(small):
+    small.idents = ["A"] * 10 + ["B"] * 10
+    np.testing.assert_allclose(
+        average_expression(small).to_numpy(),
+        average_expression(small, group_by="grp").to_numpy())
+
+
+def test_return_object_puts_the_average_in_counts_and_log1p_in_data(small):
+    """Seurat's `return.seurat = TRUE` does not re-normalize the averages."""
+    frame = average_expression(small, group_by="grp")
+    obj = average_expression(small, group_by="grp", return_object=True)
+    assert list(obj.assays["RNA"].cells()) == ["A", "B"]
+
+    counts, feats = _get_expression_matrix(obj.assays["RNA"], "counts")
+    counts = np.asarray(counts.toarray() if sp.issparse(counts) else counts)
+    np.testing.assert_allclose(counts, frame.loc[feats].to_numpy(), rtol=1e-12)
+
+    data, feats = _get_expression_matrix(obj.assays["RNA"], "data")
+    data = np.asarray(data.toarray() if sp.issparse(data) else data)
+    np.testing.assert_allclose(data, np.log1p(frame.loc[feats].to_numpy()),
+                               rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# The layer-resolution defect this work exposed
+# ---------------------------------------------------------------------------
+
+def test_asking_for_scale_data_does_not_return_the_data_layer(small,
+                                                              feature_names):
+    """`_get_expression_matrix` matched only the dotted spelling of the key.
+
+    The Assay5 layer dict is keyed ``scale.data``; the Python argument is
+    ``scale_data``. The underscore form missed the dict and fell through to the
+    ``data`` fallback — same shape, no warning, wrong numbers. Reachable from
+    ``find_markers(layer=...)`` and both aggregation functions.
+    """
+    find_variable_features(small, nfeatures=10)
+    scale_data(small)
+    assay = small.assays["RNA"]
+
+    scaled, _ = _get_expression_matrix(assay, "scale_data")
+    plain, _ = _get_expression_matrix(assay, "data")
+    scaled = np.asarray(scaled.toarray() if sp.issparse(scaled) else scaled)
+    plain = np.asarray(plain.toarray() if sp.issparse(plain) else plain)
+    assert scaled.shape != plain.shape or not np.array_equal(scaled, plain)
+
+
+@pytest.mark.parametrize("spelling", ["scale_data", "scale.data"])
+def test_both_spellings_reach_the_same_layer(small, spelling):
+    find_variable_features(small, nfeatures=10)
+    scale_data(small)
+    mat, names = _get_expression_matrix(small.assays["RNA"], spelling)
+    mat = np.asarray(mat.toarray() if sp.issparse(mat) else mat)
+    assert mat.shape[0] == len(names) == 10
+
+
+@pytest.mark.parametrize("layer", ["scale_data", "scale.data", "data", "counts"])
+def test_every_layer_is_labelled_with_its_own_features(small, layer):
+    """A matrix and a name list of different lengths mislabels every row.
+
+    ``scale.data`` holds only the scaled subset, so returning the assay's full
+    feature list beside it — which is what this did — hands the caller row labels
+    belonging to a different matrix. Same defect as #66 in ``reduction.py``.
+    """
+    find_variable_features(small, nfeatures=10)
+    scale_data(small)
+    mat, names = _get_expression_matrix(small.assays["RNA"], layer)
+    mat = np.asarray(mat.toarray() if sp.issparse(mat) else mat)
+    assert mat.shape[0] == len(names)
+
+
+def test_average_expression_on_scale_data_uses_the_scaled_subset(small):
+    find_variable_features(small, nfeatures=10)
+    scale_data(small)
+    got = average_expression(small, group_by="grp", layer="scale_data")
+    assert got.shape == (10, 2)
+    assert set(got.index) == set(small.assays["RNA"].variable_features)

--- a/tests/test_find_clusters_resolutions.py
+++ b/tests/test_find_clusters_resolutions.py
@@ -1,0 +1,211 @@
+"""``find_clusters`` at one resolution and at several, against Seurat's conventions.
+
+Seurat's ``FindClusters`` writes each resolution to its own metadata column named
+``{graph}_res.{resolution}`` and leaves the object sitting on the **last**
+resolution given. Truecell wrote only ``seurat_clusters`` and accepted only a
+scalar, so a ported script reading ``obj[["RNA_snn_res.0.5"]]`` raised
+``KeyError`` — at the default settings, with nothing in the suite noticing.
+
+Every expected value here was pinned against R Seurat 5.5.1 rather than derived
+from the Python side, because what is being tested is a naming and ordering
+*convention*, which is exactly the class of thing a Python-side re-derivation
+cannot check. See ``REVIEW_PLAN.md``.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from truecell import (
+    create_truecell_object,
+    find_clusters,
+    find_neighbors,
+    find_variable_features,
+    normalize_data,
+    run_pca,
+    scale_data,
+)
+from truecell.clustering import _res_label
+
+
+@pytest.fixture
+def clustered(small_counts, feature_names, cell_names):
+    """A small object carried as far as the SNN graph."""
+    import scipy.sparse as sp
+    rng = np.random.default_rng(1)
+    counts = sp.csr_matrix(rng.poisson(2.0, size=(200, 300)).astype(float))
+    obj = create_truecell_object(
+        counts=counts,
+        feature_names=[f"gene_{i}" for i in range(200)],
+        cell_names=[f"cell_{i}" for i in range(300)],
+    )
+    normalize_data(obj)
+    find_variable_features(obj)
+    scale_data(obj)
+    run_pca(obj, n_pcs=10)
+    find_neighbors(obj, dims=list(range(1, 6)))
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# The column label is R's number formatting, not Python's
+# ---------------------------------------------------------------------------
+
+# Pinned against R: `as.character(x)` for each value, R 4.x at the default
+# `scipen = 0`. The pair that matters most in practice is 1.0 -> "1": Python's
+# own `str(1.0)` gives "1.0", which would name the column `RNA_snn_res.1.0` and
+# leave a ported script reading `RNA_snn_res.1` with a KeyError.
+@pytest.mark.parametrize("value,expected", [
+    (0.4, "0.4"),
+    (1.0, "1"),
+    (0.50, "0.5"),
+    (1.25, "1.25"),
+    (2, "2"),
+    (0.125, "0.125"),
+    (1e-2, "0.01"),
+    (10, "10"),
+    (0.8, "0.8"),
+    (1234.5, "1234.5"),
+    (123456, "123456"),
+    (1234567, "1234567"),
+    (0.1, "0.1"),
+    (0.02, "0.02"),
+    # R switches to scientific when it is strictly shorter, ties going to fixed:
+    # "0.001" and "1e-03" are both 5 characters, so 0.001 stays fixed, while
+    # "0.0001" (6) loses to "1e-04" (5).
+    (0.001, "0.001"),
+    (0.0001, "1e-04"),
+    (0.00012, "0.00012"),
+    (1e-5, "1e-05"),
+    (1e-7, "1e-07"),
+    (1e5, "1e+05"),
+    (1e6, "1e+06"),
+])
+def test_resolution_label_matches_r_as_character(value, expected):
+    assert _res_label(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# The column exists at all — the gap that predates the multi-resolution work
+# ---------------------------------------------------------------------------
+
+def test_a_single_resolution_still_writes_its_own_column(clustered):
+    find_clusters(clustered, resolution=0.5)
+    assert "RNA_snn_res.0.5" in clustered.meta_data.columns
+    assert (clustered.meta_data["RNA_snn_res.0.5"].astype(str)
+            == clustered.meta_data["seurat_clusters"].astype(str)).all()
+
+
+def test_a_whole_number_resolution_drops_its_trailing_zero(clustered):
+    """The regression the label helper exists for, exercised end to end."""
+    find_clusters(clustered, resolution=1.0)
+    assert "RNA_snn_res.1" in clustered.meta_data.columns
+    assert "RNA_snn_res.1.0" not in clustered.meta_data.columns
+
+
+def test_the_column_name_follows_the_graph_it_clustered(clustered):
+    find_clusters(clustered, resolution=0.5, graph_name="RNA_nn")
+    assert "RNA_nn_res.0.5" in clustered.meta_data.columns
+
+
+# ---------------------------------------------------------------------------
+# Several resolutions at once
+# ---------------------------------------------------------------------------
+
+def test_each_resolution_gets_its_own_column(clustered):
+    find_clusters(clustered, resolution=[0.4, 0.8, 1.2])
+    for name in ("RNA_snn_res.0.4", "RNA_snn_res.0.8", "RNA_snn_res.1.2"):
+        assert name in clustered.meta_data.columns
+
+
+def test_the_object_is_left_on_the_last_resolution_given(clustered):
+    """Last as *given*, not largest — Seurat takes the last column of its frame."""
+    find_clusters(clustered, resolution=[1.2, 0.8, 0.4])
+    last = clustered.meta_data["RNA_snn_res.0.4"].astype(str)
+    assert (clustered.meta_data["seurat_clusters"].astype(str) == last).all()
+    assert (pd.Series(clustered.idents).astype(str).values == last.values).all()
+    # ...and specifically not the largest, which is the plausible wrong answer.
+    largest = clustered.meta_data["RNA_snn_res.1.2"].astype(str)
+    if not (largest == last).all():
+        assert not (clustered.meta_data["seurat_clusters"].astype(str)
+                    == largest).all()
+
+
+def test_a_partition_does_not_depend_on_what_preceded_it(clustered, small_counts,
+                                                         feature_names, cell_names):
+    """Verified against Seurat 5.5.1, which reseeds rather than running the stream on.
+
+    If the RNG ran on between resolutions, 0.8's partition would differ between
+    these three calls, and a user comparing resolutions would be comparing
+    partitions that also differ by seed.
+    """
+    find_clusters(clustered, resolution=[0.4, 0.8, 1.2])
+    forward = clustered.meta_data["RNA_snn_res.0.8"].astype(str).values.copy()
+
+    find_clusters(clustered, resolution=[1.2, 0.8, 0.4])
+    reverse = clustered.meta_data["RNA_snn_res.0.8"].astype(str).values.copy()
+
+    find_clusters(clustered, resolution=0.8)
+    alone = clustered.meta_data["RNA_snn_res.0.8"].astype(str).values
+
+    assert (forward == reverse).all()
+    assert (forward == alone).all()
+
+
+def test_resolutions_are_not_all_the_same_partition(clustered):
+    """Guards the loop actually using its own `res` rather than a fixed one.
+
+    Without this, passing the first resolution to every call would satisfy every
+    other test in this file: the columns would all exist and all be consistent.
+    """
+    find_clusters(clustered, resolution=[0.01, 2.0])
+    coarse = clustered.meta_data["RNA_snn_res.0.01"].astype(str)
+    fine = clustered.meta_data["RNA_snn_res.2"].astype(str)
+    assert coarse.nunique() < fine.nunique()
+
+
+# ---------------------------------------------------------------------------
+# cluster_name
+# ---------------------------------------------------------------------------
+
+def test_cluster_name_replaces_the_generated_names(clustered):
+    find_clusters(clustered, resolution=[0.4, 0.8], cluster_name=["lo", "hi"])
+    assert {"lo", "hi"} <= set(clustered.meta_data.columns)
+    assert "RNA_snn_res.0.4" not in clustered.meta_data.columns
+    # Seurat writes seurat_clusters either way.
+    assert "seurat_clusters" in clustered.meta_data.columns
+
+
+def test_a_single_cluster_name_is_accepted_as_a_string(clustered):
+    find_clusters(clustered, resolution=0.5, cluster_name="my_clusters")
+    assert "my_clusters" in clustered.meta_data.columns
+
+
+def test_a_mismatched_cluster_name_count_is_rejected(clustered):
+    with pytest.raises(ValueError, match="one per resolution"):
+        find_clusters(clustered, resolution=[0.4, 0.8], cluster_name=["only_one"])
+
+
+# ---------------------------------------------------------------------------
+# Validation happens before anything is written
+# ---------------------------------------------------------------------------
+
+def test_an_empty_resolution_list_is_rejected(clustered):
+    with pytest.raises(ValueError, match="at least one"):
+        find_clusters(clustered, resolution=[])
+
+
+@pytest.mark.parametrize("algorithm,exc", [(3, NotImplementedError),
+                                           (9, ValueError)])
+def test_a_bad_algorithm_writes_no_columns_at_all(clustered, algorithm, exc):
+    """A rejected `algorithm` leaves the object exactly as it found it.
+
+    Note what this does *not* establish. Moving the check from above the loop to
+    inside it passes this test unchanged — mutation testing confirmed it — because
+    the dispatch is the first statement of the loop body, so the first resolution
+    raises before anything is stored. The eager check is tidiness, not a guard
+    against a partial write, and the comment in ``clustering.py`` says so.
+    """
+    before = set(clustered.meta_data.columns)
+    with pytest.raises(exc):
+        find_clusters(clustered, resolution=[0.4, 0.8], algorithm=algorithm)
+    assert set(clustered.meta_data.columns) == before

--- a/tests/test_pseudobulk_vs_r.py
+++ b/tests/test_pseudobulk_vs_r.py
@@ -1,0 +1,146 @@
+"""``aggregate_expression`` against Seurat's ``AggregateExpression``.
+
+``tests/test_pseudobulk_conserved.py`` already exercises this function, but every
+assertion there checks Python against a Python re-derivation of the same formula
+(``agg["d1"] == dense[:, ::2].sum(axis=1)``). That shape of test cannot detect
+having ported the wrong *convention*, which is exactly how the CLR defect
+survived its own unit test — the kernel was right and the axis was not.
+
+This file pins values transcribed from an R Seurat 5.5.1 session instead. It
+found one defect on the first run: ``return_object=True`` left the raw sums in
+the ``data`` layer, where Seurat normalizes them.
+
+The counts matrix is hardcoded rather than drawn, so neither language's RNG is in
+the loop and the two sides are provably looking at the same numbers.
+"""
+import numpy as np
+import pytest
+import scipy.sparse as sp
+
+from truecell import (aggregate_expression, average_expression,
+                      create_truecell_object, normalize_data)
+from truecell.markers import _get_expression_matrix
+
+# 8 genes x 9 cells, column-major to match R's matrix() fill order.
+COUNTS = np.array(
+    [5, 0, 3, 3, 7, 9, 3, 5,
+     2, 4, 7, 6, 8, 8, 1, 6,
+     7, 7, 8, 1, 5, 9, 8, 9,
+     4, 3, 0, 3, 5, 0, 2, 3,
+     8, 1, 3, 3, 3, 7, 0, 1,
+     9, 9, 0, 4, 7, 3, 2, 7,
+     2, 0, 0, 4, 5, 5, 6, 8,
+     4, 1, 4, 9, 8, 1, 1, 7,
+     9, 9, 3, 6, 7, 2, 0, 3], dtype=float).reshape((8, 9), order="F")
+
+GRP = ["A", "A", "A", "B", "B", "B", "C", "C", "C"]
+COND = ["x", "y", "x", "y", "x", "y", "x", "y", "x"]
+
+# AggregateExpression(o, group.by = "grp")
+R_BY_GRP = np.array([
+    [14, 21, 15], [11, 13, 10], [18, 3, 7], [10, 10, 19],
+    [20, 15, 20], [26, 10, 8], [12, 4, 7], [20, 11, 18]], dtype=float)
+
+# AggregateExpression(o, group.by = c("grp", "cond"))
+R_BY_GRP_COND = np.array([
+    [12, 2, 8, 13, 11, 4], [7, 4, 1, 12, 9, 1], [11, 7, 3, 0, 3, 4],
+    [4, 6, 3, 7, 10, 9], [12, 8, 3, 12, 12, 8], [18, 8, 7, 3, 7, 1],
+    [11, 1, 0, 4, 6, 1], [14, 6, 1, 10, 11, 7]], dtype=float)
+
+# GetAssayData(AggregateExpression(..., return.seurat = TRUE), layer = "data")
+R_RETURN_SEURAT_DATA = np.array([
+    [6.97513565517, 7.78936889097, 7.27469276703],
+    [6.73422852209, 7.31005061772, 6.86957402540],
+    [7.22624231975, 5.84594034510, 6.51334423359],
+    [6.63903728447, 7.04788696809, 7.51093567067],
+    [7.33153010791, 7.45306228629, 7.56220161124],
+    [7.59374330606, 7.04788696809, 6.64669017025],
+    [6.82114076979, 6.13289925255, 6.51334423359],
+    [7.33153010791, 7.14311812261, 7.45689884166]])
+
+
+@pytest.fixture
+def obj():
+    o = create_truecell_object(
+        counts=sp.csc_matrix(COUNTS),
+        feature_names=[f"g{i}" for i in range(1, 9)],
+        cell_names=[f"c{i}" for i in range(1, 10)])
+    normalize_data(o)
+    o.meta_data["grp"] = GRP
+    o.meta_data["cond"] = COND
+    return o
+
+
+def _layer(obj, layer):
+    mat, feats = _get_expression_matrix(obj.assays["RNA"], layer)
+    mat = np.asarray(mat.toarray() if sp.issparse(mat) else mat)
+    return mat, feats
+
+
+def test_sums_match_seurat(obj):
+    got = aggregate_expression(obj, group_by="grp")
+    assert list(got.columns) == ["A", "B", "C"]
+    np.testing.assert_array_equal(got.to_numpy(), R_BY_GRP)
+
+
+def test_multi_column_grouping_matches_seurat(obj):
+    got = aggregate_expression(obj, group_by=["grp", "cond"])
+    assert list(got.columns) == ["A_x", "A_y", "B_x", "B_y", "C_x", "C_y"]
+    np.testing.assert_array_equal(got.to_numpy(), R_BY_GRP_COND)
+
+
+def test_return_object_normalizes_the_data_layer(obj):
+    """The defect this file found.
+
+    Seurat's ``return.seurat = TRUE`` runs ``NormalizeData`` over the pseudobulk,
+    so ``data`` is ``log1p(sums / colSums × 10000)``. Truecell left the raw sums
+    there, which every downstream reader of that layer would have taken for
+    normalized expression.
+    """
+    out = aggregate_expression(obj, group_by="grp", return_object=True)
+
+    counts, feats = _layer(out, "counts")
+    np.testing.assert_array_equal(counts, R_BY_GRP)
+
+    data, feats = _layer(out, "data")
+    np.testing.assert_allclose(data, R_RETURN_SEURAT_DATA, rtol=1e-10)
+
+    # And specifically not the two plausible wrong answers.
+    assert not np.allclose(data, R_BY_GRP)
+    assert not np.allclose(data, np.log1p(R_BY_GRP))
+
+
+def test_normalization_can_be_switched_off(obj):
+    out = aggregate_expression(obj, group_by="grp", return_object=True,
+                               normalization_method=None)
+    data, _ = _layer(out, "data")
+    np.testing.assert_array_equal(data, R_BY_GRP)
+
+
+def test_scale_factor_is_honoured(obj):
+    out = aggregate_expression(obj, group_by="grp", return_object=True,
+                               scale_factor=1e6)
+    data, _ = _layer(out, "data")
+    expected = np.log1p(R_BY_GRP / R_BY_GRP.sum(axis=0) * 1e6)
+    np.testing.assert_allclose(data, expected, rtol=1e-10)
+
+
+def test_the_two_functions_normalize_their_objects_differently(obj):
+    """The one place ``AggregateExpression`` and ``AverageExpression`` diverge.
+
+    Aggregate runs a full library-size normalization; Average takes a plain
+    ``log1p`` of the means. Wiring both to the same helper would pass every other
+    test in this file.
+    """
+    agg = aggregate_expression(obj, group_by="grp", return_object=True)
+    avg_frame = average_expression(obj, group_by="grp")
+    avg = average_expression(obj, group_by="grp", return_object=True)
+
+    agg_data, _ = _layer(agg, "data")
+    avg_data, feats = _layer(avg, "data")
+
+    np.testing.assert_allclose(agg_data, R_RETURN_SEURAT_DATA, rtol=1e-10)
+    np.testing.assert_allclose(avg_data,
+                               np.log1p(avg_frame.loc[feats].to_numpy()),
+                               rtol=1e-10)
+    assert not np.allclose(agg_data, avg_data)

--- a/truecell/__init__.py
+++ b/truecell/__init__.py
@@ -43,7 +43,7 @@ from .hto import hto_demux
 from .multiseq import multiseq_demux
 from .mixscape import calc_perturb_sig, run_mixscape, mixscape_lda
 from .markers import find_markers, find_all_markers, find_conserved_markers
-from .aggregate import aggregate_expression
+from .aggregate import aggregate_expression, average_expression
 from .sctransform import sctransform
 from .module_score import add_module_score, cell_cycle_scoring, CC_GENES
 from .spatial import (
@@ -192,6 +192,7 @@ __all__ = [
     "find_all_markers",
     "find_conserved_markers",
     "aggregate_expression",
+    "average_expression",
     "jack_straw",
     "score_jackstraw",
     "sctransform",

--- a/truecell/aggregate.py
+++ b/truecell/aggregate.py
@@ -113,6 +113,107 @@ def aggregate_expression(
     return agg_frames
 
 
+def average_expression(
+    seurat,
+    group_by: Union[str, list[str]] = "ident",
+    assays: Optional[Union[str, list[str]]] = None,
+    features: Optional[list[str]] = None,
+    layer: str = "data",
+    return_object: bool = False,
+):
+    """Mean expression within cell groups.
+
+    Mirrors R's ``AverageExpression(obj, group.by = "celltype")``, which is a
+    different function from :func:`aggregate_expression` and not a rescaling of
+    it. Two things differ, and both matter.
+
+    **It averages rather than sums**, and **on the ``data`` layer it averages the
+    back-transformed values**: ``mean(expm1(x))``, not ``mean(x)`` and not
+    ``expm1(mean(x))``. The ``data`` layer holds log1p-normalized expression, so
+    a mean taken on it is a geometric-ish mean of nothing in particular; Seurat
+    undoes the log first, averages on the linear scale, and returns that. The
+    difference is not cosmetic — on a small Poisson object the first gene reads
+    **332.84** under ``AverageExpression`` against a count mean of **3.17**.
+
+    The back-transform applies to the ``data`` layer **only**. ``counts`` and
+    ``scale.data`` are not log-normalized, so those are averaged as they stand.
+    Verified against Seurat 5.5.1 for all three layers.
+
+    Parameters
+    ----------
+    group_by      : metadata column(s) defining the groups; ``"ident"`` uses the
+                    object's active identities. Several are joined by ``"_"``.
+    assays        : assay name(s) to average (default: the active assay).
+    features      : restrict to these features (default: all).
+    layer         : layer to average (default ``"data"``, as Seurat's is).
+    return_object : if True, return a :class:`Truecell` with one "cell" per group.
+                    Seurat puts the averaged matrix in that object's ``counts``
+                    layer and ``log1p`` of it in ``data``; this does the same.
+
+    Returns
+    -------
+    ``pd.DataFrame`` | ``dict[str, pd.DataFrame]`` | ``Truecell``
+
+    See Also
+    --------
+    aggregate_expression : sums raw counts, which is what pseudobulk DE wants.
+    """
+    from .markers import expm1_keeping_sparsity
+
+    group_cols = [group_by] if isinstance(group_by, str) else list(group_by)
+    if assays is None:
+        assay_names = [seurat.active_assay]
+    else:
+        assay_names = [assays] if isinstance(assays, str) else list(assays)
+
+    labels = _group_labels(seurat, group_cols)
+    groups = sorted(labels.unique())
+    n_cells = len(labels)
+
+    group_index = {g: j for j, g in enumerate(groups)}
+    col_idx = np.fromiter((group_index[g] for g in labels), dtype=int, count=n_cells)
+    indicator = sp.csr_matrix(
+        (np.ones(n_cells), (np.arange(n_cells), col_idx)),
+        shape=(n_cells, len(groups)),
+    )
+    # Divide by the group's own size, not by the mean size: the groups are
+    # rarely balanced and Seurat averages within each.
+    sizes = np.asarray(indicator.sum(axis=0)).ravel()
+
+    avg_frames: dict[str, pd.DataFrame] = {}
+    for name in assay_names:
+        assay_obj = seurat.assays[name]
+        data, feature_names = _get_expression_matrix(assay_obj, layer)
+        if features is not None:
+            feat_set = set(features)
+            keep = np.array([f in feat_set for f in feature_names])
+            feature_names = [f for f, k in zip(feature_names, keep) if k]
+            data = data[keep, :]
+        if layer == "data":
+            data = expm1_keeping_sparsity(data)
+        summed = data @ indicator
+        if sp.issparse(summed):
+            summed = summed.toarray()
+        avg_frames[name] = pd.DataFrame(
+            np.asarray(summed) / sizes, index=feature_names, columns=groups
+        )
+
+    if return_object:
+        obj = _to_truecell(seurat, avg_frames, labels, groups, group_cols)
+        # Seurat leaves the averaged values in `counts` and writes log1p of them
+        # to `data`, rather than running NormalizeData over a matrix that is
+        # already a per-group average.
+        from .preprocessing import _set_layer
+        for name in assay_names:
+            _set_layer(obj.assays[name], "data",
+                       np.log1p(avg_frames[name].to_numpy()))
+        return obj
+
+    if len(assay_names) == 1:
+        return avg_frames[assay_names[0]]
+    return avg_frames
+
+
 def _to_truecell(seurat, agg_frames, labels, groups, group_cols):
     """Assemble aggregated frames into a Truecell object (one 'cell' per group)."""
     from .truecell import create_truecell_object

--- a/truecell/aggregate.py
+++ b/truecell/aggregate.py
@@ -44,6 +44,8 @@ def aggregate_expression(
     features: Optional[list[str]] = None,
     layer: str = "counts",
     return_object: bool = False,
+    normalization_method: str = "LogNormalize",
+    scale_factor: float = 10000.0,
 ):
     """Sum counts within cell groups to form a pseudobulk profile.
 
@@ -57,11 +59,31 @@ def aggregate_expression(
     assays        : assay name(s) to aggregate (default: the active assay).
     features      : restrict to these features (default: all).
     layer         : layer to aggregate (default ``"counts"`` — pseudobulk is
-                    defined on raw counts).
+                    defined on raw counts). Seurat's ``AggregateExpression`` has
+                    no such argument and always sums ``counts``; this is a
+                    superset with a matching default.
     return_object : if True, return a new :class:`Truecell` object with one "cell"
                     per group; if False (default), return a ``pd.DataFrame``
                     (features × groups), or a ``dict`` of them when several
                     assays are requested.
+    normalization_method : how to fill the returned object's ``data`` layer when
+                    ``return_object=True``. ``"LogNormalize"`` (Seurat's default)
+                    or ``None`` to leave ``data`` as the raw sums.
+    scale_factor  : the scale factor for that normalization (Seurat: 10000).
+
+    Notes
+    -----
+    ``return_object=True`` **normalizes**, which is easy to miss and was wrong
+    here until it was checked against R: Seurat's ``return.seurat = TRUE`` runs
+    ``NormalizeData`` over the pseudobulk, so ``data`` holds
+    ``log1p(sums / colSums × 10000)`` and not the sums. Leaving the sums in
+    ``data`` — which is what this did — hands every downstream function that
+    reads that layer un-normalized library-size-confounded values.
+
+    This is the one place ``AggregateExpression`` and ``AverageExpression``
+    diverge on their object output: :func:`average_expression` writes plain
+    ``log1p`` of the averages, with no library-size step. Verified against
+    Seurat 5.5.1 for both.
 
     Returns
     -------
@@ -106,7 +128,14 @@ def aggregate_expression(
         )
 
     if return_object:
-        return _to_truecell(seurat, agg_frames, labels, groups, group_cols)
+        obj = _to_truecell(seurat, agg_frames, labels, groups, group_cols)
+        if normalization_method is not None:
+            from .preprocessing import normalize_data
+            for name in assay_names:
+                normalize_data(obj, assay=name,
+                               normalization_method=normalization_method,
+                               scale_factor=scale_factor)
+        return obj
 
     if len(assay_names) == 1:
         return agg_frames[assay_names[0]]

--- a/truecell/clustering.py
+++ b/truecell/clustering.py
@@ -4,31 +4,58 @@ Mirrors Seurat's FindClusters().
 """
 from __future__ import annotations
 
-from typing import Optional
+from collections.abc import Sequence
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
 
 
+def _res_label(r: float) -> str:
+    """Format a resolution as R's ``as.character()`` would, for the column name.
+
+    Seurat names the column ``paste0(graph.name, "_res.", resolution)``, so the
+    label is R's numeric-to-string conversion and not Python's. The two differ on
+    the values users actually type: ``str(1.0)`` is ``"1.0"`` where R gives
+    ``"1"``, which would put the partition in ``RNA_snn_res.1.0`` and leave a
+    ported script reading ``RNA_snn_res.1`` with a ``KeyError``.
+
+    R's rule (at the default ``scipen = 0``) is to render both fixed and
+    scientific and keep whichever is shorter, ties going to fixed — so 0.001
+    stays ``0.001`` while 0.0001 becomes ``1e-04``. Verified against R 4.x on 21
+    values spanning 1e-7 to 1234567.
+    """
+    r = float(r)
+    fixed = np.format_float_positional(r, trim="-")
+    sci = np.format_float_scientific(r, trim="-", exp_digits=2)
+    return sci if len(sci) < len(fixed) else fixed
+
+
 def find_clusters(
     seurat,
-    resolution: float = 0.5,
+    resolution: Union[float, Sequence[float]] = 0.5,
     algorithm: int = 1,
     graph_name: Optional[str] = None,
     random_seed: int = 0,
     n_iterations: int = -1,
     group_singletons: bool = True,
+    cluster_name: Optional[Union[str, Sequence[str]]] = None,
 ) -> None:
     """Apply Louvain or Leiden clustering on the SNN graph.
 
-    Mirrors R's FindClusters(pbmc, resolution = 0.5).
-    Stores cluster assignments in seurat.meta_data['seurat_clusters']
-    and updates seurat.idents.
+    Mirrors R's ``FindClusters(pbmc, resolution = 0.5)``, including its
+    vector form ``FindClusters(pbmc, resolution = c(0.4, 0.8, 1.2))``.
+
+    Each resolution is written to its own metadata column, named
+    ``{graph_name}_res.{resolution}`` as Seurat names it. ``seurat_clusters`` and
+    the active identities are set from the **last** resolution in the sequence —
+    last as given, not largest, which is what Seurat does.
 
     Parameters
     ----------
-    resolution   : higher values give more / finer clusters
+    resolution   : higher values give more / finer clusters. A sequence runs each
+                   in turn, as R's ``resolution = c(...)`` does.
     algorithm    : 1 = Louvain, 2 = Louvain (multilevel, igraph's default),
                    4 = Leiden. (3 = SLM is not implemented.)
     graph_name   : SNN graph to use (defaults to '{assay}_snn')
@@ -38,6 +65,9 @@ def find_clusters(
                    neighbour, as Seurat's ``GroupSingletons`` does. With
                    ``False`` they are all pooled into one ``"singleton"``
                    cluster instead — again matching Seurat.
+    cluster_name : override the generated column name(s); one name, or one per
+                   resolution. Seurat's ``cluster.name``. ``seurat_clusters`` is
+                   still written either way.
 
     Notes
     -----
@@ -46,6 +76,12 @@ def find_clusters(
     multilevel Louvain. On the same graph that makes truecell's partition land in
     a slightly shallower optimum — measurably so, but not necessarily a worse
     one. See the clustering section of ``tutorials/integration_vignette.md``.
+
+    Each resolution is clustered from the same seed rather than from a running
+    RNG stream, so a partition does not depend on which resolutions preceded it
+    or on the order they were given in. Verified against Seurat 5.5.1, where
+    resolution 0.8 gives the same partition alone, in ``c(0.4, 0.8, 1.2)``, and
+    in ``c(1.2, 0.8, 0.4)``.
     """
     assay_name = seurat.active_assay
     if graph_name is None:
@@ -62,28 +98,64 @@ def find_clusters(
     graph = seurat.graphs[graph_name]
     mat = graph._matrix  # scipy sparse (cells × cells)
 
-    if algorithm == 4:
-        labels = _leiden_clustering(mat, resolution, random_seed, n_iterations)
-    elif algorithm in (1, 2):
-        # python-igraph's community_multilevel is the multilevel Louvain
-        # algorithm (closest to Seurat's algorithm 1/2).
-        labels = _louvain_clustering(mat, resolution, random_seed)
-    elif algorithm == 3:
+    # Validated once rather than per iteration. This does *not* prevent a partial
+    # write — the dispatch sits at the top of the loop body, so a bad `algorithm`
+    # would raise on the first resolution either way, before anything is stored.
+    # It is here so the check does not depend on the loop at all.
+    #
+    # A partial write is still reachable: if a *later* resolution fails inside
+    # igraph, the earlier columns are already on the object. That is Seurat's
+    # behaviour too, and is left alone.
+    if algorithm == 3:
         raise NotImplementedError(
             "algorithm=3 (SLM) is not implemented. Use 1 or 2 (Louvain) or "
             "4 (Leiden)."
         )
-    else:
+    if algorithm not in (1, 2, 4):
         raise ValueError(
             f"Unknown algorithm {algorithm!r}. Use 1 or 2 (Louvain) or 4 (Leiden)."
         )
 
-    str_labels = _group_singletons(
-        np.asarray([str(c) for c in labels]), mat, group_singletons
-    )
-    present = sorted(set(str_labels), key=lambda s: (not s.isdigit(), s.isdigit() and int(s), s))
-    cluster_series = pd.Categorical(str_labels, categories=present)
+    # `np.number` is here for the numpy scalars a caller gets out of an array;
+    # np.float64 subclasses float but np.float32 does not, and iterating one
+    # raises rather than falling through to the sequence branch.
+    if isinstance(resolution, (int, float, np.number)):
+        resolutions = [float(resolution)]
+    else:
+        resolutions = [float(r) for r in resolution]
+    if not resolutions:
+        raise ValueError("`resolution` is empty; give at least one value.")
 
+    if cluster_name is None:
+        names = [f"{graph_name}_res.{_res_label(r)}" for r in resolutions]
+    else:
+        names = [cluster_name] if isinstance(cluster_name, str) else list(cluster_name)
+        if len(names) != len(resolutions):
+            raise ValueError(
+                f"`cluster_name` has {len(names)} name(s) for "
+                f"{len(resolutions)} resolution(s); give one per resolution."
+            )
+
+    cluster_series = None
+    for res, name in zip(resolutions, names):
+        if algorithm == 4:
+            labels = _leiden_clustering(mat, res, random_seed, n_iterations)
+        else:
+            # python-igraph's community_multilevel is the multilevel Louvain
+            # algorithm (closest to Seurat's algorithm 1/2).
+            labels = _louvain_clustering(mat, res, random_seed)
+
+        str_labels = _group_singletons(
+            np.asarray([str(c) for c in labels]), mat, group_singletons
+        )
+        present = sorted(set(str_labels),
+                         key=lambda s: (not s.isdigit(), s.isdigit() and int(s), s))
+        cluster_series = pd.Categorical(str_labels, categories=present)
+        seurat.meta_data[name] = cluster_series
+
+    # The last resolution given, not the largest — Seurat takes the last column
+    # of its results frame, so `resolution = c(1.2, 0.8, 0.4)` leaves the object
+    # sitting on 0.4.
     seurat.meta_data["seurat_clusters"] = cluster_series
     seurat.idents = cluster_series
 

--- a/truecell/markers.py
+++ b/truecell/markers.py
@@ -26,18 +26,32 @@ def _row_pct_positive(m) -> np.ndarray:
     return (m > 0).mean(axis=1)
 
 
-def _row_expm1_sum(m) -> np.ndarray:
-    """Row sums of ``expm1(m)``, without densifying a sparse ``m``.
+def expm1_keeping_sparsity(m):
+    """``expm1(m)``, without densifying a sparse ``m``.
 
     ``expm1(0) == 0``, so the transform leaves the sparsity pattern untouched
     and applies to the stored values alone. That is what lets the fold-change
     pre-filter run on the sparse matrix instead of a dense copy of it.
+
+    Shared with :func:`truecell.aggregate.average_expression`, which un-does the
+    same log1p normalization before averaging. The two must agree — Seurat's
+    fold change and its ``AverageExpression`` are the same back-transform — and a
+    second copy of these three lines is exactly the kind of divergence nothing
+    downstream could detect.
     """
     if sp.issparse(m):
         transformed = m.copy()
         transformed.data = np.expm1(transformed.data)
+        return transformed
+    return np.expm1(m)
+
+
+def _row_expm1_sum(m) -> np.ndarray:
+    """Row sums of ``expm1(m)``, without densifying a sparse ``m``."""
+    transformed = expm1_keeping_sparsity(m)
+    if sp.issparse(transformed):
         return np.asarray(transformed.sum(axis=1)).ravel()
-    return np.expm1(m).sum(axis=1)
+    return transformed.sum(axis=1)
 
 
 def _dense_rows(m, rows: np.ndarray) -> np.ndarray:
@@ -845,25 +859,54 @@ def _deseq2_pseudobulk(
 # Helper
 # ------------------------------------------------------------------
 
+def _layer_aliases(layer: Optional[str]) -> tuple[str, ...]:
+    """The spellings a layer name can arrive as.
+
+    Seurat's layer is ``scale.data`` and the Python API argument is
+    ``scale_data``; both reach here, and the Assay5 layer dict is keyed with the
+    dotted form. Matching only one spelling means the other misses the dict and
+    falls through to the ``data`` fallback below — silently, with the right
+    shape, which is the whole problem.
+    """
+    if layer is None:
+        return ()
+    if layer in ("scale_data", "scale.data"):
+        return ("scale.data", "scale_data")
+    return (layer,)
+
+
 def _get_expression_matrix(assay_obj, layer: Optional[str]):
-    """Return (matrix features×cells, feature_names) using best available layer."""
+    """Return (matrix features×cells, feature_names) using best available layer.
+
+    The names returned are the **layer's own**, not the assay's. Only
+    ``scale.data`` holds a subset — ``scale_data()`` defaults to the variable
+    features, as R's ``ScaleData`` does — so handing back the full assay feature
+    list alongside a matrix a fraction of its height mislabels every row. That is
+    the defect fixed in ``reduction.py`` under #66; this function had the same
+    one, reachable through ``find_markers(layer=...)`` and the two aggregation
+    functions.
+    """
     from .assay5 import Assay5
 
     if isinstance(assay_obj, Assay5):
-        feature_names = assay_obj._all_feature_names
-        if layer is not None and layer in assay_obj.layers:
-            return assay_obj.layers[layer], feature_names
+        for key in _layer_aliases(layer):
+            if key in assay_obj.layers:
+                names = assay_obj._layer_features.get(
+                    key, assay_obj._all_feature_names)
+                return assay_obj.layers[key], list(names)
         for candidate in ("data", "counts"):
             if candidate in assay_obj.layers:
-                return assay_obj.layers[candidate], feature_names
+                names = assay_obj._layer_features.get(
+                    candidate, assay_obj._all_feature_names)
+                return assay_obj.layers[candidate], list(names)
         raise ValueError("No expression data layer found in Assay5.")
     else:
         feature_names = assay_obj._feature_names
         from ._sparse import is_matrix_empty
         if layer == "counts":
             return assay_obj.counts, feature_names
-        if layer == "scale_data" or layer == "scale.data":
-            return assay_obj.scale_data, feature_names
+        if layer in ("scale_data", "scale.data"):
+            return assay_obj.scale_data, assay_obj.features("scale_data")
         # Prefer log-normalized data
         if not is_matrix_empty(assay_obj.data):
             return assay_obj.data, feature_names

--- a/tutorials/de_vignette.md
+++ b/tutorials/de_vignette.md
@@ -257,18 +257,71 @@ previous version of this note called them.
 
 | Test | Genes | max \|Δlog2FC\| | p Spearman (all) | p Spearman (detected >5 %) | Top 50 |
 |---|---|---|---|---|---|
-| `wilcox` | 13,712 | 6.4e-15 | **1.000000** | 1.0000 | 50/50 |
-| `t` | 13,712 | 6.4e-15 | 0.999980 | 1.0000 | 50/50 |
-| `bimod` | 13,712 | 6.4e-15 | 0.999994 | 1.0000 | 50/50 |
-| `LR` | 13,712 | 6.4e-15 | 0.999975 | 1.0000 | 50/50 |
-| `negbinom` | 11,466 | 6.4e-15 | 0.694339 | **0.9165** | 50/50 |
-| `roc` | 13,712 | 6.4e-15 | *AUC 5.0e-04* | — | — |
-| `mast` | 13,712 | 6.4e-15 | 0.947061 | **0.9979** | 50/50 |
-| `deseq2` | 13,712 | *3.47* | 0.476954 | 0.1959 | 22/50 |
+| `wilcox` | 13,712 | 6.2e-15 | **1.000000** | 1.0000 | 50/50 |
+| `t` | 13,712 | 6.2e-15 | 0.999980 | 1.0000 | 50/50 |
+| `bimod` | 13,712 | 6.2e-15 | 0.999994 | 1.0000 | 50/50 |
+| `LR` | 13,712 | 6.2e-15 | 0.999975 | 1.0000 | 50/50 |
+| `negbinom` | 11,466 | 6.2e-15 | 0.694340 | **0.9165** | 50/50 |
+| `roc` | 13,712 | 6.2e-15 | *AUC 5.0e-04* | — | — |
+| `mast` | 13,712 | 6.2e-15 | 0.947038 | **0.9979** | 50/50 |
+| `deseq2` | 13,712 | *3.47* | 0.476942 | 0.1959 | 22/50 |
+
+> The last digits of these moved slightly when the CSV round-trip was fixed (see
+> *The two columns a person actually reads*, below): they had been read back
+> through a misparsing float reader. The change is at the ULP level and no band
+> moved, but the table is the measured one, not the previous one.
 
 `deseq2`'s row is the pseudobulk-vs-per-cell divergence described above, not a
 defect; its fold change differs too because a pseudobulk fold change is computed
 on summed counts.
+
+### The two columns a person actually reads
+
+The table above scores the statistic. It does not score the two numbers someone
+annotating clusters looks at: the fold change they sort by, and the **adjusted**
+p-value they threshold on. Neither was compared until an expert reviewer pointed
+out that the max-difference bound and a set overlap answer neither question.
+
+| Test | logFC Spearman | logFC Kendall | Top 50 by \|logFC\| | `p_val_adj` to 6 s.f. | Same call at 0.05 | Genes differing |
+|---|---|---|---|---|---|---|
+| `wilcox` | **1.000000** | **1.000000** | 50/50 | 0.9933 | **1.0000** | 0 |
+| `t` | **1.000000** | **1.000000** | 50/50 | 0.9999 | **1.0000** | 0 |
+| `bimod` | **1.000000** | **1.000000** | 50/50 | 0.9997 | 0.9999 | 2 |
+| `LR` | **1.000000** | **1.000000** | 50/50 | 0.9915 | **1.0000** | 0 |
+| `negbinom` | **1.000000** | **1.000000** | 50/50 | 0.8547 | 0.9958 | 48 |
+| `roc` | **1.000000** | **1.000000** | 50/50 | — | — | — |
+| `mast` | **1.000000** | **1.000000** | 50/50 | 0.7984 | 0.9895 | 144 |
+| `deseq2` | 0.966510 | 0.847811 | 34/50 | 0.4314 | 0.8938 | 1,401 |
+
+Rank correlation is reported *alongside* the max-difference bound rather than
+instead of it, because the two fail differently. A uniform scale error leaves
+every rank perfect and blows up the max; a handful of swapped mid-table genes
+leaves the max tiny and moves the ranks. Here both are clean: fold-change order
+is preserved exactly for all seven cell-level tests.
+
+**Do identical adjusted p-values occur?** Mostly not, and the reason is worth
+stating rather than the rate. The *correction* is identical — both tools compute
+`min(p × 13,714, 1)`, which holds bit-exactly on both sides — but the raw
+p-values feeding it differ by up to **0.54 % relative** on `wilcox`, a real
+difference between SciPy's Wilcoxon and Seurat's, so the product rarely lands on
+the same double. What survives that is what matters: the ordering is exact, and
+**every gene** falls on the same side of 0.05 for `wilcox`, `t` and `LR`.
+
+Two traps in measuring this, both of which had to be fixed before the numbers
+above meant anything:
+
+- **Seurat clamps `p_val_adj` at 1, and 11,858 of 13,712 genes land there.** A
+  bare "fraction identical" therefore reads ≈0.87 before a single interesting
+  gene is considered. `--report` scores the unclamped subset separately.
+- **Neither side's CSV round-tripped a float64.** R's `write.csv` renders 15
+  significant digits, and raising it does not help — R's own `sprintf("%.17g")`
+  is not correctly rounded and emits digits denoting a *different* double.
+  Pandas' `read_csv` misparses about a third of random doubles by an ULP at its
+  default `float_precision`. So the R side now also writes `r_<test>_exact.csv`
+  in C99 hex float (`%a`, a transcription of the IEEE-754 bits rather than a
+  decimal approximation of them), and the Python side reads with
+  `float_precision="round_trip"`. Before that, an "is it identical" comparison
+  was measuring the two languages' text formatters.
 
 ### These numbers are asserted, not just printed
 

--- a/tutorials/pbmc3k_de_tutorial.py
+++ b/tutorials/pbmc3k_de_tutorial.py
@@ -221,9 +221,86 @@ def run_tests(obj, groups: pd.Series, tests=None) -> dict[str, pd.DataFrame]:
     return out
 
 
-def compare(py: pd.DataFrame, r: pd.DataFrame, test: str) -> dict:
+def read_exact(path) -> pd.DataFrame | None:
+    """An R table written as C99 hex floats, or None if it was not written.
+
+    See the `write_exact` note in ``pbmc3k_de_verify.R``: neither R's `write.csv`
+    nor its `sprintf("%.17g")` round-trips a float64, so the ordinary CSV cannot
+    settle whether two values are *identical* — only whether they agree to about
+    15 digits. `%a` transcribes the IEEE-754 bits, and `float.fromhex` reads them
+    back exactly.
+    """
+    path = Path(path)
+    if not path.exists():
+        return None
+    raw = pd.read_csv(path, index_col=0, dtype=str)
+    out = {}
+    for col in raw.columns:
+        vals = raw[col]
+        if vals.dropna().str.startswith(("0x", "-0x", "inf", "-inf", "nan")).all():
+            out[col] = vals.map(
+                lambda s: float("nan") if pd.isna(s) else float.fromhex(s))
+        else:
+            out[col] = vals
+    return pd.DataFrame(out, index=raw.index)
+
+
+def compare_adjusted_p(py: pd.DataFrame, r: pd.DataFrame, shared,
+                       exact: pd.DataFrame | None) -> dict:
+    """Agreement on ``p_val_adj`` — the column a manual annotation is read off.
+
+    Reported separately from the raw p-value because it is a different question.
+    A raw p-value is an intermediate; ``p_val_adj`` is what a person looks at and
+    thresholds, so what matters is whether the two tools put a gene on the same
+    side of 0.05, not whether the mantissas agree.
+
+    One trap this deliberately reports around: Seurat clamps ``p_val_adj`` at 1,
+    and on this contrast **11,858 of 13,712 genes** land there in both tools. A
+    bare "fraction identical" is therefore ~0.88 before any of the interesting
+    genes are considered, and would read as agreement where it is mostly just the
+    clamp. The unclamped subset is scored on its own line for that reason.
+    """
+    res: dict = {}
+    if "p_val_adj" not in py or "p_val_adj" not in r:
+        return res
+
+    a = py.loc[shared, "p_val_adj"]
+    b = (exact.loc[shared, "p_val_adj"] if exact is not None
+         else r.loc[shared, "p_val_adj"])
+    ok = a.notna() & b.notna()
+    res["padj_n_compared"] = int(ok.sum())
+    res["padj_source"] = "hex" if exact is not None else "csv_15_digits"
+
+    clamped = ok & (a == 1.0) & (b == 1.0)
+    res["padj_both_clamped_at_1"] = int(clamped.sum())
+    free = ok & ~clamped
+    res["padj_n_unclamped"] = int(free.sum())
+
+    if exact is not None:
+        # Only meaningful against the hex tables; through the 15-digit CSV this
+        # measures R's formatter, not the computation.
+        res["padj_identical"] = float((a[ok] == b[ok]).mean())
+        if free.any():
+            res["padj_identical_unclamped"] = float((a[free] == b[free]).mean())
+
+    with np.errstate(all="ignore"):
+        for sf in (3, 6):
+            res[f"padj_agree_{sf}sf"] = float(
+                np.isclose(a[ok], b[ok], rtol=10.0 ** -sf, atol=0).mean())
+
+    # The number the reviewer's question is actually about: would the two tools
+    # put the same genes in front of someone annotating clusters?
+    for cut in (0.05, 0.01):
+        same = (a[ok] < cut) == (b[ok] < cut)
+        res[f"padj_same_call_at_{cut}"] = float(same.mean())
+        res[f"padj_disagreements_at_{cut}"] = int((~same).sum())
+    return res
+
+
+def compare(py: pd.DataFrame, r: pd.DataFrame, test: str,
+            exact: pd.DataFrame | None = None) -> dict:
     """One test's agreement with Seurat, on the genes both scored."""
-    from scipy.stats import spearmanr
+    from scipy.stats import kendalltau, spearmanr
 
     shared = py.index.intersection(r.index)
     res: dict = {"n_python": len(py), "n_r": len(r), "n_shared": len(shared)}
@@ -232,6 +309,23 @@ def compare(py: pd.DataFrame, r: pd.DataFrame, test: str) -> dict:
         d = np.abs(py.loc[shared, "avg_log2FC"] - r.loc[shared, "avg_log2FC"])
         res["log2fc_max_abs_diff"] = float(d.max())
         res["log2fc_exact"] = bool(d.max() <= LOG2FC_TOLERANCE)
+
+        # Rank agreement, alongside the bound above rather than instead of it:
+        # the two fail differently. A uniform scale error leaves every rank
+        # perfect and blows up the max; a handful of swapped mid-table genes
+        # leaves the max tiny and moves the ranks. Someone ranking markers by
+        # fold change is reading the second.
+        x, y = py.loc[shared, "avg_log2FC"], r.loc[shared, "avg_log2FC"]
+        m = x.notna() & y.notna()
+        if m.sum() > 2:
+            res["log2fc_spearman"] = float(spearmanr(x[m], y[m])[0])
+            res["log2fc_kendall"] = float(kendalltau(x[m], y[m])[0])
+            for k in (10, 25, 50):
+                top_py = set(x[m].abs().sort_values(ascending=False).head(k).index)
+                top_r = set(y[m].abs().sort_values(ascending=False).head(k).index)
+                res[f"log2fc_top{k}_overlap"] = len(top_py & top_r)
+
+    res.update(compare_adjusted_p(py, r, shared, exact))
 
     if test == "roc":
         d = np.abs(py.loc[shared, "myAUC"] - r.loc[shared, "myAUC"])
@@ -301,14 +395,22 @@ def report_concordance():
         )
     rows = []
     for test in TEST_MAP:
-        py = pd.read_csv(FIGURES / f"py_{test}.csv", index_col=0)
-        r = pd.read_csv(FIGURES / f"r_{test.lower()}.csv", index_col=0)
+        # `float_precision="round_trip"` because pandas' default CSV *reader* is
+        # not correctly rounded — it misparses about a third of random doubles by
+        # an ULP. `to_csv` was never the problem; it already writes the shortest
+        # round-trippable form. Without this the Python table is perturbed on the
+        # way back in, and an exactness comparison measures the parser.
+        py = pd.read_csv(FIGURES / f"py_{test}.csv", index_col=0,
+                         float_precision="round_trip")
+        r = pd.read_csv(FIGURES / f"r_{test.lower()}.csv", index_col=0,
+                        float_precision="round_trip")
         # Before anything is compared: was this R table computed on the groups
         # the Python side just wrote? Nothing else here can tell the difference
         # between a port that regressed and an R run left over from a previous
         # clustering, and the second reads exactly like the first.
         check_shared_groups(py, r, source=f"figures_de/r_{test.lower()}.csv")
-        rows.append({"test": test, **compare(py, r, test)})
+        exact = read_exact(FIGURES / f"r_{test.lower()}_exact.csv")
+        rows.append({"test": test, **compare(py, r, test, exact)})
     table = pd.DataFrame(rows).set_index("test")
     _print_report(table)
     verdicts = check_bands(BANDS, measure_bands(table))
@@ -361,6 +463,43 @@ def _print_report(table: pd.DataFrame) -> None:
             continue
         print(f"  {test:10s} {int(row['n_shared']):7d} {fc:10.2e} "
               f"{sp:11.6f} {ex:10.4f} {int(top):4d}/{TOP_N}")
+
+    _print_reader_facing(table)
+
+
+def _print_reader_facing(table: pd.DataFrame) -> None:
+    """The two columns a person actually reads off a marker table.
+
+    The block above scores the statistic. This one scores what someone doing the
+    annotation sees: the fold change they rank by, and the adjusted p they
+    threshold on. Both were unreported until an expert reviewer pointed out that
+    a set-overlap metric answers neither.
+    """
+    # Every cell is formatted through `cell`, because not every column exists for
+    # every row: `roc` has no `p_val_adj`, and a table too short for a rank
+    # correlation (the band tests use a two-gene stub) has no rho or tau. A row
+    # that cannot be scored should print a dash, not raise.
+    def cell(value, spec: str, width: int) -> str:
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            return f"{'—':>{width}}"
+        return format(value, spec)
+
+    print(f"\n  {'test':10s} {'logFC rho':>10s} {'logFC tau':>10s} "
+          f"{'top50':>7s} {'padj 6sf':>9s} {'call@.05':>9s} {'differ':>7s}")
+    print("  " + "-" * 68)
+    for test, row in table.iterrows():
+        top = row.get("log2fc_top50_overlap", float("nan"))
+        print(f"  {test:10s} "
+              f"{cell(row.get('log2fc_spearman'), '10.6f', 10)} "
+              f"{cell(row.get('log2fc_kendall'), '10.6f', 10)} "
+              f"{cell(top, '4.0f', 4)}/50 "
+              f"{cell(row.get('padj_agree_6sf'), '9.4f', 9)} "
+              f"{cell(row.get('padj_same_call_at_0.05'), '9.4f', 9)} "
+              f"{cell(row.get('padj_disagreements_at_0.05'), '7.0f', 7)}")
+    print("\n  `call@.05` is the fraction of genes both tools place on the same "
+          "side of\n  adjusted p = 0.05, and `differ` counts the ones they do "
+          "not — the number\n  that matters if the table is being read to "
+          "annotate clusters by hand.")
 
 
 def main():

--- a/tutorials/pbmc3k_de_verify.R
+++ b/tutorials/pbmc3k_de_verify.R
@@ -58,6 +58,28 @@ cat(sprintf("Shared cells: %d  (%s)\n", ncol(obj),
             paste(names(table(Idents(obj))), table(Idents(obj)),
                   sep = "=", collapse = " ")))
 
+# A second, exact copy of each table, for the comparisons that need bit-identity.
+#
+# `write.csv` renders doubles at 15 significant digits, which does not round-trip
+# float64 — so a Python side reading it is comparing against a value R has
+# already perturbed by a few ULP, and "identical" can never be measured. Raising
+# the digit count does not fix it: R's own `sprintf("%.17g", x)` is not correctly
+# rounded, and emits digits denoting a *different* double (0.1234567890123456789
+# comes back as ...571 where the shortest exact form is ...568). Verified in both
+# languages.
+#
+# `%a` is C99 hex float — a transcription of the IEEE-754 bits rather than a
+# decimal approximation of them — so it is exact by construction, and Python
+# reads it with `float.fromhex`. The human-readable CSV above is kept as it is,
+# because the vignette quotes from it.
+write_exact <- function(df, path) {
+  out <- as.data.frame(lapply(df, function(col) {
+    if (is.numeric(col)) sprintf("%a", col) else as.character(col)
+  }), stringsAsFactors = FALSE)
+  rownames(out) <- rownames(df)
+  write.csv(out, path)
+}
+
 # logfc.threshold = 0 and min.pct = 0 so the comparison sees every gene rather
 # than only the ones that survive a filter whose *input* is the number under
 # test. Seurat's defaults would hide exactly the disagreement worth seeing.
@@ -72,6 +94,7 @@ for (tt in TESTS) {
     next
   }
   write.csv(res, file.path(FIG, sprintf("r_%s.csv", tolower(tt))))
+  write_exact(res, file.path(FIG, sprintf("r_%s_exact.csv", tolower(tt))))
   cat(sprintf("  %-9s %6d genes  %6.1fs\n", tt, nrow(res),
               as.numeric(difftime(Sys.time(), t0, units = "secs"))))
 }


### PR DESCRIPTION
An expert reviewer read the package and returned eleven comments. Most were about
the manuscript, but tracing each one into the code found **two missing APIs and
four defects** — three of them silent. The full suite passed both before and
after every one.

`REVIEW_PLAN.md` carries the triage and what is still open.

## Missing APIs

**`find_clusters` could not express the standard idiom.**
`FindClusters(obj, resolution = c(0.4, 0.8, 1.2))` is how a resolution gets
chosen — run a few, compare, pick one. Truecell took a scalar.

Underneath sat a plainer break, present at the default settings: it wrote only
`seurat_clusters` and **never** the `{graph}_res.{resolution}` column, so a
ported script reading `obj[["RNA_snn_res.0.5"]]` raised `KeyError`. Nothing in
the suite noticed, because nothing read that column.

Three conventions pinned against Seurat 5.5.1, one of them a trap:

- The column label is **R's** number formatting. `str(1.0)` is `"1.0"` where
  `as.character(1.0)` is `"1"`, so the obvious implementation writes
  `RNA_snn_res.1.0` and the ported script fails anyway. `_res_label` reproduces
  R's rule (render fixed and scientific, keep the shorter, ties to fixed),
  checked against R on 21 values from 1e-7 to 1234567.
- The object is left on the **last resolution given**, not the largest.
- Each resolution clusters from the same seed rather than a running stream.

**`average_expression` did not exist.** Seurat ships two group-summary functions
and they are not two scalings of one: `AggregateExpression` sums raw counts,
`AverageExpression` averages the **back-transformed** `data` layer —
`mean(expm1(x))`, not `mean(x)` and not `expm1(mean(x))`. On a small Poisson
object the first gene reads **332.84** under one and **3.17** under the other.
The back-transform belongs to `data` alone. All three layers, `features=`,
multi-column `group_by` and `return_object` pinned against R; worst absolute
difference 6.8e-13 on values of order 300.

## Defects

**`_get_expression_matrix` returned the wrong layer, and mislabelled the right
one.** The Assay5 layer dict is keyed `scale.data`; the Python argument is
`scale_data`. Only the dotted spelling matched, so the underscore form fell
through to the `data` fallback — right shape, no warning, normalized values
where scaled ones were asked for. The dotted spelling then hit the second
defect: a 10-row matrix paired with the assay's full 30-name feature list, so
every row read as a different gene. Same defect fixed in `reduction.py` under
\#66; the twin survived here. **PCA was never affected** — it has its own
accessor.

**`aggregate_expression(return_object=True)` left raw sums in `data`.** Seurat's
`return.seurat = TRUE` runs `NormalizeData` over the pseudobulk, so `data` holds
`log1p(sums / colSums × 10000)` — **6.98** where Truecell had **14**. Every
downstream reader of that layer would have taken library-size-confounded sums
for normalized expression. `normalization_method` / `scale_factor` now mirror
Seurat's arguments.

**The DE suite never compared `p_val_adj`.** `grep` across the tutorial returned
nothing. That is the column a biologist annotates off, and it was unchecked.
`avg_log2FC` was checked only by a max-difference bound, never by rank.

The answer turns out to be good: fold-change order is preserved **exactly**
(Spearman and Kendall both 1.000000, top 10/25/50 all match), and **every gene**
falls on the same side of 0.05 for `wilcox`, `t` and `LR`. The Bonferroni step
is bit-identical on both sides; what differs is the raw Wilcoxon p, by up to
0.54 % relative, which changes no ranking and no call.

**Neither side of the CSV handoff round-tripped a float64.** R's `write.csv`
renders 15 significant digits, and raising it does not help — R's own
`sprintf("%.17g")` is not correctly rounded and emits digits denoting a
*different* double. Pandas' `read_csv` misparses about a third of random doubles
by an ULP at its default `float_precision`; `to_csv` was never the problem. So
any "these agree exactly" claim read from two CSVs was partly a measurement of
the two languages' text formatters. Fixed in the DE tutorial with C99 hex floats
(`%a`) from R and `float_precision="round_trip"` in Python. **42 read sites
across 17 other tutorials still have this** and are not touched here.

## Verification

- **1130 passed, 25 skipped.** mypy at its 4-error baseline; ruff advisory, +8
  and all `Optional`/`Union` in files that already carry that idiom.
- **27 mutants run, 27 caught.** One earlier survivor was a false rationale in a
  comment of mine, not a missing test — moving the `algorithm` check into the
  loop passes everything, because the dispatch is the loop's first statement.
  The comment now says that instead.
- Column names, all seven `average_expression` cases, and the pseudobulk
  normalization compared against live R Seurat 5.5.1 value by value.
- The DE `--report` exits zero with every declared band holding. Fixing the
  reader moved the parity table's last digits (max \|Δlog2FC\| 6.4e-15 →
  6.2e-15); no band moved and the vignette carries the measured values.

## Still open

Not started, listed in `REVIEW_PLAN.md`: the resolution-stability tutorial,
`add_module_score` verification on arbitrary gene programs (it is R-verified only
through the Tirosh cell-cycle sets), and the pseudobulk-DE half of a tutorial —
though the silent-defect risk there is closed by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
