### PR TITLE
Read every tutorial CSV with float_precision="round_trip"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Every tutorial CSV read now round-trips float64.** pandas' default CSV
+  *reader* is not correctly rounded — it misparses about a third of random
+  doubles by an ULP. `to_csv` was never at fault; it already writes the shortest
+  round-trippable form. So a tutorial that wrote a value, handed it to R, read
+  both back and reported "these agree exactly" was partly measuring the parser.
+
+  37 call sites across 16 tutorials now pass `float_precision="round_trip"`.
+  Three reads are exempt with stated reasons (cell labels, a row count, and the
+  DE hex reader, which parses via `float.fromhex`).
+
+  Six reported figures moved, all at the ULP level and most of them downward —
+  PBMC 8k's `percent.mt` 5.773e-15 → 5.329e-15, PBMC 3k's VST mean relative
+  difference 1.548e-14 → 4.973e-15, SCTransform's `detection_rate` 5.6e-16 →
+  5.0e-16. **No declared band moved and all nine `--report` runs still exit
+  zero.** The affected vignettes carry the measured values.
+
+  `tests/test_tutorial_csv_precision.py` pins the convention so the next
+  `pd.read_csv` cannot quietly reintroduce it, and checks that the three
+  exemptions still match something rather than silently widening the lint.
+
+  Not fixed here, because it is not lintable from Python: R's `write.csv`
+  renders 15 significant digits and raising it does not help — R's own
+  `sprintf("%.17g")` is not correctly rounded either. Where bit-identity is the
+  actual question the R script writes a C99 hex-float side table, as
+  `pbmc3k_de_verify.R` does.
+
+- **Corrected a marker-agreement bound in the PBMC 3k docs.** They stated
+  `avg_log2FC` agreement "to 4.9e-15" for both clusters whose cells match
+  exactly. That covers the 151-gene cluster (4.88e-15); the 242-gene one is
+  **4.62e-14**, an order of magnitude larger. Both figures are now given. This
+  predates the reader fix — the bound was simply the smaller of the two.
+
 - **`aggregate_expression(return_object=True)` left raw sums in the `data`
   layer.** Seurat's `AggregateExpression(return.seurat = TRUE)` runs
   `NormalizeData` over the pseudobulk, so its `data` holds

