### PR TITLE
Run the PBMC 3k tutorials in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,93 @@ jobs:
           name: coverage-xml
           path: coverage.xml
 
+  tutorials:
+    name: Run the PBMC 3k tutorials against real data
+    # The `test` job runs 1,179 unit tests and cannot see any of this. The
+    # tutorials are scripts run end to end against a real dataset, gated behind
+    # `TRUECELL_TUTORIAL_SMOKE=1` because most of them need ~200 MB of cached
+    # data — so until now nothing here ran in CI at all.
+    #
+    # That gap shipped a defect. `test_cell_type_map_matches_the_markers` was
+    # written to stop the pbmc3k figure labels drifting, was correct, and never
+    # executed: when the cluster count went 9 -> 8 the hardcoded label map kept
+    # nine entries, and the whole of 1.0.0 went out with the 14-cell platelet
+    # cluster captioned "DC" in the tutorial's headline UMAP. It was found by
+    # running the suite by hand before cutting 1.1.0. Twice now a labelled
+    # figure has been published wrong, and both times the guard existed.
+    #
+    # PBMC 3k alone, because it is 28 MB against the full set's ~200 MB and it
+    # is where the labelled figures come from. The other datasets stay
+    # developer-run; this is the slice that pays for itself.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Create venv and install
+        run: uv sync --all-extras --locked --python 3.12
+
+      - name: Cache the PBMC 3k dataset
+        uses: actions/cache@v4
+        with:
+          path: ~/.truecell_data/pbmc3k
+          # Static key on purpose. The obvious alternative, hashing
+          # `truecell/datasets.py`, throws the cache away on every unrelated
+          # edit to that module — it holds every other downloader too. **Bump
+          # the suffix by hand if `_PBMC3K_URLS` changes**, since nothing else
+          # will notice that the bytes behind the key are different.
+          key: truecell-data-pbmc3k-v1
+
+      - name: Fetch the dataset if the cache missed
+        # Idempotent: `pbmc3k()` downloads only when matrix.mtx is absent, so on
+        # a cache hit this is a load and a discard. Kept as its own step so a
+        # 10x Genomics outage reads as "the download failed" rather than as a
+        # tutorial failure thirty lines into a pytest log.
+        run: uv run python -c "from truecell.datasets import pbmc3k; pbmc3k()"
+
+      - name: Verify the dataset is actually there
+        # Without this, a fetch that half-succeeded leaves every test to skip
+        # itself on `dataset not cached` and the job is green having run
+        # nothing — which is the exact failure this job exists to end.
+        run: test -f ~/.truecell_data/pbmc3k/filtered_gene_bc_matrices/hg19/matrix.mtx
+
+      - name: Run the PBMC 3k tutorials end to end
+        shell: bash
+        env:
+          TRUECELL_TUTORIAL_SMOKE: "1"
+        run: |
+          set -o pipefail
+          # Deselecting the datasets we do *not* cache, rather than selecting
+          # the ones we do. An allow-list (`-k "pbmc3k or cell_type"`) reads
+          # more naturally and is the wrong choice: a pbmc3k test added later
+          # under any other name would quietly never run here, which is the
+          # shape of the defect this job exists to prevent. Inverted, a new
+          # pbmc3k test is picked up automatically, and a new test needing an
+          # uncached dataset turns this job red until someone adds it below —
+          # loud, and the right way round.
+          uv run pytest tests/test_tutorial_smoke.py -q \
+            -k "not cbmc and not pbmc8k and not hashing and not thp1 \
+                and not ifnb and not panc8 and not xenium and not visium" \
+            | tee smoke.log
+          # A skip is a failure *here*. Every test this selects needs only the
+          # dataset above, so the only ways to skip are a broken cache, a
+          # misspelt opt-in variable, or a new test wanting a dataset this job
+          # does not fetch — and all three produce a green tick for a job that
+          # checked nothing. Exit 5 (pytest collected nothing) already fails
+          # the step on its own.
+          if grep -qE "[0-9]+ skipped" smoke.log; then
+            echo "::error::a smoke test skipped — the dataset cache or the" \
+                 "TRUECELL_TUTORIAL_SMOKE gate is not working, so this job" \
+                 "verified nothing"
+            exit 1
+          fi
+
   freshdeps:
     # The interpolation is load-bearing: an explicit `name:` overrides the
     # default matrix suffix, so without it both legs would report under one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CI runs the PBMC 3k tutorials against real data.** A new `tutorials` job
+  caches the 28 MB dataset and runs the eleven smoke tests that need only it —
+  six tutorial scripts end to end, plus the marker table, the object-model round
+  trip, the dim-reduc extras and both cell-type-map guards. Until now
+  `test_tutorial_smoke.py` ran nowhere but a developer's machine, and the entry
+  above is what that cost.
+
+  Two details are the point rather than decoration. **A skip fails the job:**
+  every selected test needs only the cached dataset, so a skip can only mean a
+  broken cache, a misspelt `TRUECELL_TUTORIAL_SMOKE`, or a new test wanting a
+  dataset this job does not fetch — all of which would otherwise produce a green
+  tick for a job that verified nothing. And the selection **deselects the eight
+  uncached datasets** instead of selecting pbmc3k by name: an allow-list reads
+  better but would let a pbmc3k test added later under another name silently
+  never run, which is precisely the failure being fixed.
+
+  The other datasets total ~200 MB and stay developer-run, so
+  `TRUECELL_TUTORIAL_SMOKE=1 pytest tests/test_tutorial_smoke.py` before a
+  release is still the rule, not a formality.
+
 ### Fixed
 
 - **The annotated PBMC 3k UMAP captioned the platelet cluster "DC".** Shipped in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1070,8 +1070,13 @@ regime. Don't "simplify" them.
     eight clusters, so the platelet cluster was captioned "DC" throughout 1.0.0 —
     and the test caught none of it, because `test_tutorial_smoke.py` is opt-in and
     excluded from CI. A correct assertion nobody runs is not a guard. It is now
