### PR TITLE
Verify add_module_score as an equality, not a correlation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`add_module_score` is now verified against Seurat as an equality, not a
+  correlation.** Every prior comparison was correlation-based and structurally
+  had to be: `AddModuleScore` picks control genes with `sample()`, R's RNG is
+  not NumPy's, so the two cannot produce the same number. Pearson 0.9995 is a
+  real result, but it is the RNG-limited one — it cannot separate a faithful
+  port from one whose binning is subtly wrong, because binning error and
+  sampling noise land in the same residual.
+
+  `nbin=1` puts every gene in one bin and `ctrl` = pool size draws all of it;
+  `sample(n, n)` is a permutation, so the control **set** is forced and only its
+  summation order is free. In that regime the two tools agree to
+  **6.66e-15 across 20,729 cells** — floating-point associativity over 18,649
+  genes, against 1.8e-01 between two R seeds at `ctrl = 8`. The binning, control
+  selection and mean subtraction are exact.
+
+  Also adds the first coverage of the multi-program path and of any settings
+  other than the defaults: three programs in one call at `nbin=12, ctrl=40`
+  (Pearson 0.9972 / 0.9988 / 0.9986), with a guard against column
+  transposition — programs are identified by position alone, so a swap would
+  leave every correlation high and every label wrong.
+
+  Six mutants, all caught. Two survived the first pass, both because the new
+  tests fabricated the R side from Python's own column and so could not detect a
+  change in how Python computed it — the same defect shape this repo has hit
+  before. Closed by asserting the pipeline's settings produce a column that
+  differs from a default-settings recomputation.
+
 ### Fixed
 
 - **The R verify scripts now serialize anchors at full float64 precision.**

--- a/tests/test_cellcycle_tutorial.py
+++ b/tests/test_cellcycle_tutorial.py
@@ -188,3 +188,167 @@ def test_report_concordance_absent_returns_none(scored):
     _tut, obj, _summary, tmp = scored
     missing = tmp / "nope.csv"
     assert tut.report_concordance(obj, r_calls_path=missing, verbose=False) is None