--- a/tests/test_tutorial_csv_precision.py
+++ b/tests/test_tutorial_csv_precision.py
@@ -1,0 +1,99 @@
+"""Every tutorial CSV read that feeds a number must round-trip float64.
+
+pandas' default CSV *reader* is not correctly rounded — it misparses about a
+third of random doubles by an ULP. `to_csv` was never the problem; it already
+writes the shortest round-trippable form. So a tutorial that writes a value,
+hands it to R, reads both back and reports "these agree exactly" is partly
+measuring the parser.
+
+This is a lint, not a numeric check: it pins the *convention* across all
+eighteen tutorials so the next `pd.read_csv` does not quietly reintroduce it.
+The numeric consequence was small but real — fixing 37 call sites moved six
+reported max-difference figures, most of them downward (PBMC 8k's `percent.mt`
+5.773e-15 -> 5.329e-15, PBMC 3k's VST mean relative difference 1.548e-14 ->
+4.973e-15). No declared band moved.
+
+The R side of the same problem is worse and is not lintable from here: R's
+`write.csv` renders 15 significant digits, and raising it does not help because
+R's own `sprintf("%.17g")` is not correctly rounded either. Where bit-identity
+is actually the question, the R script writes a C99 hex-float side table — see
+`write_exact` in `tutorials/pbmc3k_de_verify.R`.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+TUTORIALS = Path(__file__).parent.parent / "tutorials"
+
+# Reads that carry no float into a comparison. Each is exempt for a stated
+# reason; adding to this set should require one.
+EXEMPT = {
+    ("anchors_tutorial.py", "metadata.csv"): "cell labels, no floats compared",
+    ("visium_tutorial.py", "header=header"): "wrapped in len() — a row count",
+    ("pbmc3k_de_tutorial.py", "dtype=str"): "the hex reader; floats via float.fromhex",
+}
+
+READ_CSV = re.compile(r"read_csv\(")
+
+
+def _call_text(source: str, start: int) -> str:
+    """The text of the call beginning at `start`, to its matching paren."""
+    depth, i, quote = 0, start, None
+    while i < len(source):
+        ch = source[i]
+        if quote:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+        elif ch in "\"'":
+            quote = ch
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return source[start:i + 1]
+        i += 1
+    return source[start:]
+
+
+def _offending_calls(path: Path) -> list[str]:
+    source = path.read_text()
+    bad = []
+    for m in READ_CSV.finditer(source):
+        call = _call_text(source, m.end() - 1)
+        if "float_precision" in call:
+            continue
+        if any(name == path.name and marker in call
+               for (name, marker) in EXEMPT):
+            continue
+        line = source[:m.start()].count("\n") + 1
+        bad.append(f"{path.name}:{line}  {' '.join(call.split())[:90]}")
+    return bad
+
+
+@pytest.mark.parametrize(
+    "path", sorted(TUTORIALS.glob("*.py")), ids=lambda p: p.name)
+def test_read_csv_round_trips_float64(path):
+    bad = _offending_calls(path)
+    assert not bad, (
+        "pd.read_csv without float_precision=\"round_trip\" misparses ~1/3 of "
+        "doubles by an ULP, so any exactness claim built on these values is "
+        "partly measuring the parser:\n  " + "\n  ".join(bad))
+
+
+def test_the_exemptions_still_exist():
+    """A stale exemption would silently widen this lint.
+
+    If one of the exempt calls is edited away, the entry stops matching anything
+    and quietly permits a real offender in the same file.
+    """
+    for (name, marker), reason in EXEMPT.items():
+        path = TUTORIALS / name
+        assert path.exists(), f"{name} is gone; drop its exemption ({reason})"
+        assert marker in path.read_text(), (
+            f"exemption {name}:{marker!r} ({reason}) no longer matches anything "
+            "— remove it or update the marker")

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -9,7 +9,7 @@ each pairing **R Seurat** code side-by-side with the equivalent **Python Truecel
 
 | # | Tutorial | Dataset | Key Concepts | Complexity |
 |---|----------|---------|--------------|-----------|
-| 1 | [PBMC 3k — Guided Clustering](pbmc3k_tutorial.md) | 3,000 PBMCs · 10x Genomics (2016) | QC · Normalization · HVG/VST · PCA · Louvain · UMAP · Markers. **Compared end to end**, both sides running their own pipeline: the same 2,638 barcodes survive QC, 1,998/2,000 variable features shared, PCA matched \|r\| **0.9988**, clusters at **ARI 0.938** (8 vs 9 — one 32-cell DC population), and on the two clusters whose cells match exactly the marker tables are **identical gene sets** to 4.9e-15 | Beginner |
+| 1 | [PBMC 3k — Guided Clustering](pbmc3k_tutorial.md) | 3,000 PBMCs · 10x Genomics (2016) | QC · Normalization · HVG/VST · PCA · Louvain · UMAP · Markers. **Compared end to end**, both sides running their own pipeline: the same 2,638 barcodes survive QC, 1,998/2,000 variable features shared, PCA matched \|r\| **0.9988**, clusters at **ARI 0.938** (8 vs 9 — one 32-cell DC population), and on the two clusters whose cells match exactly the marker tables are **identical gene sets** agreeing to 4.6e-14 | Beginner |
 | 2 | [PBMC 8k — Advanced Subclustering](advanced_pbmc8k_subclustering.md) | 8,400 PBMCs · GRCh38 · 10x Genomics | All of Tutorial 1 + subclustering, hierarchical cell-type gating, T/NK annotation. **Both stages compared by barcode**: same 7,475 cells after QC, global clusters at **ARI 0.977**, and the T/NK compartment handed to stage 2 matches at **Jaccard 0.9991** (4,631 of 4,635 cells) — subclusters then at ARI 0.916 and subset labels **98.2%** concordant | Intermediate |
 | 3 | [CBMC CITE-seq — Multimodal](multimodal_citeseq.md) | 8,600 CBMCs · RNA + 13 surface proteins | Multi-assay objects · CLR normalization · Protein feature plots · RNA-protein comparison · WNN joint clustering. **Compared per protein and per cell**: CLR to **4.2e-15**, WNN modality weights at Pearson **0.9847** over 8,617 shared barcodes, cell-type labels **99.29%** concordant, all cluster counts identical. Settled the long-open progenitor question — it was a labelling difference, not a WNN one | Advanced |
 | 4 | [PBMC 3k — SCTransform](sctransform_vignette.md) | 3,000 PBMCs · 10x Genomics (2016) | Regularized NB normalization · Pearson residuals · `vars.to.regress` · 30-PC workflow · SCT-vs-LogNormalize. The **fitted model is compared per gene** against Seurat's `SCTModel` feature attributes — `detection_rate`/`gmean` to machine precision, intercept and theta at **Spearman 1.0000**, the 3,848 non-overdispersed genes exactly the same set, residual variance at 0.9986; both arms now agree on cluster count (12 and 11) | Advanced |
@@ -133,7 +133,7 @@ pipeline from the same 10x bytes; nothing is pinned across them.
 | kNN graph | **52,760 = 2,638 × 20 on both** |
 | Clusters at resolution 0.5 | truecell **8**, Seurat **9** — ARI **0.938**, 2,554/2,638 cells agree |
 | The one cluster Seurat has and truecell does not | its 32 DC cells land, **all 32**, in truecell's CD14+ Mono cluster |
-| Markers on the two clusters whose cells match exactly | **identical gene sets** (151/151 and 242/242), `avg_log2FC` to 4.9e-15 |
+| Markers on the two clusters whose cells match exactly | **identical gene sets** (151/151 and 242/242), `avg_log2FC` to 4.9e-15 and 4.6e-14 respectively |
 
 The DC split is the honest caveat: at resolution 0.5 a 32-cell dendritic-cell
 population sits on the boundary, and the two runs land on opposite sides of it.
@@ -181,7 +181,7 @@ tutorials/pbmc8k_subclustering_verify.R` then
 
 | Step | truecell vs Seurat |
 |------|------------------|
-| Cells surviving QC | **the same 7,475 barcodes**, metrics exact to 5.8e-15 |
+| Cells surviving QC | **the same 7,475 barcodes**, metrics exact to 5.3e-15 |
 | Stage 1 — global clusters | truecell **13**, Seurat **12**; ARI **0.977**, 7,341/7,475 cells agree |
 | Broad lineage label, per cell | **0.9858** |
 | **The compartment handed to stage 2** | **Jaccard 0.9991** — 4,631 of 4,635 T/NK cells are the same barcodes |

--- a/tutorials/advanced_pbmc8k_subclustering.md
+++ b/tutorials/advanced_pbmc8k_subclustering.md
@@ -383,7 +383,7 @@ from the same 10x bytes.
 
 | Stage | truecell vs Seurat 5.5.1 |
 |---|---|
-| QC | **the same 7,475 barcodes**; nCount and nFeature exact, percent.mt to 5.8e-15 |
+| QC | **the same 7,475 barcodes**; nCount and nFeature exact, percent.mt to 5.3e-15 |
 | Normalized data | total to 8.2e-13 relative · kNN graph **149,500 on both** |
 | Stage 1 clusters | 13 vs 12 · **ARI 0.977** · 7,341/7,475 cells agree |
 | Broad lineage, per cell | **0.9858** |

--- a/tutorials/anchors_tutorial.py
+++ b/tutorials/anchors_tutorial.py
@@ -172,8 +172,8 @@ def compare(reduction):
     r_path = FIG / f"r_anchors_{reduction}.csv"
     if not r_path.exists():
         return None
-    r = pd.read_csv(r_path)
-    p = pd.read_csv(FIG / f"py_anchors_{reduction}.csv")
+    r = pd.read_csv(r_path, float_precision="round_trip")
+    p = pd.read_csv(FIG / f"py_anchors_{reduction}.csv", float_precision="round_trip")
     r_pairs = set(zip(r["cell1"], r["cell2"]))
     p_pairs = set(zip(p["cell1"], p["cell2"]))
     shared = r_pairs & p_pairs

--- a/tutorials/cbmc_citeseq_tutorial.py
+++ b/tutorials/cbmc_citeseq_tutorial.py
@@ -373,8 +373,8 @@ def report():
     print("=" * 74)
 
     # ---- 1. the CLR transform, which depends on nothing stochastic ----------
-    py = pd.read_csv(FIGURES / "py_adt_clr.csv").set_index("protein")
-    r = pd.read_csv(FIGURES / "r_adt_clr.csv").set_index("protein")
+    py = pd.read_csv(FIGURES / "py_adt_clr.csv", float_precision="round_trip").set_index("protein")
+    r = pd.read_csv(FIGURES / "r_adt_clr.csv", float_precision="round_trip").set_index("protein")
     prot = py.index.intersection(r.index)
     print(f"\n  ADT CLR normalisation — {len(prot)} proteins, no RNG anywhere")
     print(f"  {'statistic':<12}{'max|diff|':>14}")
@@ -384,8 +384,8 @@ def report():
         print(f"  {col:<12}{d:>14.3e}")
 
     # ---- 2. the WNN weights, per cell, on shared barcodes -------------------
-    pw = pd.read_csv(FIGURES / "py_cell_weights.csv").set_index("cell")
-    rw = pd.read_csv(FIGURES / "r_cell_weights.csv").set_index("cell")
+    pw = pd.read_csv(FIGURES / "py_cell_weights.csv", float_precision="round_trip").set_index("cell")
+    rw = pd.read_csv(FIGURES / "r_cell_weights.csv", float_precision="round_trip").set_index("cell")
     cells = pw.index.intersection(rw.index)
     pw, rw = pw.loc[cells], rw.loc[cells]
     a, b = pw["ADT.weight"].to_numpy(), rw["ADT.weight"].to_numpy()

--- a/tutorials/generate_anchors_plots.py
+++ b/tutorials/generate_anchors_plots.py
@@ -28,8 +28,8 @@ BLUE, ORANGE, GREY = "#3b6ea5", "#d1873b", "#8a8a8a"
 
 
 def _load(reduction):
-    r = pd.read_csv(FIG / f"r_anchors_{reduction}.csv")
-    p = pd.read_csv(FIG / f"py_anchors_{reduction}.csv")
+    r = pd.read_csv(FIG / f"r_anchors_{reduction}.csv", float_precision="round_trip")
+    p = pd.read_csv(FIG / f"py_anchors_{reduction}.csv", float_precision="round_trip")
     return r, p
 
 

--- a/tutorials/generate_de_plots.py
+++ b/tutorials/generate_de_plots.py
@@ -190,8 +190,8 @@ def main(data_dir=None):
     mat1, mat2, feats = _group_matrices(obj, groups)
     before = pd.Series(_old_formula(mat1, mat2), index=feats)
 
-    py = pd.read_csv(FIGURES / "py_wilcox.csv", index_col=0)
-    r = pd.read_csv(r_wilcox, index_col=0)
+    py = pd.read_csv(FIGURES / "py_wilcox.csv", index_col=0, float_precision="round_trip")
+    r = pd.read_csv(r_wilcox, index_col=0, float_precision="round_trip")
     after = py["avg_log2FC"]
     r_fc = r["avg_log2FC"]
 
@@ -200,8 +200,8 @@ def main(data_dir=None):
 
     rows = []
     for test in TEST_MAP:
-        p = pd.read_csv(FIGURES / f"py_{test}.csv", index_col=0)
-        rr = pd.read_csv(FIGURES / f"r_{test.lower()}.csv", index_col=0)
+        p = pd.read_csv(FIGURES / f"py_{test}.csv", index_col=0, float_precision="round_trip")
+        rr = pd.read_csv(FIGURES / f"r_{test.lower()}.csv", index_col=0, float_precision="round_trip")
         rows.append({"test": test, **compare(p, rr, test)})
     table = pd.DataFrame(rows).set_index("test")
     _save(test_concordance(table), "py_03_test_concordance.png")

--- a/tutorials/generate_dimreduc_plots.py
+++ b/tutorials/generate_dimreduc_plots.py
@@ -58,7 +58,7 @@ def _save(fig, name):
 def _r_pcs():
     """R's per-PC JackStraw reference, if the verify script has run."""
     path = FIGURES / "r_jackstraw_pcs.csv"