-    paired with `test_cell_type_map_covers_exactly_the_clusters_produced`, but the
-    standing gap is the gate, not the assertion. `dot_plot` — the last plotting export with no tutorial
+    paired with `test_cell_type_map_covers_exactly_the_clusters_produced`, and
+    the gate itself is closed for this dataset: the `tutorials` CI job caches
+    PBMC 3k and runs every pbmc3k smoke test on each pull request, treating a
+    *skip* as a failure so it cannot go green having checked nothing. The other
+    datasets (~200 MB) stay developer-run, so
+    `TRUECELL_TUTORIAL_SMOKE=1 pytest tests/test_tutorial_smoke.py` before a
+    release is still the rule. `dot_plot` — the last plotting export with no tutorial
     coverage — was folded into the same gallery, and drawing it is what exposed
     the mislabelling.
 - **Wave 3 — ✅ complete.**

--- a/skills/truecell-dev/SKILL.md
+++ b/skills/truecell-dev/SKILL.md
@@ -155,6 +155,13 @@ The second is **opt-in rather than skip-when-missing**, so a skip always means
 nobody asked, never that it passed. Run it before cutting a release — a green
 unit suite says nothing about whether the tutorials still work end to end.
 
+The `tutorials` CI job covers the **PBMC 3k slice only** (11 tests, dataset
+cached, a skip counts as a failure). Everything needing one of the other eight
+datasets — ~200 MB in total — still runs nowhere but a developer's machine, so
+the pre-release run above is not optional. The rule exists because it was
+skipped: 1.0.0 shipped with the platelet cluster captioned "DC" in the pbmc3k
+headline figure, under a guard that was correct and had never executed.
+
 ## The verification standard
 
 Higher than "the tests pass", and it is why the port's claims hold up.


### PR DESCRIPTION
Closes the gap #98 was found through. `test_tutorial_smoke.py` is opt-in and ran
nowhere but a developer's machine, so `test_cell_type_map_matches_the_markers` —
correct, and written precisely to stop pbmc3k figure labels drifting — never
executed, and 1.0.0 shipped with the 14-cell platelet cluster captioned "DC" in
the tutorial's headline UMAP.

## The job

A `tutorials` job that caches the **28 MB** PBMC 3k dataset and runs the eleven
smoke tests needing only it:

* six tutorial scripts end to end — guided, SCTransform, dim-reduc, objects, DE,
  lazy/BPCells
* `test_pbmc3k_prints_the_marker_table`, `test_pbmc3k_object_model_round_trips`,
  `test_pbmc3k_dimreduc_extras_hold_up`
* both cell-type-map guards, including the one added in #98

The other eight datasets total ~200 MB and stay developer-run. This is the slice
that pays for itself: it is where the labelled figures come from, and it is the
one that has now gone wrong twice.

## Two decisions that carry the job

**A skip fails it.** Every selected test needs only the cached dataset, so a skip
can only mean a broken cache, a misspelt `TRUECELL_TUTORIAL_SMOKE`, or a new test
wanting a dataset this job does not fetch. Each would otherwise be a green tick
on a job that verified nothing — which is the exact failure being fixed, and this
repo has a long history of it. Mutation-tested locally, both ways:

| Simulated fault | Result |
|---|---|
| Opt-in variable unset (misspelt env var) | `11 skipped` → **step exits 1** |
| `HOME` pointed elsewhere (cache miss) | `11 skipped` → **step exits 1** |

A separate `test -f …/matrix.mtx` step catches a half-successful download before
pytest is reached, and pytest's exit 5 covers "collected nothing" if someone
renames a test out of the filter.

**The filter deselects the eight uncached datasets** rather than selecting pbmc3k
by name. An allow-list (`-k "pbmc3k or cell_type"`) reads better and is the wrong
choice — a pbmc3k test added later under another name would quietly never run
here, reproducing the defect this job exists to prevent. Inverted, new pbmc3k
tests are picked up automatically, and a test needing an uncached dataset turns
the job red until someone extends the list. Loud, and the right way round.
Verified both forms select the same 11 of 26 today.

## Notes

* The cache key is static (`truecell-data-pbmc3k-v1`) rather than a hash of
  `truecell/datasets.py`, which holds every other downloader too and would
  discard the cache on unrelated edits. **Bump it by hand if `_PBMC3K_URLS`
  changes** — a comment in the workflow says so.
* On a cache miss the job downloads from `cf.10xgenomics.com`, so an outage there
  turns it red. Kept as its own step so that reads as a failed download rather
  than a mysterious tutorial failure. Making it advisory instead was tempting and
  rejected: a job that cannot fail is what put us here.
* No action versions changed; the job reuses the ones already in `ci.yml`.
* Runtime will be whatever this PR's own run reports — I have not put an
  estimate in the changelog, since the local slice was still running when this
  was opened.

`ROADMAP.md` and `skills/truecell-dev` are updated to say the gate is closed for
pbmc3k **only**, and that the full opt-in suite before a release is still the
rule rather than a formality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)