+
+
+# ---------------------------------------------------------------------------
+# The deterministic regime and the multi-program call
+# ---------------------------------------------------------------------------
+
+def test_the_deterministic_regime_is_actually_deterministic(scored):
+    """`nbin=1` + `ctrl=pool` must remove the seed from the answer.
+
+    This is the premise the exact comparison rests on: with one bin and a draw
+    that exhausts it, `sample(n, n)` is a permutation, so the control *set* is
+    forced and only its summation order is random. If that stopped being true —
+    a different default, a change to the pool — the exact comparison would
+    quietly become a loose one, and nothing else here would notice.
+    """
+    from truecell import add_module_score
+
+    _tut, obj, _summary, _tmp = scored
+    genes = list(obj.assays["RNA"].features())
+    program = [g for g in tut.IFN_PROGRAM if g in genes][:5]
+    if len(program) < 2:
+        pytest.skip("synthetic fixture carries too few IFN genes")
+
+    seen = []
+    for seed in (1, 4242):
+        add_module_score(obj, features={"Probe": program},
+                         nbin=1, ctrl=len(genes), seed=seed)
+        seen.append(np.asarray(obj.meta_data["Probe"], dtype=float).copy())
+    assert np.max(np.abs(seen[0] - seen[1])) <= tut.EXACT_TOLERANCE
+
+
+def test_the_default_regime_is_not_deterministic(scored):
+    """The control: at default settings the seed *does* move the score.
+
+    Without this, a bug that ignored `seed` entirely would make the test above
+    pass for the wrong reason.
+    """
+    from truecell import add_module_score
+
+    _tut, obj, _summary, _tmp = scored
+    genes = list(obj.assays["RNA"].features())
+    program = [g for g in tut.IFN_PROGRAM if g in genes][:5]
+    if len(program) < 2:
+        pytest.skip("synthetic fixture carries too few IFN genes")
+
+    seen = []
+    for seed in (1, 4242):
+        add_module_score(obj, features={"Probe2": program}, nbin=4, ctrl=3,
+                         seed=seed)
+        seen.append(np.asarray(obj.meta_data["Probe2"], dtype=float).copy())
+    assert np.max(np.abs(seen[0] - seen[1])) > tut.EXACT_TOLERANCE
+
+
+def test_scoring_writes_the_exact_and_multi_columns(scored):
+    _tut, obj, _summary, _tmp = scored
+    assert tut.EXACT_NAME in obj.meta_data.columns
+    for i in (1, 2, 3):
+        assert f"{tut.MULTI_NAME}{i}" in obj.meta_data.columns
+
+
+def test_exact_comparison_flags_a_difference_above_tolerance(scored):
+    """The exact check must be able to fail, not just to pass."""
+    _tut, obj, _summary, tmp = scored
+    meta, cells = obj.meta_data, obj.cell_names()
+    base = dict(cell=cells, R_Phase=np.asarray(meta[tut.PHASE_COL]),
+                R_S_Score=np.asarray(meta[tut.S_COL]),
+                R_G2M_Score=np.asarray(meta[tut.G2M_COL]),
+                R_IFN=np.asarray(meta[tut.IFN_NAME]))
+
+    exact = np.asarray(meta[tut.EXACT_NAME], dtype=float)
+    pd.DataFrame({**base, "R_IFN_exact": exact}).to_csv(tmp / "r_calls.csv",
+                                                        index=False)
+    assert tut.report_concordance(obj, verbose=False)["exact"]["within_tolerance"]
+
+    nudged = exact.copy()
+    nudged[0] += 1e-6            # far above EXACT_TOLERANCE, far below any score
+    pd.DataFrame({**base, "R_IFN_exact": nudged}).to_csv(tmp / "r_calls.csv",
+                                                          index=False)
+    out = tut.report_concordance(obj, verbose=False)
+    assert not out["exact"]["within_tolerance"]
+    assert out["exact"]["max_abs_diff"] == pytest.approx(1e-6, rel=1e-6)
+
+
+def test_transposed_multi_columns_are_detected(scored):
+    """Two programs swapped must be caught.
+
+    A transposition leaves every per-position correlation *high* whenever the
+    programs score similarly, so `pearson > 0.9` on each column proves nothing.
+    What catches it is that each Python column has to match its own R column
+    better than it matches either of the others.
+    """
+    _tut, obj, _summary, tmp = scored
+    meta, cells = obj.meta_data, obj.cell_names()
+    cols = [np.asarray(meta[f"{tut.MULTI_NAME}{i}"], dtype=float) for i in (1, 2, 3)]
+    base = dict(cell=cells, R_Phase=np.asarray(meta[tut.PHASE_COL]),
+                R_S_Score=np.asarray(meta[tut.S_COL]),
+                R_G2M_Score=np.asarray(meta[tut.G2M_COL]),
+                R_IFN=np.asarray(meta[tut.IFN_NAME]),
+                R_IFN_exact=np.asarray(meta[tut.EXACT_NAME], dtype=float))
+
+    pd.DataFrame({**base, "R_Multi1": cols[0], "R_Multi2": cols[1],
+                  "R_Multi3": cols[2]}).to_csv(tmp / "r_calls.csv", index=False)
+    assert tut.report_concordance(obj, verbose=False)["multi_not_transposed"]
+
+    # Programs 1 and 2 swapped on the R side.
+    pd.DataFrame({**base, "R_Multi1": cols[1], "R_Multi2": cols[0],
+                  "R_Multi3": cols[2]}).to_csv(tmp / "r_calls.csv", index=False)
+    assert not tut.report_concordance(obj, verbose=False)["multi_not_transposed"]
+
+
+def test_run_scoring_actually_uses_the_deterministic_settings(scored):
+    """`run_scoring` must compute the EXACT column in the deterministic regime.
+
+    Mutation testing caught this gap: dropping `nbin=1, ctrl=n_features` from
+    `run_scoring` left every other test in this file green, because they all
+    fabricate the R side *from Python's own column* — so a column computed the
+    wrong way still matched itself. The property has to be asserted on the
+    pipeline's output, not on a hand-made call with the right arguments.
+
+    Seed-invariance is the property that *defines* the regime, but it cannot be
+    the assertion here: this fixture carries few enough genes that ctrl=100
+    exhausts every bin at the defaults too, so both columns come out
+    seed-invariant (2.2e-15) and the check would not discriminate. Asserting
+    that the EXACT column differs from a default-settings recomputation does
+    discriminate, because nbin=1 draws a different control set.
+    """
+    from truecell import add_module_score
+
+    _tut, obj, _summary, _tmp = scored
+    tut.run_scoring(obj, seed=1)
+    exact = np.asarray(obj.meta_data[tut.EXACT_NAME], dtype=float).copy()
+
+    genes = set(obj.assays["RNA"].features())
+    program = [g for g in tut.IFN_PROGRAM if g in genes]
+    add_module_score(obj, features={"DfltExact": program}, seed=1)
+    at_defaults = np.asarray(obj.meta_data["DfltExact"], dtype=float)
+
+    assert np.max(np.abs(exact - at_defaults)) > tut.EXACT_TOLERANCE
+
+
+def test_run_scoring_uses_non_default_settings_for_the_multi_call(scored):
+    """The multi call must run at nbin=12/ctrl=40, not at the defaults.
+
+    Also from mutation testing: reverting those arguments changed nothing any
+    test could see. Recomputing the same three programs at the defaults and
+    requiring a difference pins the settings themselves.
+    """
+    from truecell import add_module_score
+
+    _tut, obj, _summary, _tmp = scored
+    tut.run_scoring(obj, seed=1)
+    stored = [np.asarray(obj.meta_data[f"{tut.MULTI_NAME}{i}"], dtype=float).copy()
+              for i in (1, 2, 3)]
+
+    genes = set(obj.assays["RNA"].features())
+    programs = [[g for g in CC_GENES["s_genes"] if g in genes],
+                [g for g in CC_GENES["g2m_genes"] if g in genes],
+                [g for g in tut.IFN_PROGRAM if g in genes]]
+    add_module_score(obj, features=programs, name="Dflt", seed=1)
+    at_defaults = [np.asarray(obj.meta_data[f"Dflt{i}"], dtype=float)
+                   for i in (1, 2, 3)]
+
+    assert any(np.max(np.abs(s - d)) > tut.EXACT_TOLERANCE
+               for s, d in zip(stored, at_defaults))

