### PR TITLE
Trim the two slowest tutorials from the CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,9 +159,22 @@ jobs:
           # pbmc3k test is picked up automatically, and a new test needing an
           # uncached dataset turns this job red until someone adds it below —
           # loud, and the right way round.
+          #
+          # `lazy_bpcells` and `de_tutorial` are excluded for a **different
+          # reason, and it is a weaker one**: both pass here, and their data is
+          # already cached. They were 65% of the runtime (136s and 102s of 364s
+          # locally; the first CI run took 16m33s for the eleven), and neither
+          # produces a labelled figure, which is the drift this job exists to
+          # catch. So they are a cost trim, not a coverage judgement — the code
+          # they exercise is real and no unit test covers it the same way, and
+          # out-of-core has a history here (see ROADMAP's T-lazy entry). They
+          # run in the full opt-in suite, which is a pre-release requirement
+          # precisely because this job is not the whole story. If this job ever
+          # gets a faster runner, put them back first.
           uv run pytest tests/test_tutorial_smoke.py -q \
             -k "not cbmc and not pbmc8k and not hashing and not thp1 \
-                and not ifnb and not panc8 and not xenium and not visium" \
+                and not ifnb and not panc8 and not xenium and not visium \
+                and not lazy_bpcells and not de_tutorial" \
             | tee smoke.log
           # A skip is a failure *here*. Every test this selects needs only the
           # dataset above, so the only ways to skip are a broken cache, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **CI runs the PBMC 3k tutorials against real data.** A new `tutorials` job
-  caches the 28 MB dataset and runs the eleven smoke tests that need only it —
-  six tutorial scripts end to end, plus the marker table, the object-model round
-  trip, the dim-reduc extras and both cell-type-map guards. Until now
-  `test_tutorial_smoke.py` ran nowhere but a developer's machine, and the entry
-  above is what that cost.
+  caches the 28 MB dataset and runs nine smoke tests against it — four tutorial
+  scripts end to end (guided, SCTransform, dim-reduc, objects), plus the marker
+  table, the object-model round trip, the dim-reduc extras and both
+  cell-type-map guards. Until now `test_tutorial_smoke.py` ran nowhere but a
+  developer's machine, and the entry above is what that cost.
+
+  `lazy_bpcells` and `pbmc3k_de` are deliberately **not** in it. Both pass and
+  both have their data cached; they were 65% of the runtime (136s and 102s of
+  364s locally, and the first CI run measured **16m33s** for all eleven), and
+  neither draws a labelled figure. That is a cost trim rather than a coverage
+  judgement, and it is the weaker half of this change: the full opt-in suite is
+  the only thing that runs them, which is why the pre-release run stays a
+  requirement.
 
   Two details are the point rather than decoration. **A skip fails the job:**
   every selected test needs only the cached dataset, so a skip can only mean a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1072,9 +1072,11 @@ regime. Don't "simplify" them.
     excluded from CI. A correct assertion nobody runs is not a guard. It is now
     paired with `test_cell_type_map_covers_exactly_the_clusters_produced`, and
     the gate itself is closed for this dataset: the `tutorials` CI job caches
-    PBMC 3k and runs every pbmc3k smoke test on each pull request, treating a
-    *skip* as a failure so it cannot go green having checked nothing. The other
-    datasets (~200 MB) stay developer-run, so
+    PBMC 3k and runs nine of its eleven smoke tests on each pull request,
+    treating a *skip* as a failure so it cannot go green having checked nothing.
+    `lazy_bpcells` and `pbmc3k_de` are held out for runtime (65% of it) and are
+    covered only by the full opt-in run. The other datasets (~200 MB) stay
+    developer-run, so
     `TRUECELL_TUTORIAL_SMOKE=1 pytest tests/test_tutorial_smoke.py` before a
     release is still the rule. `dot_plot` — the last plotting export with no tutorial
     coverage — was folded into the same gallery, and drawing it is what exposed

--- a/skills/truecell-dev/SKILL.md
+++ b/skills/truecell-dev/SKILL.md
@@ -155,9 +155,11 @@ The second is **opt-in rather than skip-when-missing**, so a skip always means
 nobody asked, never that it passed. Run it before cutting a release — a green
 unit suite says nothing about whether the tutorials still work end to end.
 
-The `tutorials` CI job covers the **PBMC 3k slice only** (11 tests, dataset
-cached, a skip counts as a failure). Everything needing one of the other eight
-datasets — ~200 MB in total — still runs nowhere but a developer's machine, so
+The `tutorials` CI job covers **part of the PBMC 3k slice** (9 of its 11 tests,
+dataset cached, a skip counts as a failure). `lazy_bpcells` and `pbmc3k_de` are
+held out for runtime, so out-of-core and the DE tutorial are verified *only* by
+the command above. Everything needing one of the other eight datasets — ~200 MB
+in total — still runs nowhere but a developer's machine, so
 the pre-release run above is not optional. The rule exists because it was
 skipped: 1.0.0 shipped with the platelet cluster captioned "DC" in the pbmc3k
 headline figure, under a guard that was correct and had never executed.


### PR DESCRIPTION
Follow-up to #99. Its first run took **17m0s**, 16m33s of that in pytest — a lot
to add to every pull request.

## The trim

Two tests were 65% of the slice:

| Test | Local | Share |
|---|---:|---:|
| `lazy_bpcells_tutorial.py` | 135.8s | 37% |
| `pbmc3k_de_tutorial.py` | 101.9s | 28% |

Holding both out, **measured**:

| | Tests | Local runtime |
|---|---:|---:|
| Before | 11 | 6m03s |
| After | 9 | **2m01s** |

What stays: the guided, SCTransform, dim-reduc and objects tutorials end to end,
the marker table, the object-model round trip, the dim-reduc extras, and both
cell-type-map guards — including the one from #98.

## What this is, and is not

**A cost trim, not a coverage judgement**, and the weaker half of the CI change.
Both excluded tests pass, and their dataset is already cached — they are dropped
purely for time. Neither draws a labelled figure, which is the drift this job
exists to catch, so the trim preserves what the job is *for*.

But the code they exercise is real, no unit test covers it the same way, and
out-of-core has previous here (ROADMAP's T-lazy entry: 18 green tests of
`LazyMatrix` in isolation while no library function could consume one). They now
run only in the full opt-in suite — which is exactly why the pre-release run
stays a requirement rather than a formality. The workflow comment says so, and
says to put them back first if the job ever gets a faster runner.

This is a **different** kind of exclusion from the eight dataset-based ones
above it in the same filter, so it carries its own comment rather than being
folded into that list.

## Verification

* 9 passed in 121.65s, no skips
* Guard re-checked under the new filter: with `TRUECELL_TUTORIAL_SMOKE` unset,
  `9 skipped` → **step exits 1**. Trimming the selection did not weaken the
  thing that stops this job going green having run nothing.
* `CHANGELOG.md`, `ROADMAP.md` and `skills/truecell-dev` updated to say nine
  rather than eleven, and to **name the two that are missing** — a doc that says
  "the tutorials run in CI" without that qualifier is how the last gap hid.

Expected CI runtime is ~5-6 min of pytest against the 16m33s baseline; this PR's
own run is the figure to trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)