### PR TITLE
Write down the two changes that shipped undocumented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,53 @@ wrong layer with mislabelled features.
 
   `cluster_name` is supported, matching Seurat's `cluster.name`.
 
+### Performance
+
+- **`find_markers` filters before it densifies.** It built a dense
+  (all genes × cells) float64 array per group and only then computed the
+  `min_pct` and `logfc_threshold` masks that reduce it to the genes actually
+  tested. Both masks are computable on the sparse matrix — `expm1(0) == 0`, so
+  the fold-change transform preserves the sparsity pattern and applies to the
+  stored values alone — so they now run first and only the survivors are
+  densified. On PBMC 3k that is ~1.6k rows of 13.7k.
+
+  `find_all_markers` calls this once per cluster, so the saving grows with
+  cluster count as well as with *n*:
+
+  | dataset (clusters) | time | peak memory |
+  |---|---|---|
+  | ifnb (15) | 25.37s → **8.03s** | 9420 MB → **3580 MB** |
+  | pbmc8k (9) | 12.71s → **6.32s** | 9253 MB → **2406 MB** |
+  | thp1 (7) | 45.52s → **23.87s** | 10620 MB → 9428 MB |
+  | pbmc3k (8) | 2.36s → **1.54s** | |
+
+  The marker tables are **byte-identical** before and after across all eight
+  tests on PBMC 3k, and all 76 step anchors match across the benchmark suite.
+
+- **A cross-language benchmark suite** — `tutorials/benchmark/`, reported in
+  [`PERFORMANCE.md`](tutorials/benchmark/PERFORMANCE.md). The tutorials
+  established that Truecell and Seurat agree; nothing measured what each answer
+  costs. Eight benches — the standard workflow on four datasets from 2.7k to
+  20.7k cells, SCTransform, integration, the DE suite, Moran's I and a pure-BLAS
+  control — mirrored step for step in both languages.
+
+  Time is measured inside each process and memory from outside: R's `gc()` and
+  Python's `tracemalloc` measure different things and neither sees the other's
+  allocator, so the parent samples the child's process-tree RSS every 50 ms.
+  **Every step reports an anchor**, so the report can show both arms did the same
+  work before comparing how long they took — which is why the Truecell arm runs
+  first and the R arm adopts its cluster assignment. Without that the two sides
+  cluster differently and `find_all_markers` would be timing 9 one-vs-rest tests
+  against 12.
+
+  Truecell is faster in **50 of 68** step comparisons and slower in 17. Read the
+  report rather than that ratio: it loses the standard end-to-end workflow by
+  1.4×, and the machine, the BLAS both stacks link, and the presence of `presto`
+  are all load-bearing — R linked against Accelerate/vecLib is a different
+  measurement from the reference BLAS it ships with.
+
+### Added
+
 - **`split_by` on `dim_plot`, `feature_plot` and `vln_plot`.** Seurat uses three
   *different* mechanisms for this, which is the part worth getting right; each
   was probed against Seurat 5.5.1 rather than assumed.


### PR DESCRIPTION
Found while drafting the 1.1.0 release notes: **#91 and #92 merged without
CHANGELOG entries.** `git show --stat` confirms neither commit touched the file.

Both shipped in 1.1.0, so the changelog understates that release — and
`CHANGELOG.md` travels inside the sdist that is now on PyPI.

This matters against the repo's own rule, from `skills/truecell-dev`:

> **`CHANGELOG.md` is the authority on what shipped** … One PR per coherent
> change, with the changelog entry in it.

## What was missing

**#92 — `find_markers` filters before it densifies.** The one a user deciding
whether to upgrade would actually want to see:

| dataset (clusters) | time | peak memory |
|---|---|---|
| ifnb (15) | 25.37s → **8.03s** | 9420 MB → **3580 MB** |
| pbmc8k (9) | 12.71s → **6.32s** | 9253 MB → **2406 MB** |
| thp1 (7) | 45.52s → **23.87s** | 10620 MB → 9428 MB |
| pbmc3k (8) | 2.36s → **1.54s** | |

Marker tables byte-identical before and after; all 76 step anchors match.

**#91 — the cross-language benchmark suite** (`tutorials/benchmark/`, reported
in `PERFORMANCE.md`): eight benches mirrored step for step in both languages,
time measured inside each process and memory sampled from outside.

## Placement

By chronology within the `[1.1.0]` section — after #93, before #90 — under a new
`### Performance` heading. That required splitting the merged `### Added` block
so `split_by` stays with the release it came from.

## Two things I was deliberate about

**Numbers are transcribed, not re-derived.** They come from #92's commit body
and `PERFORMANCE.md`; nothing here was re-measured, and nothing was rounded into
a nicer shape.

**The benchmark entry does not lead with "faster in 50 of 68."** That ratio
without its conditions is close to misleading: the suite *loses* the standard
end-to-end workflow by 1.4×, and the machine, the BLAS both stacks link against,
and `presto`'s presence are all load-bearing. The entry states the ratio, states
the loss, and points at the report.

## Scope

No code change. 1.1.0 is already tagged and published — this corrects the record
rather than the release, and needs no re-upload.

Verified: 1179 passed, `test_packaging.py` and `test_docs.py` green (32), the
relative link to `tutorials/benchmark/PERFORMANCE.md` resolves under the docs
site's symlinked tutorials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)