--- a/tutorials/cellcycle_vignette.md
+++ b/tutorials/cellcycle_vignette.md
@@ -178,6 +178,43 @@ extremely tightly, and the discrete phase is robust to the residual wobble:
 > (Agreement with Papalexi's *published* phase — a different pipeline — is 0.88,
 > for context.)
 
+### Taking the RNG out, so the algorithm can be checked exactly
+
+The correlations above are the strongest result available *while the control set
+is random* — and that is a real limit, not a formality. A correlation of 0.9995
+cannot separate a faithful port from one whose binning is subtly wrong, because
+binning error and sampling noise land in the same residual.
+
+There is one regime where the randomness disappears. `nbin = 1` puts every gene
+in a single bin, and `ctrl` equal to the pool size then draws that whole bin:
+`sample(n, n)` is a permutation, so the control **set** is forced and only its
+summation order is free. Scored that way, the two tools must produce the same
+number, not a correlated one:
+
+| | max \|Δ\| across 20,729 cells |
+|---|---:|
+| `nbin = 1`, `ctrl` = pool (control set forced) | **6.66e-15** |
+| `ctrl = 8` (bins ≈ 8 genes), two seeds in R alone | 1.8e-01 |
+
+6.66e-15 is floating-point associativity over 18,649 genes — R shows 6.2e-15
+between two of *its own* seeds in this regime, and truecell 3.6e-15. So the
+binning, the control-set selection and the mean subtraction are exact; the
+0.9995 above is the RNG and nothing else.
+
+There is no exact regime in the general case, which is worth stating so nobody
+looks for one: `cut()` produces uneven bins, R errors if `ctrl` exceeds the
+smallest bin's population, and no single `ctrl` both fits the smallest and
+exhausts the largest.
+
+### Three programs in one call, at non-default settings
+
+Everything above runs one program at a time at `nbin = 24, ctrl = 100`. Scoring
+S, G2/M and interferon in a single call at `nbin = 12, ctrl = 40` exercises both
+the multi-program path and settings nothing had used: Pearson 0.9972 / 0.9988 /
+0.9986, with column order preserved. Order is the part worth pinning — programs
+are identified by position alone, so a transposition would leave every
+correlation high and every label wrong.
+
 The scores correlate at Pearson ≥ 0.998 — the algorithm is faithfully ported, and
 the only reason the numbers are not bit-identical is the random control set.
 **96.62 % of cells get the same phase call**, and the ~3.4 % that differ sit right

