### PR TITLE
Point the tutorials index at the guided-tour notebook

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -5,6 +5,39 @@ each pairing **R Seurat** code side-by-side with the equivalent **Python Truecel
 
 ---
 
+## New here? Start with the notebook
+
+[**A vial of blood, and nobody told you what's in it**](truecell_guided_tour.ipynb) —
+a guided tour of the whole package in one runnable notebook.
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/GenomicAI/truecell/blob/main/tutorials/truecell_guided_tour.ipynb)
+
+It takes an unlabelled 32,738 × 2,700 matrix and ends with a named map of the human
+immune system, explaining *why* each step exists rather than only which function to
+call: the object model and its layers, QC, normalization, feature selection, PCA,
+graph clustering, UMAP, marker detection, annotation, pseudobulk, module scores and
+the DE test menu — then a catalogue of everything one PBMC sample cannot demonstrate
+(integration, reference mapping, CITE-seq, hashing, Mixscape, spatial, sketching,
+out-of-core) and a Seurat → truecell translation table.
+
+**It is committed with its outputs**, so all twelve figures and every printed table
+render on GitHub without running anything. Click the badge to get a live copy — it
+downloads its own data and needs about 3–5 minutes end to end.
+
+How it differs from the eighteen below: this is an **on-ramp**, not a verification.
+The tutorials in the table each run the same analysis in R and in Python and report
+how far apart the two land; the notebook teaches the workflow and the judgement calls
+around it — where QC thresholds come from, why `resolution` has no correct value, why
+a UMAP's between-cluster distances mean nothing, and why `find_markers` sorted by
+p-value hands you ribosomal genes.
+
+> The notebook is **generated** by [`build_guided_tour.py`](build_guided_tour.py).
+> Edit that and regenerate; patching the `.ipynb` directly gets reverted on the next
+> build. Its prose quotes numbers the run produces, so re-run and reconcile the text
+> if you change the pipeline.
+
+---
+
 ## Tutorial Overview
 
 | # | Tutorial | Dataset | Key Concepts | Complexity |


### PR DESCRIPTION
Adds a **"New here? Start with the notebook"** section to
[`tutorials/README.md`](tutorials/README.md), above the overview table — Colab
badge, what the notebook covers, and the note that it ships with its outputs so
GitHub renders all twelve figures without anyone running it.

## The one judgement call

**It is deliberately not row 19 of the table.** Every row there is an R-vs-Python
verification that reports how far the two implementations land apart — ARI 0.899,
98.71% concordant, 24 of 24 anchors. The notebook is an on-ramp: it teaches the
workflow and the judgement around it (where QC thresholds come from, why
`resolution` has no correct value, why UMAP between-cluster distance means
nothing, why `find_markers` sorted by p-value hands you ribosomal genes). Filing
it as a nineteenth would misrepresent both it and the table, so the section sits
above the table and says explicitly how the two differ.

For the same reason the opening **"Eighteen end-to-end tutorials"** line is
unchanged — it is still exactly true.

The section also records that the notebook is generated by
`build_guided_tour.py`, since someone opening the `.ipynb` to fix a typo would
otherwise have their edit reverted by the next regeneration.

## Verification

Both links are relative so they resolve on GitHub *and* on the docs site, which
is the part that could have broken: `mkdocs.yml` sets `links.not_found: warn` and
CI builds with `--strict`, so a link into a non-markdown file is a real risk.

`tests/test_docs.py` passes (18 tests), but it finished in 4.5s, which is too fast
for a mkdocstrings build to be believable on its own — so I built the site
directly and checked the artifacts rather than the exit code:

- 41 pages built, exit 0, no link warnings
- `truecell_guided_tour.ipynb` (1,316,275 bytes) and `build_guided_tour.py`
  (55,165 bytes) both land in the site directory
- the rendered `tutorials/index.html` carries `href="truecell_guided_tour.ipynb"`
  and `href="build_guided_tour.py"`, both pointing at files that exist there

Docs-only change; no package code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