-    return pd.read_csv(path) if path.exists() else None
+    return pd.read_csv(path, float_precision="round_trip") if path.exists() else None
 
 
 def jackstraw_scores(summary):

--- a/tutorials/generate_svf_plots.py
+++ b/tutorials/generate_svf_plots.py
@@ -59,7 +59,7 @@ def _r_moransi():
     """R's Moran's I per gene, from the verify script's anchors, if present."""
     path = FIGURES / "r_moransi.csv"
     if path.exists():
-        return pd.read_csv(path, index_col=0)["observed"]
+        return pd.read_csv(path, index_col=0, float_precision="round_trip")["observed"]
     return None
 
 

--- a/tutorials/ifnb_integration_tutorial.py
+++ b/tutorials/ifnb_integration_tutorial.py
@@ -331,7 +331,7 @@ def report_concordance(obj, r_calls_path=None, verbose=True) -> dict | None:
                   "`Rscript tutorials/ifnb_integration_verify.R` first.")
         return None
 
-    r = pd.read_csv(path).set_index("cell")
+    r = pd.read_csv(path, float_precision="round_trip").set_index("cell")
     cells = obj.cell_names()
     r = r.reindex(cells)
     meta = obj.meta_data

--- a/tutorials/ifnb_sketch_tutorial.py
+++ b/tutorials/ifnb_sketch_tutorial.py
@@ -324,7 +324,7 @@ def _read_r_scores(path, column, cells):
     of ``subset``, and trusting it to match would make every downstream number
     quietly wrong rather than loudly absent.
     """
-    frame = pd.read_csv(path)
+    frame = pd.read_csv(path, float_precision="round_trip")
     series = frame.set_index(frame.columns[0])[column]
     missing = [c for c in cells if c not in series.index]
     if missing:
@@ -533,10 +533,10 @@ def report_concordance(summary, figures=FIGURES):
 
     comp_path = figures / "r_sketch_composition.csv"
     if comp_path.exists():
-        out["sketch_composition"] = pd.read_csv(comp_path)
+        out["sketch_composition"] = pd.read_csv(comp_path, float_precision="round_trip")
     proj_path = figures / "r_projection.csv"
     if proj_path.exists() and "projected" in summary:
-        frame = pd.read_csv(proj_path).set_index("cell")
+        frame = pd.read_csv(proj_path, float_precision="round_trip").set_index("cell")
         shared = [c for c in cells if c in frame.index]
         position = {c: i for i, c in enumerate(cells)}
         py = np.array([str(summary["projected"][position[c]]) for c in shared])

--- a/tutorials/panc8_reference_mapping_tutorial.py
+++ b/tutorials/panc8_reference_mapping_tutorial.py
@@ -363,7 +363,7 @@ def report_concordance(query, predictions, r_calls_path=None, verbose=True) -> d
                   "`Rscript tutorials/panc8_reference_mapping_verify.R` first.")
         return None
 
-    r = pd.read_csv(path).set_index("cell")
+    r = pd.read_csv(path, float_precision="round_trip").set_index("cell")
     cells = query.cell_names()
     r = r.reindex(cells)
     truth = np.asarray(query.meta_data[CELLTYPE]).astype(str)

--- a/tutorials/pbmc3k_dimreduc_tutorial.py
+++ b/tutorials/pbmc3k_dimreduc_tutorial.py
@@ -376,7 +376,7 @@ def _read_feature_matrix(path, features):
     """Read an R feature × dim CSV and align its rows to ``features`` by name."""
     if not Path(path).exists():
         return None
-    df = pd.read_csv(path).set_index("feature")
+    df = pd.read_csv(path, float_precision="round_trip").set_index("feature")
     df.index = [_r_feature_key(i) for i in df.index]
     # Set equality, not just "every Python feature is present": R holding extra
     # features means it selected a different HVG set, which the old one-sided
@@ -513,7 +513,7 @@ def report_concordance(obj, summary, verbose=True) -> dict | None:
         path = FIGURES / name
         if not path.exists():
             return None
-        frame = pd.read_csv(path).set_index("cell")
+        frame = pd.read_csv(path, float_precision="round_trip").set_index("cell")
         check_same_cells(cells, frame, source=f"figures_dimreduc/{name}")
         return frame.reindex(cells)
 
@@ -527,7 +527,7 @@ def report_concordance(obj, summary, verbose=True) -> dict | None:
     # --- JackStraw ---------------------------------------------------------
     pcs_path = FIGURES / "r_jackstraw_pcs.csv"
     if pcs_path.exists():
-        r_pcs = pd.read_csv(pcs_path)
+        r_pcs = pd.read_csv(pcs_path, float_precision="round_trip")
         r_emp = _read_feature_matrix(FIGURES / "r_jackstraw_p.csv",
                                      obj.reductions["pca"].features())
         py_scores = summary["pc_scores"]

--- a/tutorials/pbmc3k_sctransform_tutorial.py
+++ b/tutorials/pbmc3k_sctransform_tutorial.py
@@ -306,8 +306,8 @@ def report():
 
     # `keep_default_na=False` because gene symbols include literal "NA"-like
     # tokens that pandas would otherwise read as missing.
-    py = pd.read_csv(FIGURES / "py_sct_model.csv", keep_default_na=False)
-    r = pd.read_csv(FIGURES / "r_sct_model.csv", keep_default_na=False)
+    py = pd.read_csv(FIGURES / "py_sct_model.csv", keep_default_na=False, float_precision="round_trip")
+    r = pd.read_csv(FIGURES / "r_sct_model.csv", keep_default_na=False, float_precision="round_trip")
     # `Read10X` rewrites "_" to "-" in gene symbols and truecell's loader does
     # not, so one gene (RP11-442N24__B.1) spells differently on the two sides.
     # That belongs to the two file readers, not to SCTransform — normalise to

--- a/tutorials/pbmc3k_tutorial.md
+++ b/tutorials/pbmc3k_tutorial.md
@@ -1038,7 +1038,7 @@ on this dataset:
 | PCA (10 dims) | matched \|r\| mean **0.9988**, min 0.9946, no reordering |
 | kNN graph | **52,760 on both** (2,638 × 20) |
 | Clusters | 8 vs 9 — **ARI 0.938**, concordance 0.968 (see Step 11) |
-| Markers, where the clusters hold identical cells | **identical gene sets** (151/151, 242/242), `avg_log2FC` to 4.9e-15 |
+| Markers, where the clusters hold identical cells | **identical gene sets** (151/151, 242/242), `avg_log2FC` to 4.9e-15 and 4.6e-14 respectively |
 
 That last row is the one to read carefully. Two clusters — B cells and
 Platelets — came out with exactly the same membership on both sides, and on

--- a/tutorials/pbmc3k_tutorial.py
+++ b/tutorials/pbmc3k_tutorial.py
@@ -522,8 +522,8 @@ def report() -> None:
     print("truecell vs Seurat 5.5.1 — PBMC 3k guided clustering, end to end")
     print("=" * 78)
 
-    pc = pd.read_csv(FIGURES / "py_cell_meta.csv").set_index("cell")
-    rc = pd.read_csv(FIGURES / "r_cell_meta.csv").set_index("cell")
+    pc = pd.read_csv(FIGURES / "py_cell_meta.csv", float_precision="round_trip").set_index("cell")
+    rc = pd.read_csv(FIGURES / "r_cell_meta.csv", float_precision="round_trip").set_index("cell")
 
     # ---- 1. did QC keep the same cells, with the same metrics? -------------
     only_py = pc.index.difference(rc.index)
@@ -541,8 +541,8 @@ def report() -> None:
         print(f"  {col:<18}{d:>14.3e}")
 
     # ---- 2. the VST statistics and the 2,000 it selected -------------------
-    ph = pd.read_csv(FIGURES / "py_hvg.csv").set_index("gene")
-    rh = pd.read_csv(FIGURES / "r_hvg.csv").set_index("gene")
+    ph = pd.read_csv(FIGURES / "py_hvg.csv", float_precision="round_trip").set_index("gene")
+    rh = pd.read_csv(FIGURES / "r_hvg.csv", float_precision="round_trip").set_index("gene")
     genes = ph.index.intersection(rh.index)
     print(f"\n  Variable features (VST) — {len(genes)} shared genes "
           f"of {len(ph)} / {len(rh)}")
@@ -635,8 +635,8 @@ def report() -> None:
         print(f"    {ct:<16}{py_ct.get(ct, 0):>9}{r_ct.get(ct, 0):>9}")
 
     # ---- 6. markers, on the matched clusters -------------------------------
-    pm = pd.read_csv(FIGURES / "py_markers.csv")
-    rm = pd.read_csv(FIGURES / "r_markers.csv")
+    pm = pd.read_csv(FIGURES / "py_markers.csv", float_precision="round_trip")
+    rm = pd.read_csv(FIGURES / "r_markers.csv", float_precision="round_trip")
     pm["cluster"] = pm["cluster"].astype(str)
     rm["cluster"] = rm["cluster"].astype(str)
     print(f"\n  Markers — {len(pm)} rows truecell, {len(rm)} R "

--- a/tutorials/pbmc8k_subclustering_tutorial.py
+++ b/tutorials/pbmc8k_subclustering_tutorial.py
@@ -389,8 +389,8 @@ def report() -> None:
     print("truecell vs Seurat 5.5.1 — PBMC 8k, global clustering then T/NK subclustering")
     print("=" * 78)
 
-    pc = pd.read_csv(FIGURES / "py_cell_meta.csv").set_index("cell")
-    rc = pd.read_csv(FIGURES / "r_cell_meta.csv").set_index("cell")
+    pc = pd.read_csv(FIGURES / "py_cell_meta.csv", float_precision="round_trip").set_index("cell")
+    rc = pd.read_csv(FIGURES / "r_cell_meta.csv", float_precision="round_trip").set_index("cell")
 
     # ---- 1. did QC keep the same cells? ------------------------------------
     only_py, only_r = pc.index.difference(rc.index), rc.index.difference(pc.index)
@@ -443,8 +443,8 @@ def report() -> None:
     # The load-bearing check. Everything downstream is conditioned on this set,
     # so two compartments of the same size drawn from different clusters would
     # make every later number incomparable while looking fine.
-    pt = pd.read_csv(FIGURES / "py_tnk_cells.csv").set_index("cell")
-    rt = pd.read_csv(FIGURES / "r_tnk_cells.csv").set_index("cell")
+    pt = pd.read_csv(FIGURES / "py_tnk_cells.csv", float_precision="round_trip").set_index("cell")
+    rt = pd.read_csv(FIGURES / "r_tnk_cells.csv", float_precision="round_trip").set_index("cell")
     sp_, sr = set(pt.index), set(rt.index)
     inter, union = sp_ & sr, sp_ | sr
     print(f"\n  The T/NK compartment — truecell {len(sp_)} cells, R {len(sr)}")

--- a/tutorials/pbmc_hashing_tutorial.py
+++ b/tutorials/pbmc_hashing_tutorial.py
@@ -247,7 +247,7 @@ def report_concordance(obj, r_calls_path=None, verbose=True) -> dict | None:
                   "`Rscript tutorials/pbmc_hashing_verify.R` first.")
         return None
 
-    r = pd.read_csv(path).set_index("cell")
+    r = pd.read_csv(path, float_precision="round_trip").set_index("cell")
     cells = obj.cell_names()
     r = r.reindex(cells)
     meta = obj.meta_data

--- a/tutorials/sctransform_vignette.md
+++ b/tutorials/sctransform_vignette.md
@@ -277,7 +277,7 @@ of the resolution difference:
 | Genes v2 calls non-overdispersed | 3,848 | 3,848 — the *same* genes (Jaccard 1.0000) | ✅ |
 | Regularized intercept vs R (Spearman) | — | 1.0000 | ✅ |
 | Residual variance vs R (Spearman) | — | 0.9986 (Pearson 0.9996) | ✅ |
-| `detection_rate` · `gmean` vs R | — | max abs diff 5.6e-16 · 1.2e-12 | ✅ |
+| `detection_rate` · `gmean` vs R | — | max abs diff 5.0e-16 · 1.2e-12 | ✅ |
 | Residual clips (`sqrt(N)` · `sqrt(N/30)`) | ±51.9615 · ±9.4868 | identical | ✅ |
 
 **These numbers are reproduced, not recorded.** Everything in the table above

--- a/tutorials/thp1_cellcycle_tutorial.py
+++ b/tutorials/thp1_cellcycle_tutorial.py
@@ -271,7 +271,7 @@ def report_concordance(obj, r_calls_path=None, verbose=True) -> dict | None:
                   "`Rscript tutorials/thp1_cellcycle_verify.R` first.")
         return None
 
-    r = pd.read_csv(path).set_index("cell")
+    r = pd.read_csv(path, float_precision="round_trip").set_index("cell")
     cells = obj.cell_names()
     r = r.reindex(cells)
     meta = obj.meta_data

--- a/tutorials/thp1_mixscape_tutorial.py
+++ b/tutorials/thp1_mixscape_tutorial.py
@@ -295,7 +295,7 @@ def report_concordance(obj, r_calls_path=None, verbose=True) -> dict | None:
                   "`Rscript tutorials/thp1_mixscape_verify.R` first.")
         return None
 
-    r = pd.read_csv(path).set_index("cell")
+    r = pd.read_csv(path, float_precision="round_trip").set_index("cell")
     cells = obj.cell_names()
     r = r.reindex(cells)
     meta = obj.meta_data


### PR DESCRIPTION
Follow-up to #93, which fixed this in the DE tutorial only and left 42 read
sites across 17 others.

pandas' default CSV **reader** is not correctly rounded — it misparses about a
third of random doubles by an ULP. `to_csv` was never at fault; it already
writes the shortest round-trippable form. So a tutorial that wrote a value,
handed it to R, read both back and reported "these agree exactly" was partly
measuring the parser rather than the port.

## What changed

**37 call sites across 16 tutorials.** Three reads stay exempt with stated
reasons: cell labels in `anchors_tutorial`, a row count wrapped in `len()` in
`visium_tutorial`, and the DE hex reader, which parses floats via
`float.fromhex`.

**Six reported figures moved**, all at the ULP level and most of them downward:

| Tutorial | Figure | Before → After |
|---|---|---:|
| PBMC 8k | `percent.mt` | 5.773e-15 → **5.329e-15** |
| PBMC 3k | VST mean, max rel | 1.548e-14 → **4.973e-15** |
| PBMC 3k | VST variance, max\|diff\| | 1.592e-11 → 1.614e-11 |
| PBMC 3k | marker row 7→8 | 4.80e-14 → **4.62e-14** |
| SCTransform | `detection_rate` | 5.6e-16 → **5.0e-16** |
| CITE-seq | min | 2.082e-16 → 2.498e-16 |

**No declared band moved.** All nine `--report` runs still exit zero, and
re-running them reproduces the new values exactly. The four affected vignettes
carry the measured numbers. The `[0.9.0]` changelog entries quoting the old
figures are left alone — they were accurate at that release, and a changelog is
a record rather than a live table.

## A near miss worth recording

The first attempt inserted the argument before the last `)` on the line. For
`pd.read_csv(path).set_index("cell")` that lands it **inside `set_index`** —
syntactically valid, passes an AST check, and would have raised `TypeError` at
runtime on 16 of the 37 sites. Caught only by reading back every changed line
rather than trusting the parse. Redone with paren matching from the
`read_csv(` position.

## Guard

`tests/test_tutorial_csv_precision.py` pins the convention across all eighteen
tutorials so the next `pd.read_csv` cannot quietly reintroduce it. It also
asserts the three exemptions still match something — a stale exemption stops
matching and silently permits a real offender in the same file. Both guards
mutation-tested: stripping the parameter from one call fails that file's case,
and editing an exempt call's marker fails both the file case and the
exemption check.

## Also corrected

PBMC 3k's docs claimed `avg_log2FC` agreement "to 4.9e-15" for **both** clusters
whose cells match exactly. That covers the 151-gene cluster (4.88e-15); the
242-gene one is **4.62e-14**, ten times larger. Both figures are now stated.
This predates the reader fix — the bound was simply the smaller of the two.

## Verification

1168 passed, 25 skipped. mypy at its 4-error baseline. No figure churn.

## Not in this PR

The R half is not lintable from Python and is unchanged: `write.csv` renders 15
significant digits, and raising it does not help because R's own
`sprintf("%.17g")` is not correctly rounded either. Only the DE tutorial has the
C99 hex-float (`%a`) side table. The tutorials making the strongest exactness
claims — the object model ("91 of 91 anchors, no tolerance"), Visium
(`max|Δx| = 0`), out-of-core ("bit-identical"), and spatial (Moran's I to
1.6e-14) — still cross the language boundary through plain CSVs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