--- a/tutorials/thp1_cellcycle_tutorial.py
+++ b/tutorials/thp1_cellcycle_tutorial.py
@@ -102,6 +102,24 @@ IFN_PROGRAM = [
 ]
 IFN_NAME = "IFN.Response"
 
+#: The same interferon program scored in the deterministic regime (``nbin=1``,
+#: ``ctrl`` = the whole pool), where the control set is forced and the two tools
+#: must agree on the number rather than merely correlate.
+EXACT_NAME = "IFN.Exact"
+
+#: Prefix for the three-programs-in-one-call check. `add_module_score` appends a
+#: 1-based index per program, as `AddModuleScore` does, so this yields
+#: ``Multi1`` (S), ``Multi2`` (G2M), ``Multi3`` (IFN) — and the *order* is the
+#: part worth pinning, since nothing but position identifies which is which.
+MULTI_NAME = "Multi"
+
+#: Summation-order slack for the deterministic regime. Two seeds of the same
+#: forced control set differ by 6.2e-15 in R and 3.6e-15 in truecell — floating
+#: point associativity over ~13k genes, not disagreement. Bounded well below the
+#: 1.8e-1 that separates two seeds at ctrl = 8, so a genuine binning defect
+#: cannot hide under it.
+EXACT_TOLERANCE = 1e-11
+
 
 def section(title: str) -> None:
     print(f"\n{'=' * 70}\n{title}\n{'=' * 70}")
@@ -222,6 +240,20 @@ def run_scoring(obj, seed=1):
     cell_cycle_scoring(obj, s_features=s_genes, g2m_features=g2m_genes, seed=seed)
     add_module_score(obj, features={IFN_NAME: ifn_genes}, seed=seed)
 
+    # The same program with the RNG taken out — see the note in the R script.
+    # `nbin=1` puts every gene in one bin and `ctrl=pool` draws all of it, so the
+    # control set is forced and only its summation order is random. That turns a
+    # correlation into an equality: this is the one comparison here that tests
+    # the *algorithm* rather than the algorithm plus two different RNGs.
+    n_features = len(obj.assays["RNA"].features())
+    add_module_score(obj, features={EXACT_NAME: ifn_genes},
+                     nbin=1, ctrl=n_features, seed=seed)
+
+    # Three programs in one call, at non-default nbin/ctrl. Both the multi-program
+    # path and any setting other than (24, 100) were previously unexercised.
+    add_module_score(obj, features=[s_genes, g2m_genes, ifn_genes],
+                     name=MULTI_NAME, nbin=12, ctrl=40, seed=seed)
+
     FIGURES.mkdir(exist_ok=True)
     (FIGURES / "s_genes.txt").write_text("\n".join(s_genes) + "\n")
     (FIGURES / "g2m_genes.txt").write_text("\n".join(g2m_genes) + "\n")
@@ -285,6 +317,35 @@ def report_concordance(obj, r_calls_path=None, verbose=True) -> dict | None:
         "ifn_score": score_correlation(meta[IFN_NAME].to_numpy(), r["R_IFN"].to_numpy()),
     }
 
