### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-08
+
+Ten weeks of plotting work, a domain-expert review, and the release-readiness
+run that found the defect below. The API additions are backwards compatible;
+the fixes change output, which is the point of them.
+
+**If you are on 1.0.0, the reasons to move are the corrections**, not the
+features: the categorical palette could give two clusters the same colour,
+`vln_plot` drew the wrong violin three ways, `aggregate_expression` left raw
+sums where Seurat log-normalizes, and `_get_expression_matrix` returned the
+wrong layer with mislabelled features.
+
 ### Added
 
 - **CI runs the PBMC 3k tutorials against real data.** A new `tutorials` job
@@ -2064,7 +2076,10 @@ Tagged but never published to PyPI; `0.1.1` was the first release on PyPI.
 - Spatial primitives: `FOV`, `Centroids`, `Segmentation`, `Molecules`.
 - Plotting, I/O, AnnData interop, and the bundled example datasets.
 
-[Unreleased]: https://github.com/GenomicAI/truecell/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/GenomicAI/truecell/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/GenomicAI/truecell/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/GenomicAI/truecell/compare/v0.9.0...v1.0.0
+[0.9.0]: https://github.com/GenomicAI/truecell/compare/v0.2.0...v0.9.0
 [0.2.0]: https://github.com/GenomicAI/truecell/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/GenomicAI/truecell/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/GenomicAI/truecell/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "truecell"
-version = "1.0.0"
+version = "1.1.0"
 description = "Python single-cell genomics toolkit — a port of Seurat's core data structures and analysis pipeline"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -2338,7 +2338,7 @@ wheels = [
 
 [[package]]
 name = "truecell"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Fourteen merged pull requests since `v1.0.0` (#84–#100), tagged on 29 July.

**MINOR, not PATCH.** `average_expression`, multi-resolution `find_clusters`,
`split_by` faceting and the theme layer are additions; nothing was removed or
renamed.

## Why a 1.0.0 user should move

The corrections, not the features. All of these are live on PyPI right now:

| Defect in 1.0.0 | Fixed in |
|---|---|
| The categorical palette repeats colours — two clusters can render identically | #86 |
| `vln_plot` draws the wrong violin (bandwidth, trim, points) | #89 |
| `aggregate_expression(return_object=True)` leaves raw sums where Seurat log-normalizes | #93 |
| `_get_expression_matrix` returns the wrong layer, with mislabelled features | #93 |
| The pbmc3k annotated UMAP captions the platelet cluster "DC" | #98 |

Anyone doing pseudobulk, or reading a violin, or trusting a cluster colour, is
getting something wrong on 1.0.0.

## The diff

Three files.

* `pyproject.toml` — 1.0.0 → 1.1.0
* `CHANGELOG.md` — `[1.1.0] - 2026-08-08` cut, `[Unreleased]` kept empty
  (`test_changelog_exists_and_leads_with_unreleased` requires it first)
* `uv.lock` — **one line**, the project's own version

That lock diff was the thing to check rather than assume. `uv lock` can
re-resolve the scientific stack, and `pyproject.toml`'s own comment explains why
that matters here: the committed tutorial figures were drawn in a `--locked`
environment, and a silent numpy or umap-learn step moves them for reasons no
anchor reports. Verified by diff — nothing else moved.

**Also fixed:** the changelog's link references had been stale since 0.2.0, with
no entries for 0.9.0 or 1.0.0 and `[Unreleased]` still comparing against
`v0.2.0`. A release is when that matters, so it is done here.

## Verification

| Check | Result |
|---|---|
| `tests/test_packaging.py` | 14 passed |
| Full suite | **1179 passed**, 26 skipped |
| `uv build` | both artifacts built |
| `uvx twine check dist/*` | PASSED, PASSED |
| Clean-venv wheel install | imports, reports `1.1.0` |

The local reinstall matters and is easy to skip: `__version__` resolves through
the *installed* dist-info, so editing `pyproject.toml` alone leaves
`test_version_matches_pyproject` failing against a stale `1.0.0` dist-info.

The stale 1.0.0 wheel and tarball have been cleared out of `dist/` so an upload
cannot re-push them. They were moved rather than deleted — they are what is
currently published.

## Noted, not fixed here

The sdist ships `.claude/` and `docs/` although
`[tool.hatch.build.targets.sdist].include` names neither. Checked against the
1.0.0 tarball: **identical**, so this pre-dates the release and is not a
regression. At 598 KB it harms nobody, but the include list and the actual
contents disagree, and that is worth a separate look — not a change to make on a
release branch.

## After merge

Annotated tag `v1.1.0`, then the upload, which is the maintainer's to run —
`twine` needs the PyPI token and I do not use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)