+    # The deterministic regime, compared as an equality rather than a correlation.
+    if "R_IFN_exact" in r.columns and EXACT_NAME in meta.columns:
+        diff = np.abs(meta[EXACT_NAME].to_numpy() - r["R_IFN_exact"].to_numpy())
+        out["exact"] = {
+            "max_abs_diff": float(np.nanmax(diff)),
+            "within_tolerance": bool(np.nanmax(diff) <= EXACT_TOLERANCE),
+            "n_cells": int(np.isfinite(diff).sum()),
+        }
+
+    # Three programs from one call. Compared per position, because position is
+    # the only thing identifying which program a column holds — a transposition
+    # here would leave every correlation high and every label wrong.
+    multi = [f"{MULTI_NAME}{i}" for i in (1, 2, 3)]
+    if all(c in meta.columns for c in multi) and "R_Multi1" in r.columns:
+        out["multi"] = {
+            col: score_correlation(meta[col].to_numpy(),
+                                   r[f"R_Multi{i}"].to_numpy())
+            for i, col in enumerate(multi, start=1)
+        }
+        # Guard against the transposition the per-position check would otherwise
+        # miss if two programs happened to score alike: each Python column must
+        # correlate with its own R column better than with either other one.
+        out["multi_not_transposed"] = all(
+            out["multi"][multi[i]]["pearson"] >= max(
+                score_correlation(meta[multi[i]].to_numpy(),
+                                  r[f"R_Multi{j + 1}"].to_numpy())["pearson"]
+                for j in range(3) if j != i)
+            for i in range(3))
+
     if verbose:
         section("R-vs-Python concordance (shared counts & gene lists)")
         board = build_scoreboard([
@@ -301,6 +362,23 @@ def report_concordance(obj, r_calls_path=None, verbose=True) -> dict | None:
         print("  pearson/spearman: score agreement — high despite the control-gene")
         print("                    RNG differing between NumPy and R (scores are not")
         print("                    expected to be identical, only to track).")
+
+        if "multi" in out:
+            print(f"\n  Three programs from one call (nbin=12, ctrl=40) — "
+                  f"non-default settings and the multi-program path:")
+            for i, col in enumerate([f"{MULTI_NAME}{k}" for k in (1, 2, 3)], 1):
+                print(f"    {col} (program {i}): pearson "
+                      f"{out['multi'][col]['pearson']:.4f}")
+            print(f"    column order preserved: {out['multi_not_transposed']}")
+
+        if "exact" in out:
+            print(f"\n  With the RNG removed (nbin=1, ctrl=pool — the control set "
+                  f"is forced,\n  so only summation order varies): max |Δ| = "
+                  f"{out['exact']['max_abs_diff']:.3e} over "
+                  f"{out['exact']['n_cells']} cells")
+            print(f"  within {EXACT_TOLERANCE:.0e}: {out['exact']['within_tolerance']}")
+            print("  This is the one line here that tests the algorithm rather than")
+            print("  the algorithm plus two different random number generators.")
     return out
 
 

--- a/tutorials/thp1_cellcycle_verify.R
+++ b/tutorials/thp1_cellcycle_verify.R
@@ -80,6 +80,39 @@ obj <- AddModuleScore(obj, features = list(ifn_genes), name = "IFN.Response",
 # AddModuleScore appends the program index to `name`; a single program -> "...1".
 ifn_col <- if ("IFN.Response1" %in% colnames(obj[[]])) "IFN.Response1" else "IFN.Response"
 
+# ---- 2b. The same function with the RNG taken out of it ----------------------
+#
+# Every comparison above is correlation-based, and has to be: AddModuleScore
+# picks its control genes with `sample()`, R's RNG is not NumPy's, so the two
+# tools cannot produce the same score for the same cell. Pearson 0.998 is a real
+# result but it is the *RNG-limited* one — it cannot distinguish a faithful port
+# from one whose binning is subtly wrong, because binning error and sampling
+# noise both land in the same residual.
+#
+# `nbin = 1` puts every gene in one bin, and `ctrl` equal to the pool size then
+# draws the entire bin. `sample(n, n)` is a permutation, so the control *set* is
+# forced and only its summation order is random. That makes the score
+# deterministic up to floating-point associativity — measured at 6.2e-15 between
+# two seeds here, against 1.8e-1 at ctrl = 8 — and lets the algorithm be compared
+# exactly instead of correlated.
+#
+# ctrl cannot exceed the bin population (R errors), which is why the general case
+# has no exact regime: `cut()` gives uneven bins, so no single ctrl both fits the
+# smallest and exhausts the largest.
+pool_n <- nrow(obj)
+obj <- AddModuleScore(obj, features = list(ifn_genes), name = "IFN.Exact",
+                      nbin = 1, ctrl = pool_n, seed = 1)
+exact_col <- if ("IFN.Exact1" %in% colnames(obj[[]])) "IFN.Exact1" else "IFN.Exact"
+
+# ---- 2c. Several programs in one call, at non-default nbin/ctrl ---------------
+# The defaults (nbin = 24, ctrl = 100) are the only settings any comparison has
+# ever run at, and a multi-program call is a different code path from three
+# single-program ones — Seurat names the columns by position, which is exactly
+# the kind of convention that goes wrong silently.
+multi <- list(readLines(S_TXT), readLines(G2M_TXT), ifn_genes)
+obj <- AddModuleScore(obj, features = multi, name = "Multi",
+                      nbin = 12, ctrl = 40, seed = 1)
+
 # ---- 3. Per-cell calls for the Python concordance report (write first) --------
 calls <- data.frame(
   cell        = colnames(obj),
@@ -87,6 +120,10 @@ calls <- data.frame(
   R_S_Score   = as.numeric(obj$S.Score),
   R_G2M_Score = as.numeric(obj$G2M.Score),
   R_IFN       = as.numeric(obj[[ifn_col]][, 1]),
+  R_IFN_exact = as.numeric(obj[[exact_col]][, 1]),
+  R_Multi1    = as.numeric(obj[["Multi1"]][, 1]),
+  R_Multi2    = as.numeric(obj[["Multi2"]][, 1]),
+  R_Multi3    = as.numeric(obj[["Multi3"]][, 1]),
   stringsAsFactors = FALSE
 )
 write.csv(calls, file.path(FIG, "r_calls.csv"), row.names = FALSE)


### PR DESCRIPTION
Closes the last package item from the domain-expert review — comment 11.3,
*"Can we check module scores concordance? I breathe and eat gene module scores
in my analyses."*

## The problem with every prior comparison

They were all correlation-based, and structurally had to be. `AddModuleScore`
picks its control genes with `sample()`, R's RNG is not NumPy's, so the two
tools **cannot** produce the same score for the same cell.

Pearson 0.9995 is a real result, but it is the *RNG-limited* one: it cannot
separate a faithful port from one whose binning is subtly wrong, because binning
error and sampling noise land in the same residual.

## Taking the RNG out

`nbin = 1` puts every gene in a single bin, and `ctrl` equal to the pool size
then draws that whole bin. `sample(n, n)` is a permutation, so the control
**set** is forced and only its summation order is free.

| | max \|Δ\| across 20,729 cells |
|---|---:|
| `nbin = 1`, `ctrl` = pool | **6.66e-15** |
| `ctrl = 8` (bins ≈ 8 genes), two seeds in R alone | 1.8e-01 |

6.66e-15 is floating-point associativity over 18,649 genes — R shows 6.2e-15
between two of *its own* seeds in this regime, and truecell 3.6e-15. Thirteen
orders of magnitude of headroom, so the binning, the control-set selection and
the mean subtraction are exact, and the 0.9995 is the RNG and nothing else.

**No exact regime exists in the general case**, and the vignette says so, so
nobody hunts for one: `cut()` gives uneven bins, R errors when `ctrl` exceeds the
smallest bin's population, and no single `ctrl` both fits the smallest and
exhausts the largest.

## Parameter coverage

Everything previously ran one program at a time at `nbin = 24, ctrl = 100`.
Three programs in one call at `nbin = 12, ctrl = 40` gives Pearson 0.9972 /
0.9988 / 0.9986, with a dedicated guard against column transposition — programs
are identified by **position alone**, so a swap would leave every correlation
high and every label wrong.

## Verification

Six mutants, all caught — including a widened tolerance, a self-comparison, a
short-circuited transposition guard, and reverting either set of non-default
parameters.

**Two survived the first pass, and the reason is worth recording:** the new
tests fabricated the R side from Python's own column, so a change in *how Python
computed that column* was invisible to them. That is the same defect shape this
repo has hit before (T-de, #48). Closed by asserting the pipeline's settings
produce a column that differs from a default-settings recomputation.

A third trap, noted in the test rather than left for the next person: the first
fix attempt failed because the synthetic fixture is too small — with few genes
`ctrl = 100` exhausts every bin, so the *default* regime is seed-invariant too
and could not discriminate.

1175 passed, 25 skipped. mypy at its 4-error baseline.

## Correction to `REVIEW_PLAN.md`

That file claimed `add_module_score` was "R-verified only through cell-cycle."
**It was not** — an arbitrary 25-gene interferon program was already compared at
Pearson 0.9995. I had read the vignette's title and not its contents. The real
gap was the *regime*, not the gene set, and the commit message says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
